### PR TITLE
Split semantic_analyser

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -40,11 +40,12 @@ add_library(ast STATIC
   passes/args_resolver.cpp
   passes/probe_prune.cpp
   passes/resource_analyser.cpp
-  passes/semantic_analyser.cpp
+  passes/type_checker.cpp
   passes/codegen_llvm.cpp
   passes/resolve_imports.cpp
   passes/recursion_check.cpp
   passes/tracepoint_format_parser.cpp
+  passes/type_resolver.cpp
   passes/type_system.cpp
   passes/unstable_feature.cpp
   passes/usdt_arguments.cpp

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -413,7 +413,7 @@ SizedType ident_to_sized_type(const std::string &ident)
     // fits into a smaller int. This will also affect casts from a smaller
     // int and cause an ERROR: Integer size mismatch.
     // This could potentially be revisited or the cast relaxed
-    // if we check the variant values during semantic analysis.
+    // if we check the variant values during type resolution.
     return CreateEnum(64, enum_name);
   }
   return ident_to_c_struct(ident);

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -814,7 +814,7 @@ public:
   const SizedType &type() const
   {
     // This must always be resolved inline, and when used as an expression will
-    // be replaced during semantic analysis with a suitable tuple.
+    // be replaced during type resolution with a suitable tuple.
     static SizedType none = CreateNone();
     return none;
   }
@@ -1391,7 +1391,7 @@ public:
 
 // Scalar map assignment is purely syntactic sugar that is removed by the pass
 // returned by`CreateMapSugarPass`. This is replaced by the expansion of
-// default keys, so that later steps (semantic analysis, code generation),
+// default keys, so that later steps (type resolution, code generation),
 // don't need to worry about this. Maps whose accesses are bound to a single
 // key will be automatically collapsed into scalar values on the output side.
 class AssignScalarMapStatement : public Node {

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1523,7 +1523,7 @@ Value *IRBuilderBPF::CreateGetNs(TimestampMode ts, const Location &loc)
     case TimestampMode::sw_tai:
       if (!bpftrace_.delta_taitime_.has_value())
         LOG(BUG)
-            << "delta_taitime_ should have been checked in semantic analysis";
+            << "delta_taitime_ should have been checked in an earlier pass";
       uint64_t delta = (bpftrace_.delta_taitime_->tv_sec * 1e9) +
                        bpftrace_.delta_taitime_->tv_nsec;
       Value *ns = CreateGetNs(TimestampMode::boot, loc);

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -964,7 +964,7 @@ AttachPointParser::State AttachPointParser::watchpoint_parser()
   }
   ap_->len = *len_parsed;
 
-  // Semantic analyser will ensure a cmd/pid was provided
+  // An earlier pass will ensure a cmd/pid was provided
   ap_->target = bpftrace_.get_watchpoint_binary_path().value_or("");
 
   ap_->mode = parts_[3];

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -499,7 +499,7 @@ std::optional<Expression> LiteralFolder::visit(Binop &op)
     auto *rs = other.as<String>();
     if (!rs) {
       // This is a mix of a string and something else. This may be a runtime
-      // type, and we need to leave it up to the semantic analysis.
+      // type, and we need to leave it up to later type checking.
       return std::nullopt;
     }
 

--- a/src/ast/passes/map_sugar.h
+++ b/src/ast/passes/map_sugar.h
@@ -27,6 +27,7 @@ public:
 };
 
 const std::unordered_set<std::string>& getAssignRewriteFuncs();
+const std::unordered_set<std::string>& getRawMapArgFuncs();
 
 Pass CreateMapSugarPass();
 

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -561,7 +561,7 @@ void ResourceAnalyser::update_variable_info(Variable &var)
   // Note we don't check if a variable has been declared/assigned before.
   // We do this to simplify the code and make it more robust to changes
   // in other modules at the expense of memory over-allocation. Otherwise,
-  // we would need to track scopes like SemanticAnalyser and CodegenLLVM
+  // we would need to track scopes like TypeChecker and CodegenLLVM
   // and duplicate scope tracking in a third module.
   if (exceeds_stack_limit(var.var_type.GetSize())) {
     resources_.variable_buffers++;

--- a/src/ast/passes/type_checker.cpp
+++ b/src/ast/passes/type_checker.cpp
@@ -1,0 +1,1946 @@
+#include <algorithm>
+#include <arpa/inet.h>
+#include <bpf/bpf.h>
+#include <cstring>
+#include <optional>
+#include <regex>
+#include <set>
+#include <string>
+#include <sys/stat.h>
+
+#include "arch/arch.h"
+#include "ast/ast.h"
+#include "ast/async_event_types.h"
+#include "ast/context.h"
+#include "ast/helpers.h"
+#include "ast/integer_types.h"
+#include "ast/passes/fold_literals.h"
+#include "ast/passes/macro_expansion.h"
+#include "ast/passes/map_sugar.h"
+#include "ast/passes/named_param.h"
+#include "ast/passes/type_checker.h"
+#include "ast/passes/type_system.h"
+#include "bpftrace.h"
+#include "btf/compat.h"
+#include "collect_nodes.h"
+#include "config.h"
+#include "log.h"
+#include "probe_matcher.h"
+#include "probe_types.h"
+#include "types.h"
+#include "util/paths.h"
+#include "util/strings.h"
+#include "util/system.h"
+#include "util/wildcard.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+struct arg_type_spec {
+  Type type = Type::integer;
+  bool literal = false;
+
+  // This indicates that this is just a placeholder as we use the index in the
+  // vector of arg_type_spec as the number argument to check.
+  bool skip_check = false;
+};
+
+struct call_spec {
+  size_t min_args = 0;
+  size_t max_args = 0;
+  // NOLINTBEGIN(readability-redundant-member-init)
+  std::vector<arg_type_spec> arg_types = {};
+  // NOLINTEND(readability-redundant-member-init)
+};
+
+class TypeChecker : public Visitor<TypeChecker> {
+public:
+  explicit TypeChecker(ASTContext &ctx,
+                       BPFtrace &bpftrace,
+                       CDefinitions &c_definitions,
+                       TypeMetadata &type_metadata,
+                       bool has_child = true)
+      : ctx_(ctx),
+        bpftrace_(bpftrace),
+        c_definitions_(c_definitions),
+        type_metadata_(type_metadata),
+        has_child_(has_child)
+  {
+  }
+
+  using Visitor<TypeChecker>::visit;
+  void visit(String &string);
+  void visit(Identifier &identifier);
+  void visit(Call &call);
+  void visit(Sizeof &szof);
+  void visit(Offsetof &offof);
+  void visit(Typeof &typeof);
+  void visit(Typeinfo &typeinfo);
+  void visit(Map &map);
+  void visit(MapAddr &map_addr);
+  void visit(MapDeclStatement &decl);
+  void visit(VariableAddr &var_addr);
+  void visit(Binop &binop);
+  void visit(Unop &unop);
+  void visit(While &while_block);
+  void visit(For &f);
+  void visit(Jump &jump);
+  void visit(IfExpr &if_expr);
+  void visit(FieldAccess &acc);
+  void visit(ArrayAccess &arr);
+  void visit(TupleAccess &acc);
+  void visit(MapAccess &acc);
+  void visit(Cast &cast);
+  void visit(Tuple &tuple);
+  void visit(Record &record);
+  void visit(Expression &expr);
+  void visit(ExprStatement &expr);
+  void visit(AssignMapStatement &assignment);
+  void visit(AssignVarStatement &assignment);
+  void visit(VarDeclStatement &decl);
+  void visit(Unroll &unroll);
+  void visit(Probe &probe);
+  void visit(BlockExpr &block);
+  void visit(Subprog &subprog);
+  void visit(Program &program);
+
+private:
+  ASTContext &ctx_;
+  BPFtrace &bpftrace_;
+  const CDefinitions &c_definitions_;
+  const TypeMetadata &type_metadata_;
+
+  [[nodiscard]] bool check_arg(Call &call,
+                               size_t index,
+                               const arg_type_spec &spec);
+  [[nodiscard]] bool check_call(Call &call);
+  [[nodiscard]] bool check_nargs(const Call &call, size_t expected_nargs);
+  [[nodiscard]] bool check_varargs(const Call &call,
+                                   size_t min_nargs,
+                                   size_t max_nargs);
+
+  bool check_arg(Call &call,
+                 Type type,
+                 size_t index,
+                 bool want_literal = false);
+
+  Probe *get_probe();
+
+  Node *find_variable_scope(const std::string &var_ident);
+
+  bool in_loop()
+  {
+    return loop_depth_ > 0;
+  };
+
+  Node *top_level_node_ = nullptr;
+
+  // Holds the function currently being visited by this
+  // TypeChecker.
+  std::string func_;
+  // Holds the function argument index currently being
+  // visited by this TypeChecker.
+  int func_arg_idx_ = -1;
+  std::map<std::string, bpf_map_type> bpf_map_type_;
+
+  uint32_t loop_depth_ = 0;
+  bool has_child_ = false;
+
+  // Track variable assignment state for "use before assign" warnings
+  std::vector<Node *> scope_stack_;
+  std::map<Node *, std::map<std::string, bool>> variables_used_;
+
+  // Track map declarations for "unused map" warnings
+  std::map<std::string, MapDeclStatement *> map_decls_;
+  std::set<std::string> used_maps_;
+};
+
+} // namespace
+
+static const std::map<std::string, call_spec> CALL_SPEC = {
+  { "avg",
+    { .min_args = 3,
+      .max_args = 3,
+      .arg_types = { arg_type_spec{ .skip_check=true },
+                     arg_type_spec{ .skip_check=true },
+                     arg_type_spec{ .type = Type::integer } } } },
+  { "bswap", { .min_args = 1, .max_args = 1 } },
+  { "buf",
+    { .min_args=1,
+      .max_args=2,
+
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer } } } },
+  { "cat",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "cgroupid",
+    { .min_args=1,
+      .max_args=1,
+
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "cgroup_path",
+    { .min_args=1,
+      .max_args=2,
+
+      .arg_types={
+        arg_type_spec{ .type=Type::integer },
+        arg_type_spec{ .type=Type::string } } } },
+  { "clear",
+    { .min_args=1,
+      .max_args=1,
+      .arg_types={}
+      } },
+  { "count",
+    { .min_args=2,
+      .max_args=2,
+      .arg_types={}
+       } },
+  { "debugf",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "errorf",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "exit",
+    { .min_args=0,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::integer } } } },
+  { "hist",
+    { .min_args=3,
+      .max_args=4,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer },
+        arg_type_spec{ .type=Type::integer, .literal=true } } } },
+  { "join",
+    { .min_args=1,
+      .max_args=2,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "kaddr",
+    { .min_args=1,
+      .max_args=1,
+
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "kptr",
+    { .min_args=1,
+      .max_args=1,
+       } },
+  { "kstack",
+    { .min_args=0,
+      .max_args=2,
+       } },
+  { "ksym",
+    { .min_args=1,
+      .max_args=1,
+       } },
+  { "stack_len",
+    { .min_args=1,
+      .max_args=1,
+
+    } },
+  { "lhist",
+    { .min_args=6,
+      .max_args=6,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer },
+        arg_type_spec{ .type=Type::integer, .literal=true },
+        arg_type_spec{ .type=Type::integer, .literal=true },
+        arg_type_spec{ .type=Type::integer, .literal=true } } } },
+  { "tseries",
+    { .min_args=5,
+      .max_args=6,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer },
+        arg_type_spec{ .type=Type::integer, .literal=true },
+        arg_type_spec{ .type=Type::integer, .literal=true },
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "macaddr",
+    { .min_args=1,
+      .max_args=1,
+       } },
+  { "max",
+    { .min_args=3,
+      .max_args=3,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer } } } },
+  { "min",
+    { .min_args=3,
+      .max_args=3,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer } } } },
+  { "nsecs",
+    { .min_args=0,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::timestamp_mode } } } },
+  { "ntop",
+    { .min_args=1,
+      .max_args=2,
+       } },
+  { "offsetof",
+    { .min_args=2,
+      .max_args=2,
+       } },
+  { "path",
+    { .min_args=1,
+      .max_args=2,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer, .literal=true } } } },
+  { "percpu_kaddr",
+    { .min_args=1,
+      .max_args=2,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true },
+        arg_type_spec{ .type=Type::integer } } } },
+  { "print",
+    { .min_args=1,
+      .max_args=3,
+      .arg_types={
+        // This may be a pure map or not.
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer, .literal=true },
+        arg_type_spec{ .type=Type::integer, .literal=true } } } },
+
+  { "printf",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "pton",
+    { .min_args=1,
+      .max_args=1,
+       } },
+  { "reg",
+    { .min_args=1,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "sizeof",
+    { .min_args=1,
+      .max_args=1,
+       } },
+  { "skboutput",
+    { .min_args=4,
+      .max_args=4,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true }, // pcap file name
+        arg_type_spec{ .type=Type::pointer },      // *skb
+        arg_type_spec{ .type=Type::integer },      // cap length
+        // cap offset, default is 0
+        // some tracepoints like dev_queue_xmit will output ethernet header,
+        // set offset to 14 bytes can exclude this header
+        arg_type_spec{ .type=Type::integer } } } },
+  { "stats",
+    { .min_args=3,
+      .max_args=3,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer } } } },
+  { "str",
+    { .min_args=1,
+      .max_args=2,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer } } } },
+  { "strftime",
+    { .min_args=2,
+      .max_args=2,
+      .arg_types={
+          arg_type_spec{ .type=Type::string, .literal=true },
+          arg_type_spec{ .type=Type::integer } } } },
+  { "strncmp",
+    { .min_args=3,
+      .max_args=3,
+      .arg_types={
+          arg_type_spec{ .type=Type::string },
+          arg_type_spec{ .type=Type::string },
+          arg_type_spec{ .type=Type::integer, .literal=true } } } },
+  { "sum",
+    { .min_args=3,
+      .max_args=3,
+      .arg_types={
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .skip_check=true },
+        arg_type_spec{ .type=Type::integer } } } },
+  { "system",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "time",
+    { .min_args=0,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "__builtin_uaddr",
+    { .min_args=1,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "unwatch",
+    { .min_args=1,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::integer } } } },
+  { "uptr",
+    { .min_args=1,
+      .max_args=1,
+       } },
+  { "ustack",
+    { .min_args=0,
+      .max_args=2,
+       } },
+  { "usym",
+    { .min_args=1,
+      .max_args=1,
+       } },
+  { "warnf",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
+  { "zero",
+    { .min_args=1,
+      .max_args=1,
+      .arg_types={} } },
+  { "pid",
+    { .min_args=0,
+      .max_args=1 },
+  },
+  { "socket_cookie",
+    { .min_args=1,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::pointer }, // struct sock *
+      } } },
+  { "fail",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true },
+      } } },
+};
+// clang-format on
+
+// These are types which aren't valid for scratch variables
+// e.g. this is not valid `let $x: sum_t;`
+static bool IsValidVarDeclType(const SizedType &ty)
+{
+  switch (ty.GetTy()) {
+    case Type::avg_t:
+    case Type::count_t:
+    case Type::hist_t:
+    case Type::lhist_t:
+    case Type::tseries_t:
+    case Type::max_t:
+    case Type::min_t:
+    case Type::stats_t:
+    case Type::sum_t:
+    case Type::voidtype:
+      return false;
+    case Type::integer:
+    case Type::kstack_t:
+    case Type::ustack_t:
+    case Type::timestamp:
+    case Type::ksym_t:
+    case Type::usym_t:
+    case Type::inet:
+    case Type::username:
+    case Type::string:
+    case Type::buffer:
+    case Type::pointer:
+    case Type::array:
+    case Type::mac_address:
+    case Type::c_struct:
+    case Type::tuple:
+    case Type::record:
+    case Type::cgroup_path_t:
+    case Type::none:
+    case Type::timestamp_mode:
+    case Type::boolean:
+      return true;
+  }
+  return false; // unreachable
+}
+
+bool IsValidPtrOp(Operator op)
+{
+  switch (op) {
+    case Operator::PRE_INCREMENT:
+    case Operator::PRE_DECREMENT:
+    case Operator::POST_INCREMENT:
+    case Operator::POST_DECREMENT:
+    case Operator::MUL:
+      return true;
+    default:
+      return false;
+  }
+}
+
+void TypeChecker::visit(String &string)
+{
+  if ((func_ == "printf" || func_ == "errorf" || func_ == "warnf") &&
+      func_arg_idx_ == 0)
+    return;
+
+  const auto str_len = bpftrace_.config_->max_strlen;
+  if (!is_compile_time_func(func_) && string.value.size() > str_len - 1) {
+    string.addError() << "String is too long (over " << str_len
+                      << " bytes): " << string.value;
+  }
+}
+
+void TypeChecker::visit(Identifier &identifier)
+{
+  if (func_ == "pid" || func_ == "tid") {
+    if (identifier.ident != "curr_ns" && identifier.ident != "init") {
+      identifier.addError()
+          << "Invalid PID namespace mode: " << identifier.ident
+          << " (expects: curr_ns or init)";
+    }
+  } else if (func_ == "signal") {
+    if (identifier.ident != "current_pid" &&
+        identifier.ident != "current_tid") {
+      identifier.addError() << "Invalid signal target: " << identifier.ident
+                            << " (expects: current_pid or current_tid)";
+    }
+  } else if (identifier.ident_type.IsNoneTy()) {
+    identifier.addError() << "Unknown identifier: '" + identifier.ident + "'";
+  }
+}
+
+void TypeChecker::visit(Call &call)
+{
+  // Check for unsafe-ness first. It is likely the most pertinent issue
+  // (and should be at the top) for any function call.
+  if (bpftrace_.safe_mode_ && is_unsafe_func(call.func)) {
+    call.addError() << call.func
+                    << "() is an unsafe function being used in safe mode";
+  }
+
+  struct func_setter {
+    func_setter(TypeChecker &analyser, const std::string &s)
+        : analyser_(analyser), old_func_(analyser_.func_)
+    {
+      analyser_.func_ = s;
+    }
+
+    ~func_setter()
+    {
+      analyser_.func_ = old_func_;
+      analyser_.func_arg_idx_ = -1;
+    }
+
+  private:
+    TypeChecker &analyser_;
+    std::string old_func_;
+  };
+
+  func_setter scope_bound_func_setter{ *this, call.func };
+
+  for (size_t i = 0; i < call.vargs.size(); ++i) {
+    func_arg_idx_ = i;
+    visit(call.vargs.at(i));
+  }
+
+  if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
+    for (auto *ap : probe->attach_points) {
+      if (!ap->check_available(call.func)) {
+        call.addError() << call.func << " can not be used with \""
+                        << ap->provider << "\" probes";
+      }
+    }
+  }
+
+  if (!check_call(call)) {
+    return;
+  }
+
+  if (call.func == "hist") {
+    if (call.vargs.size() == 3) {
+      call.vargs.emplace_back(ctx_.make_node<Integer>(call.loc, 0)); // default
+                                                                     // bits is
+                                                                     // 0
+    } else {
+      const auto *bits = call.vargs.at(3).as<Integer>();
+      if (!bits) {
+        // Bug here as the validity of the integer literal is already checked by
+        // check_arg above.
+        LOG(BUG) << call.func << ": invalid bits value, need integer literal";
+      } else if (bits->value > 5) {
+        call.addError() << call.func << ": bits " << bits->value
+                        << " must be 0..5";
+      }
+    }
+
+    call.return_type = CreateHist();
+  } else if (call.func == "lhist") {
+    Expression &min_arg = call.vargs.at(3);
+    Expression &max_arg = call.vargs.at(4);
+    Expression &step_arg = call.vargs.at(5);
+    auto *min = min_arg.as<Integer>();
+    auto *max = max_arg.as<Integer>();
+    auto *step = step_arg.as<Integer>();
+
+    if (!min) {
+      call.addError() << call.func
+                      << ": invalid min value (must be non-negative literal)";
+      return;
+    }
+    if (!max) {
+      call.addError() << call.func
+                      << ": invalid max value (must be non-negative literal)";
+      return;
+    }
+    if (!step) {
+      call.addError() << call.func << ": invalid step value";
+      return;
+    }
+
+    if (step->value <= 0) {
+      call.addError() << "lhist() step must be >= 1 (" << step->value
+                      << " provided)";
+    } else {
+      int buckets = (max->value - min->value) / step->value;
+      if (buckets > 1000) {
+        call.addError()
+            << "lhist() too many buckets, must be <= 1000 (would need "
+            << buckets << ")";
+      }
+    }
+    if (min->value > max->value) {
+      call.addError() << "lhist() min must be less than max (provided min "
+                      << min->value << " and max " << max->value << ")";
+    }
+    if ((max->value - min->value) < step->value) {
+      call.addError()
+          << "lhist() step is too large for the given range (provided step "
+          << step->value << " for range " << (max->value - min->value) << ")";
+    }
+  } else if (call.func == "tseries") {
+    const static std::set<std::string> ALLOWED_AGG_FUNCS = {
+      "avg",
+      "sum",
+      "max",
+      "min",
+    };
+    Expression &interval_ns_arg = call.vargs.at(3);
+    Expression &num_intervals_arg = call.vargs.at(4);
+
+    auto *interval_ns = interval_ns_arg.as<Integer>();
+    auto *num_intervals = num_intervals_arg.as<Integer>();
+
+    if (!interval_ns) {
+      call.addError()
+          << call.func
+          << ": invalid interval_ns value (must be non-negative literal)";
+      return;
+    }
+    if (!num_intervals) {
+      call.addError()
+          << call.func
+          << ": invalid num_intervals value (must be non-negative literal)";
+      return;
+    }
+
+    if (interval_ns->value <= 0) {
+      call.addError() << "tseries() interval_ns must be >= 1 ("
+                      << interval_ns->value << " provided)";
+      return;
+    }
+
+    if (num_intervals->value <= 0) {
+      call.addError() << "tseries() num_intervals must be >= 1 ("
+                      << num_intervals->value << " provided)";
+      return;
+    } else if (num_intervals->value > 1000000) {
+      call.addError() << "tseries() num_intervals must be < 1000000 ("
+                      << num_intervals->value << " provided)";
+    }
+
+    if (call.vargs.size() == 6) {
+      auto &aggregator = *call.vargs.at(5).as<String>();
+      if (!ALLOWED_AGG_FUNCS.contains(aggregator.value)) {
+        auto &err = call.addError();
+        err << "tseries() expects one of the following aggregation "
+               "functions: ";
+        size_t i = 0;
+        for (const std::string &agg : ALLOWED_AGG_FUNCS) {
+          err << agg;
+          if (i++ != ALLOWED_AGG_FUNCS.size() - 1) {
+            err << ", ";
+          }
+        }
+        err << " (\"" << aggregator.value << "\" provided)";
+      }
+    }
+
+    call.return_type = CreateVoid();
+  } else if (call.func == "str") {
+    auto &arg = call.vargs.at(0);
+    const auto &t = arg.type();
+    if (!t.IsStringTy() && !t.IsIntegerTy() && !t.IsPtrTy()) {
+      call.addError()
+          << call.func
+          << "() expects a string, integer or a pointer type as first "
+          << "argument (" << t << " provided)";
+    }
+    auto strlen = bpftrace_.config_->max_strlen;
+    if (call.vargs.size() == 2) {
+      if (auto *integer = call.vargs.at(1).as<Integer>()) {
+        if (integer->value + 1 > strlen) {
+          call.addWarning() << "length param (" << integer->value
+                            << ") is too long and will be shortened to "
+                            << strlen << " bytes (see BPFTRACE_MAX_STRLEN)";
+        } else {
+          strlen = integer->value + 1; // Storage for NUL byte.
+        }
+      }
+
+      if (auto *integer = dynamic_cast<NegativeInteger *>(
+              call.vargs.at(1).as<NegativeInteger>())) {
+        call.addError() << call.func << "cannot use negative length ("
+                        << integer->value << ")";
+      }
+    }
+    call.return_type = CreateString(strlen);
+    call.return_type.SetAS(AddrSpace::kernel);
+  } else if (call.func == "buf") {
+    const uint64_t max_strlen = bpftrace_.config_->max_strlen;
+    if (max_strlen >
+        std::numeric_limits<decltype(AsyncEvent::Buf::length)>::max()) {
+      call.addError() << "BPFTRACE_MAX_STRLEN too large to use on buffer ("
+                      << max_strlen << " > "
+                      << std::numeric_limits<uint32_t>::max() << ")";
+    }
+
+    auto &arg = call.vargs.at(0);
+    if (!(arg.type().IsIntTy() || arg.type().IsStringTy() ||
+          arg.type().IsPtrTy() || arg.type().IsArrayTy())) {
+      call.addError()
+          << call.func
+          << "() expects an integer, string, or array argument but saw "
+          << typestr(arg.type().GetTy());
+    }
+
+    if (call.vargs.size() == 1) {
+      if (!arg.type().IsArrayTy()) {
+        call.addError() << call.func
+                        << "() expects a length argument for non-array type "
+                        << typestr(arg.type().GetTy());
+      }
+    } else {
+      if (auto *integer = call.vargs.at(1).as<NegativeInteger>()) {
+        call.addError() << call.func << "cannot use negative length ("
+                        << integer->value << ")";
+      }
+    }
+  } else if (call.func == "ksym" || call.func == "usym") {
+    // allow symbol lookups on casts (eg, function pointers)
+    auto &arg = call.vargs.at(0);
+    const auto &type = arg.type();
+    if (!type.IsIntegerTy() && !type.IsPtrTy()) {
+      call.addError() << call.func
+                      << "() expects an integer or pointer argument";
+    }
+  } else if (call.func == "ntop") {
+    int index = 0;
+    if (call.vargs.size() == 2) {
+      check_arg(call, Type::integer, 0);
+      index = 1;
+    }
+
+    auto &arg = call.vargs.at(index);
+    if (!arg.type().IsIntTy() && !arg.type().IsStringTy() &&
+        !arg.type().IsArrayTy())
+      call.addError() << call.func
+                      << "() expects an integer or array argument, got "
+                      << arg.type().GetTy();
+
+    // Kind of:
+    //
+    // struct {
+    //   int af_type;
+    //   union {
+    //     char[4] inet4;
+    //     char[16] inet6;
+    //   }
+    // }
+    auto type = arg.type();
+
+    if ((arg.type().IsArrayTy() || arg.type().IsStringTy()) &&
+        type.GetSize() != 4 && type.GetSize() != 16)
+      call.addError() << call.func
+                      << "() argument must be 4 or 16 bytes in size";
+  } else if (call.func == "join") {
+    auto &arg = call.vargs.at(0);
+    if (!(arg.type().IsIntTy() || arg.type().IsPtrTy())) {
+      call.addError() << "() only supports int or pointer arguments" << " ("
+                      << arg.type().GetTy() << " provided)";
+    }
+  } else if (call.func == "reg") {
+    auto reg_name = call.vargs.at(0).as<String>()->value;
+    auto offset = arch::Host::register_to_pt_regs_offset(reg_name);
+    if (!offset) {
+      call.addError() << "'" << reg_name
+                      << "' is not a valid register on this architecture"
+                      << " (" << arch::Host::Machine << ")";
+    }
+  } else if (call.func == "percpu_kaddr") {
+    const auto &symbol = call.vargs.at(0).as<String>()->value;
+    if (bpftrace_.btf_->get_var_type(symbol).IsNoneTy()) {
+      call.addError() << "Could not resolve variable \"" << symbol
+                      << "\" from BTF";
+    }
+  } else if (call.func == "printf" || call.func == "errorf" ||
+             call.func == "warnf" || call.func == "system" ||
+             call.func == "cat" || call.func == "debugf") {
+    const auto &fmt = call.vargs.at(0).as<String>()->value;
+    std::vector<SizedType> args;
+    for (size_t i = 1; i < call.vargs.size(); i++) {
+      args.push_back(call.vargs[i].type());
+    }
+    FormatString fs(fmt);
+    auto ok = fs.check(args);
+    if (!ok) {
+      call.addError() << ok.takeError();
+    }
+    // The `debugf` call is a builtin, and is subject to more much rigorous
+    // checks. We've already validate the basic counts, etc. but we need to
+    // apply these additional constraints which includes a limited surface.
+    if (call.func == "debugf") {
+      call.addWarning()
+          << "The debugf() builtin is not recommended for production use. "
+             "For more information see bpf_trace_printk in bpf-helpers(7).";
+      // bpf_trace_printk cannot use more than three arguments, see
+      // bpf-helpers(7).
+      constexpr int PRINTK_MAX_ARGS = 3;
+      if (args.size() > PRINTK_MAX_ARGS) {
+        call.addError() << "cannot use more than " << PRINTK_MAX_ARGS
+                        << " conversion specifiers";
+      }
+      for (size_t i = 0; i < args.size(); i++) {
+        // bpf_trace_printk_format_types is a subset of printf_format_types
+        // that contains valid types for bpf_trace_printk() see iovisor/bcc
+        // BTypeVisitor::checkFormatSpecifiers.
+        static const std::unordered_map<std::string, Type>
+            bpf_trace_printk_format_types = { { "d", Type::integer },
+                                              { "u", Type::integer },
+                                              { "x", Type::integer },
+                                              { "p", Type::integer },
+                                              { "s", Type::string } };
+        auto it = bpf_trace_printk_format_types.find(fs.specs[i].specifier);
+        if (it == bpf_trace_printk_format_types.end()) {
+          call.vargs.at(0).node().addError()
+              << "Invalid format specifier for `debugf`: "
+              << fs.specs[i].specifier;
+          continue;
+        }
+        if (args[i].GetTy() != it->second) {
+          call.vargs.at(i + 1).node().addError()
+              << "Type does not match format specifier: "
+              << fs.specs[i].specifier;
+          continue;
+        }
+      }
+    }
+  }
+  if (call.func == "print") {
+    if (auto *map = call.vargs.at(0).as<Map>()) {
+      // N.B. that print is parameteric in the type, so this is not checked
+      // by `check_arg` as there is no spec for the first argument.
+      if (map->type().IsNoneTy()) {
+        map->addError() << "Undefined map: " + map->ident;
+      } else {
+        if (in_loop()) {
+          call.addWarning() << "Due to it's asynchronous nature using "
+                               "'print()' in a loop can "
+                               "lead to unexpected behavior. The map will "
+                               "likely be updated "
+                               "before the runtime can 'print' it.";
+        }
+        if (map->value_type.IsStatsTy() && call.vargs.size() > 1) {
+          call.addWarning()
+              << "print()'s top and div arguments are ignored when used on "
+                 "stats() maps.";
+        }
+      }
+    }
+    // Note that IsPrintableTy() is somewhat disingenuous here. Printing a
+    // non-map value requires being able to serialize the entire value, so
+    // map-backed types like count(), min(), max(), etc. cannot be printed
+    // through the non-map printing mechanism.
+    //
+    // We rely on the fact that type checking enforces types like count(),
+    // min(), max(), etc. to be assigned directly to a map.
+    else if (call.vargs.at(0).type().IsMultiKeyMapTy()) {
+      call.addError()
+          << "Map type " << call.vargs.at(0).type()
+          << " cannot print the value of individual keys. You must print "
+             "the whole map.";
+    } else if (call.vargs.at(0).type().IsPrintableTy()) {
+      if (call.vargs.size() != 1)
+        call.addError() << "Non-map print() only takes 1 argument, "
+                        << call.vargs.size() << " found";
+    } else {
+      call.addError() << call.vargs.at(0).type() << " type passed to "
+                      << call.func << "() is not printable";
+    }
+  } else if (call.func == "stack_len") {
+    if (!call.vargs.at(0).type().IsStack()) {
+      call.addError() << "len() expects a map or stack to be provided";
+    }
+  } else if (call.func == "strftime") {
+    auto &arg = call.vargs.at(1);
+    call.return_type.ts_mode = arg.type().ts_mode;
+    if (call.return_type.ts_mode == TimestampMode::monotonic) {
+      call.addError() << "strftime() can not take a monotonic timestamp";
+    }
+  } else if (call.func == "path") {
+    auto *probe = get_probe();
+    if (probe == nullptr)
+      return;
+
+    if (!bpftrace_.feature_->has_d_path()) {
+      call.addError()
+          << "BPF_FUNC_d_path not available for your kernel version";
+    }
+
+    // Argument for path can be both record and pointer.
+    // It's pointer when it's passed directly from the probe
+    // argument, like: path(args.path))
+    // It's record when it's referenced as object pointer
+    // member, like: path(args.filp->f_path))
+    auto &arg = call.vargs.at(0);
+    if (arg.type().GetTy() != Type::c_struct &&
+        arg.type().GetTy() != Type::pointer) {
+      call.addError() << "path() only supports pointer or record argument ("
+                      << arg.type().GetTy() << " provided)";
+    }
+
+    if (call.vargs.size() == 2) {
+      if (!call.vargs.at(1).is<Integer>()) {
+        call.addError() << call.func
+                        << ": invalid size value, need non-negative literal";
+      }
+    }
+
+    ProbeType type = probe->get_probetype();
+    if (type != ProbeType::fentry && type != ProbeType::fexit &&
+        type != ProbeType::iter) {
+      call.addError() << "The path function can only be used with "
+                      << "'fentry', 'fexit', 'iter' probes";
+    }
+  } else if (call.func == "strncmp") {
+    if (!call.vargs.at(2).is<Integer>()) {
+      call.addError() << "Builtin strncmp requires a non-negative literal";
+    }
+  } else if (call.func == "kptr" || call.func == "uptr") {
+    // kptr should accept both integer or pointer. Consider case: kptr($1)
+    auto &arg = call.vargs.at(0);
+    if (!arg.type().IsIntTy() && !arg.type().IsPtrTy()) {
+      call.addError() << call.func << "() only supports "
+                      << "integer or pointer arguments (" << arg.type().GetTy()
+                      << " provided)";
+      return;
+    }
+  } else if (call.func == "macaddr") {
+    auto &arg = call.vargs.at(0);
+    if (!arg.type().IsIntTy() && !arg.type().IsArrayTy() &&
+        !arg.type().IsByteArray() && !arg.type().IsPtrTy())
+      call.addError() << call.func
+                      << "() only supports array or pointer arguments" << " ("
+                      << arg.type().GetTy() << " provided)";
+
+    if (arg.is<String>())
+      call.addError() << call.func
+                      << "() does not support literal string arguments";
+
+    // N.B. When converting from BTF, we can treat string types as 7 bytes in
+    // order to signal to userspace that they are well-formed. However, we can
+    // convert from anything as long as there are at least 6 bytes to read.
+    const auto &type = arg.type();
+    if ((type.IsArrayTy() || type.IsByteArray()) && type.GetSize() < 6) {
+      call.addError() << call.func
+                      << "() argument must be at least 6 bytes in size";
+    }
+  } else if (call.func == "nsecs") {
+    if (call.return_type.ts_mode == TimestampMode::tai &&
+        !bpftrace_.feature_->has_helper_ktime_get_tai_ns()) {
+      call.addError()
+          << "Kernel does not support tai timestamp, please try sw_tai";
+    }
+    if (call.return_type.ts_mode == TimestampMode::sw_tai &&
+        !bpftrace_.delta_taitime_.has_value()) {
+      call.addError() << "Failed to initialize sw_tai in "
+                         "userspace. This is very unexpected.";
+    }
+  } else if (call.func == "pid" || call.func == "tid") {
+    if (call.vargs.size() == 1) {
+      auto &arg = call.vargs.at(0);
+      if (!(arg.as<Identifier>())) {
+        call.addError() << call.func
+                        << "() only supports curr_ns and init as the argument ("
+                        << arg.type().GetTy() << " provided)";
+      }
+    }
+  } else if (call.func == "socket_cookie") {
+    auto logError = [&]<typename T>(T name) {
+      call.addError() << call.func
+                      << "() only supports 'struct sock *' as the argument ("
+                      << name << " provided)";
+    };
+
+    const auto &type = call.vargs.at(0).type();
+    if (!type.IsPtrTy() || !type.GetPointeeTy().IsCStructTy()) {
+      logError(type.GetTy());
+      return;
+    }
+    if (!type.GetPointeeTy().IsCompatible(CreateCStruct("struct sock"))) {
+      logError("'" + type.GetPointeeTy().GetName() + " *'");
+      return;
+    }
+  } else if (call.func == "fail") {
+    // This is basically a static_assert failure. It will halt the compilation.
+    // We expect to hit this path only when using the `typeof` folds.
+    bool fail_valid = true;
+    std::vector<output::Primitive> args;
+    for (size_t i = 0; i < call.vargs.size(); ++i) {
+      if (!call.vargs[i].is_literal()) {
+        fail_valid = false;
+        call.addError() << "fail() arguments need to be literals";
+      } else {
+        if (i != 0) {
+          if (auto *val = call.vargs[i].as<String>()) {
+            args.emplace_back(val->value);
+          } else if (auto *val = call.vargs[i].as<Integer>()) {
+            args.emplace_back(val->value);
+          } else if (auto *val = call.vargs[i].as<NegativeInteger>()) {
+            args.emplace_back(val->value);
+          } else if (auto *val = call.vargs[i].as<Boolean>()) {
+            args.emplace_back(val->value);
+          }
+        } else {
+          if (!call.vargs[0].is<String>()) {
+            call.addError()
+                << "first argument to fail() must be a string literal";
+          }
+        }
+      }
+    }
+
+    if (fail_valid) {
+      FormatString fs(call.vargs[0].as<String>()->value);
+      call.addError() << fs.format(args);
+    }
+  } else if (call.func == "exit") {
+    // OK
+  } else {
+    // Check here if this corresponds to an external function. We convert the
+    // external type metadata into the internal `SizedType` representation and
+    // check that they are exactly equal.
+    auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
+    if (!maybe_func) {
+      if (call.return_type.IsNoneTy()) {
+        LOG(BUG) << "Unknown builtin function " << call.func;
+      }
+      return;
+    }
+
+    const auto &func = *maybe_func;
+    auto proto = func.type();
+    if (!proto) {
+      return;
+    }
+
+    // Convert all arguments.
+    auto argument_types = proto->argument_types();
+    if (!argument_types) {
+      call.addError() << "Unable to read argument types: "
+                      << argument_types.takeError();
+      return;
+    }
+    // Check the argument count.
+    if (argument_types->size() != call.vargs.size()) {
+      call.addError() << "Function `" << call.func << "` requires "
+                      << argument_types->size() << " arguments, got only "
+                      << call.vargs.size();
+      return;
+    }
+    std::vector<std::pair<std::string, SizedType>> args;
+    for (size_t i = 0; i < argument_types->size(); i++) {
+      const auto &[name, type] = argument_types->at(i);
+      auto compat_arg_type = getCompatType(type);
+      if (!compat_arg_type) {
+        // If the required type is a **pointer**, and the provided type is
+        // a **pointer**, then we let it slide. Just assume the user knows
+        // what they are doing. The verifier will catch them out otherwise.
+        if (type.is<btf::Pointer>() && call.vargs[i].type().IsPtrTy()) {
+          args.emplace_back(name, call.vargs[i].type());
+          continue;
+        }
+        call.addError() << "Unable to convert argument type, "
+                        << "function requires '" << type << "', " << "found '"
+                        << typestr(call.vargs[i].type())
+                        << "': " << compat_arg_type.takeError();
+        continue;
+      }
+      args.emplace_back(name, std::move(*compat_arg_type));
+    }
+    if (args.size() != argument_types->size()) {
+      return; // Already emitted errors.
+    }
+    // Check all the individual arguments.
+    bool ok = true;
+    for (size_t i = 0; i < args.size(); i++) {
+      const auto &[name, type] = args[i];
+      if (type != call.vargs[i].type()) {
+        if (!name.empty()) {
+          call.vargs[i].node().addError()
+              << "Expected " << typestr(type) << " for argument `" << name
+              << "` got " << typestr(call.vargs[i].type());
+        } else {
+          call.vargs[i].node().addError()
+              << "Expected " << typestr(type) << " got "
+              << typestr(call.vargs[i].type());
+        }
+        ok = false;
+      }
+    }
+    // Build our full proto as an error message.
+    std::stringstream fullmsg;
+    fullmsg << "Function `" << call.func << "` requires arguments (";
+    bool first = true;
+    for (const auto &[name, type] : args) {
+      if (!first) {
+        fullmsg << ", ";
+      }
+      fullmsg << typestr(type);
+      first = false;
+    }
+    fullmsg << ")";
+    if (!ok) {
+      call.addError() << fullmsg.str();
+      return;
+    }
+  }
+}
+
+void TypeChecker::visit(Sizeof &szof)
+{
+  visit(szof.record);
+}
+
+void TypeChecker::visit(Offsetof &offof)
+{
+  visit(offof.record);
+}
+
+void TypeChecker::visit(Typeof &typeof)
+{
+  visit(typeof.record);
+}
+
+void TypeChecker::visit(Typeinfo &typeinfo)
+{
+  Visitor<TypeChecker>::visit(typeinfo);
+}
+
+Probe *TypeChecker::get_probe()
+{
+  auto *probe = dynamic_cast<Probe *>(top_level_node_);
+  return probe;
+}
+
+void TypeChecker::visit(MapDeclStatement &decl)
+{
+  const auto bpf_type = get_bpf_map_type(decl.bpf_type);
+  if (!bpf_type) {
+    auto &err = decl.addError();
+    err << "Invalid bpf map type: " << decl.bpf_type;
+    auto &hint = err.addHint();
+    add_bpf_map_types_hint(hint);
+  } else {
+    bpf_map_type_.insert({ decl.ident, *bpf_type });
+  }
+
+  map_decls_.insert({ decl.ident, &decl });
+}
+
+void TypeChecker::visit(Map &map)
+{
+  used_maps_.insert(map.ident);
+
+  // Note that the naked `Map` node actually gets no type, the type
+  // is applied to the node at the `MapAccess` level.
+  auto found_kind = bpf_map_type_.find(map.ident);
+  if (found_kind != bpf_map_type_.end()) {
+    if (!bpf_map_types_compatible(map.value_type, found_kind->second)) {
+      auto map_type = get_bpf_map_type(map.value_type);
+      map.addError() << "Incompatible map types. Type from declaration: "
+                     << get_bpf_map_type_str(found_kind->second)
+                     << ". Type from value/key type: "
+                     << get_bpf_map_type_str(map_type);
+    }
+  }
+}
+void TypeChecker::visit(MapAddr &map_addr)
+{
+  visit(map_addr.map);
+}
+
+void TypeChecker::visit(VariableAddr &var_addr)
+{
+  if (var_addr.var_addr_type.IsNoneTy()) {
+    var_addr.addError() << "No type available for variable "
+                        << var_addr.var->ident;
+  }
+  // We can't know if the pointer to a scratch variable was passed
+  // to an external function for assignment so just mark it as assigned.
+  if (auto *scope = find_variable_scope(var_addr.var->ident)) {
+    variables_used_[scope][var_addr.var->ident] = true;
+  }
+}
+
+void TypeChecker::visit(ArrayAccess &arr)
+{
+  visit(arr.expr);
+  visit(arr.indexpr);
+
+  const SizedType &type = arr.expr.type();
+
+  if (!type.IsArrayTy() && !type.IsPtrTy() && !type.IsStringTy()) {
+    arr.addError() << "The array index operator [] can only be "
+                      "used on arrays and pointers, found "
+                   << type.GetTy() << ".";
+    return;
+  }
+
+  if (type.IsPtrTy() && type.GetPointeeTy().GetSize() == 0) {
+    arr.addError() << "The array index operator [] cannot be used "
+                      "on a pointer to an unsized type (void *).";
+  }
+
+  if (auto *integer = arr.indexpr.as<Integer>()) {
+    auto num = [&]() -> size_t {
+      if (type.IsArrayTy()) {
+        return type.GetNumElements();
+      } else if (type.IsStringTy()) {
+        return type.GetSize();
+      } else {
+        return 0;
+      }
+    }();
+    if (num != 0 && static_cast<size_t>(integer->value) >= num) {
+      arr.addError() << "the index " << integer->value
+                     << " is out of bounds for array of size " << num;
+    }
+  } else if (!arr.indexpr.type().IsIntTy() || arr.indexpr.type().IsSigned()) {
+    arr.addError() << "The array index operator [] only "
+                      "accepts positive (unsigned) integer indices. Got: "
+                   << arr.indexpr.type();
+  }
+}
+
+void TypeChecker::visit(TupleAccess &acc)
+{
+  visit(acc.expr);
+  const SizedType &type = acc.expr.type();
+
+  if (!type.IsTupleTy()) {
+    acc.addError() << "Can not access index '" << acc.index
+                   << "' on expression of type '" << type << "'";
+    return;
+  }
+
+  if (acc.index >= type.GetFields().size()) {
+    acc.addError() << "Invalid tuple index: " << acc.index << ". Found "
+                   << type.GetFields().size() << " elements in tuple.";
+  }
+}
+
+void TypeChecker::visit(Binop &binop)
+{
+  visit(binop.left);
+  visit(binop.right);
+
+  const auto &lht = binop.left.type();
+  const auto &rht = binop.right.type();
+  bool is_int_binop = (lht.IsCastableMapTy() || lht.IsIntTy() ||
+                       lht.IsBoolTy()) &&
+                      (rht.IsCastableMapTy() || rht.IsIntTy() ||
+                       rht.IsBoolTy());
+  bool is_ptr_binop = lht.IsPtrTy() || rht.IsPtrTy();
+  bool is_array_binop = lht.IsArrayTy() && rht.IsArrayTy();
+
+  if (is_int_binop || is_ptr_binop) {
+    // Already handled in a previous pass
+  } else if (is_array_binop) {
+    if (binop.op != Operator::EQ && binop.op != Operator::NE) {
+      binop.addError() << "The " << opstr(binop)
+                       << " operator cannot be used on arrays.";
+    }
+
+    if (lht.GetNumElements() != rht.GetNumElements()) {
+      binop.addError()
+          << "Only arrays of same size support comparison operators.";
+    }
+
+    if (!lht.GetElementTy().IsIntegerTy() || lht != rht) {
+      binop.addError()
+          << "Only arrays of same sized integer support comparison operators.";
+    }
+  } else if (!lht.IsCompatible(rht)) {
+    auto &err = binop.addError();
+    err << "Type mismatch for '" << opstr(binop) << "': comparing " << lht
+        << " with " << rht;
+    err.addContext(binop.left.loc()) << "left (" << lht << ")";
+    err.addContext(binop.right.loc()) << "right (" << rht << ")";
+  }
+  // Also allow combination like reg("sp") + 8
+  else if (binop.op != Operator::EQ && binop.op != Operator::NE) {
+    binop.addError() << "The " << opstr(binop)
+                     << " operator can not be used on expressions of types "
+                     << lht << ", " << rht;
+  }
+}
+
+void TypeChecker::visit(Unop &unop)
+{
+  if (unop.op == Operator::PRE_INCREMENT ||
+      unop.op == Operator::PRE_DECREMENT ||
+      unop.op == Operator::POST_INCREMENT ||
+      unop.op == Operator::POST_DECREMENT) {
+    if (!unop.expr.is<Variable>() && !unop.expr.is<MapAccess>()) {
+      unop.addError() << "The " << opstr(unop)
+                      << " operator must be applied to a map or variable";
+    }
+  }
+
+  visit(unop.expr);
+
+  const SizedType &type = unop.expr.type();
+  bool invalid = false;
+  // Unops are only allowed on ints (e.g. ~$x), dereference only on pointers
+  // and context (we allow args->field for backwards compatibility)
+  if (type.IsBoolTy()) {
+    invalid = unop.op != Operator::LNOT;
+  } else if (!type.IsIntegerTy() && !((type.IsPtrTy() || type.IsCtxAccess()) &&
+                                      IsValidPtrOp(unop.op))) {
+    invalid = true;
+  }
+  if (invalid) {
+    unop.addError() << "The " << opstr(unop)
+                    << " operator can not be used on expressions of type '"
+                    << type << "'";
+  }
+}
+
+void TypeChecker::visit(IfExpr &if_expr)
+{
+  visit(if_expr.cond);
+  visit(if_expr.left);
+  visit(if_expr.right);
+}
+
+void TypeChecker::visit(Unroll &unroll)
+{
+  visit(unroll.expr);
+
+  auto *integer = unroll.expr.as<Integer>();
+  if (!integer) {
+    unroll.addError() << "invalid unroll value";
+    return;
+  }
+
+  if (integer->value > static_cast<uint64_t>(100)) {
+    unroll.addError() << "unroll maximum value is 100";
+  } else if (integer->value < static_cast<uint64_t>(1)) {
+    unroll.addError() << "unroll minimum value is 1";
+  }
+
+  visit(unroll.block);
+}
+
+void TypeChecker::visit(Jump &jump)
+{
+  if (jump.ident == JumpType::RETURN) {
+    visit(jump.return_value);
+    if (dynamic_cast<Probe *>(top_level_node_)) {
+      if (jump.return_value.has_value()) {
+        const auto &ty = jump.return_value->type();
+        if (!ty.IsIntegerTy()) {
+          jump.addError() << "Probe return values can only be integers. Found "
+                          << ty;
+        }
+      }
+    }
+  }
+}
+
+void TypeChecker::visit(While &while_block)
+{
+  visit(while_block.cond);
+
+  loop_depth_++;
+  visit(while_block.block);
+  loop_depth_--;
+}
+
+void TypeChecker::visit(For &f)
+{
+  if (f.iterable.is<Range>() && !bpftrace_.feature_->has_helper_loop()) {
+    f.addError() << "Missing required kernel feature: loop";
+  }
+
+  visit(f.iterable);
+
+  // Create scope for the loop and mark loop variable as assigned
+  scope_stack_.push_back(&f);
+  variables_used_[scope_stack_.back()][f.decl->ident] = true;
+
+  loop_depth_++;
+  visit(f.block);
+  loop_depth_--;
+
+  scope_stack_.pop_back();
+
+  if (auto *range = f.iterable.as<Range>()) {
+    if (!range->start.type().IsIntTy()) {
+      range->addError() << "Loop range requires an integer for the start value";
+    }
+    if (!range->end.type().IsIntTy()) {
+      range->addError() << "Loop range requires an integer for the end value";
+    }
+  }
+
+  // Currently, we do not pass BPF context to the callback so disable builtins
+  // which require ctx access.
+  CollectNodes<Builtin> builtins;
+  builtins.visit(f.block);
+  for (const Builtin &builtin : builtins.nodes()) {
+    if (builtin.builtin_type.IsCtxAccess()) {
+      builtin.addError() << "'" << builtin.ident
+                         << "' builtin is not allowed in a for-loop";
+    }
+  }
+}
+
+void TypeChecker::visit(FieldAccess &acc)
+{
+  visit(acc.expr);
+
+  const auto &record = acc.expr.type().GetStruct();
+  const auto &field = record->GetField(acc.field);
+
+  if (record->is_tracepoint_args && field.offset < 8)
+    acc.addError() << "BPF does not support accessing common tracepoint fields";
+}
+
+void TypeChecker::visit(MapAccess &acc)
+{
+  visit(acc.map);
+  visit(acc.key);
+
+  if (acc.map->type().IsCastableMapTy() &&
+      !bpftrace_.feature_->has_helper_map_lookup_percpu_elem()) {
+    acc.addError() << "Missing required kernel feature: map_lookup_percpu_elem";
+  }
+
+  // Validate map key type
+  const auto &key_type = acc.key.type();
+  if (key_type.IsPtrTy() && key_type.IsCtxAccess()) {
+    // map functions only accepts a pointer to a element in the stack
+    acc.key.node().addError() << "context cannot be part of a map key";
+  }
+
+  if (key_type.IsHistTy() || key_type.IsLhistTy() || key_type.IsStatsTy() ||
+      key_type.IsTSeriesTy()) {
+    acc.key.node().addError() << key_type << " cannot be part of a map key";
+  }
+
+  if (key_type.IsNoneTy() || key_type.IsVoidTy()) {
+    acc.key.node().addError() << "Invalid map key type: " << key_type;
+  }
+
+  // For tuple keys, validate each element
+  if (key_type.IsTupleTy()) {
+    for (const auto &field : key_type.GetFields()) {
+      if (field.type.IsPtrTy() && field.type.IsCtxAccess()) {
+        acc.key.node().addError() << "context cannot be part of a map key";
+      }
+      if (field.type.IsHistTy() || field.type.IsLhistTy() ||
+          field.type.IsStatsTy() || field.type.IsTSeriesTy()) {
+        acc.key.node().addError()
+            << field.type << " cannot be part of a map key";
+      }
+    }
+  }
+}
+
+void TypeChecker::visit(Cast &cast)
+{
+  visit(cast.expr);
+  visit(cast.typeof);
+
+  const auto &resolved_ty = cast.type();
+  if (resolved_ty.IsNoneTy()) {
+    cast.addError() << "Incomplete cast, unknown type";
+    return;
+  }
+
+  auto rhs = cast.expr.type();
+  if (rhs.IsCStructTy()) {
+    cast.addError() << "Cannot cast from struct type \"" << cast.expr.type()
+                    << "\"";
+    return;
+  } else if (rhs.IsNoneTy()) {
+    cast.addError() << "Cannot cast from \"" << cast.expr.type() << "\" type";
+    return;
+  }
+
+  // Resolved the type because we may mutate it below, for various reasons.
+  cast.typeof->record = resolved_ty;
+  auto &ty = std::get<SizedType>(cast.typeof->record);
+
+  auto logError = [&]() {
+    cast.addError() << "Cannot cast from \"" << rhs << "\" to \"" << ty << "\"";
+  };
+
+  if (ty.IsStringTy() && rhs.IsStringTy()) {
+    if (ty.GetSize() < rhs.GetSize()) {
+      logError();
+    }
+    return;
+  }
+
+  if (!ty.IsIntTy() && !ty.IsPtrTy() && !ty.IsBoolTy() &&
+      (!ty.IsPtrTy() || ty.GetElementTy().IsIntTy() ||
+       ty.GetElementTy().IsCStructTy()) &&
+      // we support casting integers to int arrays
+      !(ty.IsArrayTy() && ty.GetElementTy().IsBoolTy()) &&
+      !(ty.IsArrayTy() && ty.GetElementTy().IsIntTy())) {
+    logError();
+  }
+
+  if (ty.IsArrayTy()) {
+    if (ty.GetNumElements() == 0) {
+      if (ty.GetElementTy().GetSize() == 0)
+        cast.addError() << "Could not determine size of the array";
+      else {
+        if (rhs.GetSize() % ty.GetElementTy().GetSize() != 0) {
+          cast.addError() << "Cannot determine array size: the element size is "
+                             "incompatible with the cast integer size";
+        }
+      }
+    }
+
+    if (rhs.IsIntTy()) {
+      if ((ty.GetElementTy().IsIntegerTy() || ty.GetElementTy().IsBoolTy())) {
+        if ((ty.GetSize() <= 8) && (ty.GetSize() > rhs.GetSize())) {
+          // ok
+        } else if (ty.GetSize() != rhs.GetSize()) {
+          logError();
+        }
+      }
+    } else {
+      if ((!rhs.IsBoolTy() && !rhs.IsStringTy()) ||
+          ty.GetSize() != rhs.GetSize()) {
+        logError();
+      }
+    }
+  }
+
+  if (ty.IsEnumTy()) {
+    if (!c_definitions_.enum_defs.contains(ty.GetName())) {
+      cast.addError() << "Unknown enum: " << ty.GetName();
+    } else {
+      if (auto *integer = cast.expr.as<Integer>()) {
+        const auto &enums = c_definitions_.enum_defs.at(ty.GetName());
+        if (!enums.contains(integer->value)) {
+          cast.addError() << "Enum: " << ty.GetName()
+                          << " doesn't contain a variant value of "
+                          << integer->value;
+        }
+      }
+    }
+  }
+
+  if (!rhs.IsPtrTy() && !rhs.IsCastableMapTy() && !rhs.IsIntTy()) {
+    if (ty.IsBoolTy() && !rhs.IsStringTy()) {
+      logError();
+    }
+
+    if (ty.IsIntTy() && !rhs.IsBoolTy() && !rhs.IsCtxAccess() &&
+        !rhs.IsArrayTy()) {
+      logError();
+    }
+  }
+
+  if ((rhs.IsArrayTy() && (!ty.IsIntTy() || ty.GetSize() != rhs.GetSize()))) {
+    logError();
+  }
+}
+
+void TypeChecker::visit(Tuple &tuple)
+{
+  for (auto &elem : tuple.elems) {
+    visit(elem);
+
+    // If elem type is none that means that the tuple is not yet resolved.
+    if (elem.type().IsMultiKeyMapTy()) {
+      elem.node().addError()
+          << "Map type " << elem.type() << " cannot exist inside a tuple.";
+    }
+  }
+}
+
+void TypeChecker::visit(Record &record)
+{
+  for (auto *named_arg : record.elems) {
+    auto &elem = named_arg->expr;
+    visit(elem);
+
+    if (elem.type().IsMultiKeyMapTy()) {
+      elem.node().addError()
+          << "Map type " << elem.type() << " cannot exist inside a record.";
+    }
+  }
+}
+
+void TypeChecker::visit(Expression &expr)
+{
+  Visitor<TypeChecker>::visit(expr);
+}
+
+void TypeChecker::visit(ExprStatement &expr)
+{
+  visit(expr.expr);
+
+  bool warn_discarded = true;
+  if (auto *unop = expr.expr.as<Unop>()) {
+    if (unop->op == Operator::PRE_INCREMENT ||
+        unop->op == Operator::PRE_DECREMENT ||
+        unop->op == Operator::POST_INCREMENT ||
+        unop->op == Operator::POST_DECREMENT) {
+      warn_discarded = false;
+    }
+  }
+
+  if (expr.expr.type().IsNoneTy() || expr.expr.type().IsVoidTy()) {
+    warn_discarded = false;
+  }
+
+  if (warn_discarded) {
+    expr.addWarning() << "Return value discarded.";
+  }
+}
+
+static const std::unordered_map<Type, std::string_view> AGGREGATE_HINTS{
+  { Type::count_t, "count()" },
+  { Type::sum_t, "sum(retval)" },
+  { Type::min_t, "min(retval)" },
+  { Type::max_t, "max(retval)" },
+  { Type::avg_t, "avg(retval)" },
+  { Type::hist_t, "hist(retval)" },
+  { Type::lhist_t, "lhist(rand %10, 0, 10, 1)" },
+  { Type::tseries_t, "tseries(rand %10, 10s, 1)" },
+  { Type::stats_t, "stats(arg2)" },
+};
+
+void TypeChecker::visit(AssignMapStatement &assignment)
+{
+  visit(assignment.map_access);
+  visit(assignment.expr);
+}
+
+void TypeChecker::visit(AssignVarStatement &assignment)
+{
+  visit(assignment.expr);
+
+  // Only visit the declaration if it is a `let` declaration,
+  // otherwise skip as it is not a variable access.
+  if (std::holds_alternative<VarDeclStatement *>(assignment.var_decl)) {
+    visit(assignment.var_decl);
+  }
+
+  if (assignment.var()->var_type.IsNoneTy()) {
+    assignment.addError() << "Invalid expression for assignment";
+  }
+
+  // Mark variable as assigned
+  const auto &var_ident = assignment.var()->ident;
+  if (auto *scope = find_variable_scope(var_ident)) {
+    variables_used_[scope][var_ident] = true;
+  }
+}
+
+void TypeChecker::visit(VarDeclStatement &decl)
+{
+  visit(decl.typeof);
+
+  if (decl.typeof) {
+    const auto &ty = decl.typeof->type();
+    if (!ty.IsNoneTy()) {
+      if (!IsValidVarDeclType(ty)) {
+        decl.addError() << "Invalid variable declaration type: " << ty;
+      } else {
+        decl.var->var_type = ty;
+      }
+    } else {
+      // We couldn't resolve that specific type by now.
+      decl.addError() << "Type cannot be resolved: still none";
+    }
+  }
+
+  // Register variable in current scope as not yet assigned
+  if (!scope_stack_.empty()) {
+    const std::string &var_ident = decl.var->ident;
+    variables_used_[scope_stack_.back()].insert({ var_ident, false });
+  }
+}
+
+void TypeChecker::visit(BlockExpr &block)
+{
+  scope_stack_.push_back(&block);
+  visit(block.stmts);
+  visit(block.expr);
+  scope_stack_.pop_back();
+}
+
+void TypeChecker::visit(Probe &probe)
+{
+  top_level_node_ = &probe;
+  variables_used_.clear();
+  visit(probe.attach_points);
+  visit(probe.block);
+}
+
+void TypeChecker::visit(Subprog &subprog)
+{
+  // Note that we visit the subprogram and process arguments *after*
+  // constructing the stack with the variable states. This is because the
+  // arguments, etc. may have types defined in terms of the arguments
+  // themselves. We already handle detecting circular dependencies.
+  variables_used_.clear();
+  scope_stack_.push_back(&subprog);
+  top_level_node_ = &subprog;
+
+  // Mark args as assigned (they come from the caller)
+  for (SubprogArg *arg : subprog.args) {
+    variables_used_[scope_stack_.back()].insert({ arg->var->ident, true });
+  }
+
+  // Validate that arguments are set.
+  visit(subprog.args);
+  for (SubprogArg *arg : subprog.args) {
+    if (arg->typeof->type().IsNoneTy()) {
+      arg->addError() << "Unable to resolve argument type.";
+    }
+  }
+
+  // Visit all statements.
+  visit(subprog.block);
+
+  // Validate that the return type is valid.
+  visit(subprog.return_type);
+  if (subprog.return_type->type().IsNoneTy()) {
+    subprog.return_type->addError()
+        << "Unable to resolve suitable return type.";
+  }
+  scope_stack_.pop_back();
+}
+
+void TypeChecker::visit(Program &program)
+{
+  Visitor<TypeChecker>::visit(program);
+
+  for (const auto &[ident, decl] : map_decls_) {
+    if (!used_maps_.contains(ident)) {
+      decl->addWarning() << "Unused map: " << ident;
+    }
+  }
+}
+
+bool TypeChecker::check_arg(Call &call, size_t index, const arg_type_spec &spec)
+{
+  if (spec.skip_check) {
+    return true;
+  }
+  return check_arg(call, spec.type, index, spec.literal);
+}
+
+bool TypeChecker::check_call(Call &call)
+{
+  auto spec = CALL_SPEC.find(call.func);
+  if (spec == CALL_SPEC.end()) {
+    return true;
+  }
+
+  auto ret = true;
+  if (spec->second.min_args != spec->second.max_args) {
+    ret = check_varargs(call, spec->second.min_args, spec->second.max_args);
+  } else {
+    ret = check_nargs(call, spec->second.min_args);
+  }
+
+  if (!ret) {
+    return ret;
+  }
+
+  for (size_t i = 0; i < spec->second.arg_types.size() && i < call.vargs.size();
+       ++i) {
+    ret = check_arg(call, i, spec->second.arg_types.at(i));
+  }
+
+  return ret;
+}
+
+// Checks the number of arguments passed to a function is correct.
+bool TypeChecker::check_nargs(const Call &call, size_t expected_nargs)
+{
+  std::stringstream err;
+  auto nargs = call.vargs.size();
+  assert(nargs >= call.injected_args);
+  assert(expected_nargs >= call.injected_args);
+  nargs -= call.injected_args;
+  expected_nargs -= call.injected_args;
+
+  if (nargs != expected_nargs) {
+    if (expected_nargs == 0)
+      err << call.func << "() requires no arguments";
+    else if (expected_nargs == 1)
+      err << call.func << "() requires one argument";
+    else
+      err << call.func << "() requires " << expected_nargs << " arguments";
+
+    err << " (" << nargs << " provided)";
+    call.addError() << err.str();
+    return false;
+  }
+  return true;
+}
+
+// Checks the number of arguments passed to a function is within a specified
+// range.
+bool TypeChecker::check_varargs(const Call &call,
+                                size_t min_nargs,
+                                size_t max_nargs)
+{
+  std::stringstream err;
+  auto nargs = call.vargs.size();
+  assert(nargs >= call.injected_args);
+  assert(min_nargs >= call.injected_args);
+  assert(max_nargs >= call.injected_args);
+  nargs -= call.injected_args;
+  min_nargs -= call.injected_args;
+  max_nargs -= call.injected_args;
+
+  if (nargs < min_nargs) {
+    if (min_nargs == 1)
+      err << call.func << "() requires at least one argument";
+    else
+      err << call.func << "() requires at least " << min_nargs << " arguments";
+
+    err << " (" << nargs << " provided)";
+    call.addError() << err.str();
+    return false;
+  } else if (nargs > max_nargs) {
+    if (max_nargs == 0)
+      err << call.func << "() requires no arguments";
+    else if (max_nargs == 1)
+      err << call.func << "() takes up to one argument";
+    else
+      err << call.func << "() takes up to " << max_nargs << " arguments";
+
+    err << " (" << nargs << " provided)";
+    call.addError() << err.str();
+    return false;
+  }
+
+  return true;
+}
+
+// Checks an argument passed to a function is of the correct type.
+//
+// This function does not check that the function has the correct number of
+// arguments. Either check_nargs() or check_varargs() should be called first
+// to validate this.
+bool TypeChecker::check_arg(Call &call,
+                            Type type,
+                            size_t index,
+                            bool want_literal)
+{
+  const auto &arg = call.vargs.at(index);
+
+  if (want_literal && (!arg.is_literal() || arg.type().GetTy() != type)) {
+    call.addError() << call.func << "() expects a " << type << " literal ("
+                    << arg.type().GetTy() << " provided)";
+    if (type == Type::string) {
+      // If the call requires a string literal and a positional parameter is
+      // given, tell user to use str()
+      auto *pos_param = arg.as<PositionalParameter>();
+      if (pos_param)
+        pos_param->addError() << "Use str($" << pos_param->n << ") to treat $"
+                              << pos_param->n << " as a string";
+    }
+    return false;
+  } else if (arg.type().GetTy() != type) {
+    call.addError() << call.func << "() only supports " << type
+                    << " arguments (" << arg.type().GetTy() << " provided)";
+    return false;
+  }
+  return true;
+}
+
+Node *TypeChecker::find_variable_scope(const std::string &var_ident)
+{
+  for (auto *scope : scope_stack_) {
+    if (auto search_val = variables_used_[scope].find(var_ident);
+        search_val != variables_used_[scope].end()) {
+      return scope;
+    }
+  }
+  return nullptr;
+}
+
+Pass CreateTypeCheckerPass()
+{
+  auto fn = [](ASTContext &ast,
+               BPFtrace &b,
+               CDefinitions &c_definitions,
+               TypeMetadata &types) {
+    TypeChecker checker(
+        ast, b, c_definitions, types, !b.cmd_.empty() || b.child_ != nullptr);
+    checker.visit(ast.root);
+  };
+
+  return Pass::create("TypeChecker", fn);
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/type_checker.h
+++ b/src/ast/passes/type_checker.h
@@ -4,6 +4,6 @@
 
 namespace bpftrace::ast {
 
-Pass CreateSemanticPass();
+Pass CreateTypeCheckerPass();
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/type_resolver.cpp
+++ b/src/ast/passes/type_resolver.cpp
@@ -17,7 +17,7 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_resolver.h"
 #include "ast/passes/type_system.h"
 #include "bpftrace.h"
 #include "btf/compat.h"
@@ -109,36 +109,6 @@ private:
   int num_passes_ = 1;
 };
 
-struct arg_type_spec {
-  Type type = Type::integer;
-  bool literal = false;
-
-  // This indicates that this is just a placeholder as we use the index in the
-  // vector of arg_type_spec as the number argument to check.
-  bool skip_check = false;
-};
-
-struct map_type_spec {
-  // This indicates that the argument must be a map type. The given function
-  // may be called to determine the map type.
-  std::function<SizedType(const Call &call)> type;
-};
-
-struct map_key_spec {
-  // This indicates that the argument is a key expression for another map
-  // argument, which is found in argument `map_index`.
-  size_t map_index;
-};
-
-struct call_spec {
-  size_t min_args = 0;
-  size_t max_args = 0;
-  // NOLINTBEGIN(readability-redundant-member-init)
-  std::vector<std::variant<arg_type_spec, map_type_spec, map_key_spec>>
-      arg_types = {};
-  // NOLINTEND(readability-redundant-member-init)
-};
-
 template <util::TypeName name>
 class AssignMapDisallowed : public Visitor<AssignMapDisallowed<name>> {
 public:
@@ -151,15 +121,15 @@ public:
   }
 };
 
-class SemanticAnalyser : public Visitor<SemanticAnalyser> {
+class TypeResolver : public Visitor<TypeResolver> {
 public:
-  explicit SemanticAnalyser(ASTContext &ctx,
-                            BPFtrace &bpftrace,
-                            CDefinitions &c_definitions,
-                            MapMetadata &map_metadata,
-                            NamedParamDefaults &named_param_defaults,
-                            TypeMetadata &type_metadata,
-                            MacroRegistry &macro_registry)
+  explicit TypeResolver(ASTContext &ctx,
+                        BPFtrace &bpftrace,
+                        CDefinitions &c_definitions,
+                        MapMetadata &map_metadata,
+                        NamedParamDefaults &named_param_defaults,
+                        TypeMetadata &type_metadata,
+                        MacroRegistry &macro_registry)
       : ctx_(ctx),
         bpftrace_(bpftrace),
         c_definitions_(c_definitions),
@@ -172,7 +142,7 @@ public:
 
   int analyse();
 
-  using Visitor<SemanticAnalyser>::visit;
+  using Visitor<TypeResolver>::visit;
   void visit(String &string);
   void visit(StackMode &mode);
   void visit(Identifier &identifier);
@@ -184,7 +154,6 @@ public:
   void visit(Typeinfo &typeinfo);
   void visit(Map &map);
   void visit(MapAddr &map_addr);
-  void visit(MapDeclStatement &decl);
   void visit(Variable &var);
   void visit(VariableAddr &var_addr);
   void visit(Binop &binop);
@@ -228,32 +197,15 @@ private:
   std::optional<size_t> check(Sizeof &szof);
   std::optional<size_t> check(Offsetof &offof);
 
-  [[nodiscard]] bool check_arg(Call &call,
-                               size_t index,
-                               const arg_type_spec &spec);
-  [[nodiscard]] bool check_arg(Call &call,
-                               size_t index,
-                               const map_type_spec &spec);
-  [[nodiscard]] bool check_arg(Call &call,
-                               size_t index,
-                               const map_key_spec &spec);
-  [[nodiscard]] bool check_call(Call &call);
-  [[nodiscard]] bool check_nargs(const Call &call, size_t expected_nargs);
-  [[nodiscard]] bool check_varargs(const Call &call,
-                                   size_t min_nargs,
-                                   size_t max_nargs);
+  void check_map_value(Map &map, Call &call, SizedType type);
 
-  bool check_arg(Call &call,
-                 Type type,
-                 size_t index,
-                 bool want_literal = false);
-  bool check_symbol(const Call &call, int arg_num);
-
+  bool check_symbol(const Call &call);
   void check_stack_call(Call &call, bool kernel);
 
   Probe *get_probe(Node &node, std::string name = "");
 
-  bool is_valid_assignment(const Expression &expr, bool map_without_type);
+  bool is_valid_assignment(const Expression &expr,
+                           bool map_without_type = false);
   SizedType *get_map_type(const Map &map);
   SizedType *get_map_key_type(const Map &map);
   void assign_map_type(Map &map,
@@ -282,7 +234,6 @@ private:
 
   void binop_ptr(Binop &op);
   void binop_int(Binop &op);
-  void binop_array(Binop &op);
 
   void create_int_cast(Expression &exp, const SizedType &target_type);
   void create_string_cast(Expression &exp, const SizedType &target_type);
@@ -297,22 +248,14 @@ private:
                           const SizedType &target_type);
 
   bool has_error() const;
-  bool in_loop()
-  {
-    return loop_depth_ > 0;
-  };
 
   // At the moment we iterate over the stack from top to
   // bottom as variable shadowing is not supported.
   std::vector<Node *> scope_stack_;
   Node *top_level_node_ = nullptr;
 
-  // Holds the function currently being visited by this
-  // SemanticAnalyser.
+  // Holds the function currently being visited by this TypeResolver.
   std::string func_;
-  // Holds the function argument index currently being
-  // visited by this SemanticAnalyser.
-  int func_arg_idx_ = -1;
   // This is specifically for visiting Identifiers
   // in typeof, sizeof, cast, and offsetof expressions
   // as the ident is treated like a type name, e.g.
@@ -327,388 +270,15 @@ private:
   std::map<Node *, CollectNodes<Variable>> for_vars_referenced_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, SizedType> map_key_;
-  std::map<std::string, bpf_map_type> bpf_map_type_;
   std::map<std::string, SizedType> agg_map_val_;
-
-  uint32_t loop_depth_ = 0;
 };
 
 } // namespace
 
-static const std::map<std::string, call_spec> CALL_SPEC = {
-  { "avg",
-    { .min_args = 3,
-      .max_args = 3,
-      .arg_types = { map_type_spec{
-                         .type = std::function<SizedType(const ast::Call &)>(
-                             [](const ast::Call &call) -> SizedType {
-                              return CreateAvg(
-                                   call.vargs.at(2).type().IsSigned());
-                             }) },
-                     map_key_spec{ .map_index = 0 },
-                     arg_type_spec{ .type = Type::integer } } } },
-  { "bswap", { .min_args = 1, .max_args = 1 } },
-  { "buf",
-    { .min_args=1,
-      .max_args=2,
-
-      .arg_types={
-        arg_type_spec{ .skip_check=true },
-        arg_type_spec{ .type=Type::integer } } } },
-  { "cat",
-    { .min_args=1,
-      .max_args=128,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "cgroupid",
-    { .min_args=1,
-      .max_args=1,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "cgroup_path",
-    { .min_args=1,
-      .max_args=2,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::integer },
-        arg_type_spec{ .type=Type::string } } } },
-  { "clear",
-    { .min_args=1,
-      .max_args=1,
-      .arg_types={
-        map_type_spec{},
-      }
-      } },
-  { "count",
-    { .min_args=2,
-      .max_args=2,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const Call&)>([](const ast::Call&) -> SizedType { return CreateCount(); })
-        },
-        map_key_spec{ .map_index=0 },
-      }
-       } },
-  { "debugf",
-    { .min_args=1,
-      .max_args=128,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "errorf",
-    { .min_args=1,
-      .max_args=128,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "exit",
-    { .min_args=0,
-      .max_args=1,
-      .arg_types={
-        arg_type_spec{ .type=Type::integer } } } },
-  { "hist",
-    { .min_args=3,
-      .max_args=4,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const ast::Call&)>([]([[maybe_unused]] const ast::Call &call) -> SizedType { return CreateHist(); })
-        },
-        map_key_spec{ .map_index=0 },
-        arg_type_spec{ .type=Type::integer },
-        arg_type_spec{ .type=Type::integer, .literal=true } } } },
-  { "join",
-    { .min_args=1,
-      .max_args=2,
-      .arg_types={
-        arg_type_spec{ .skip_check=true },
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "kaddr",
-    { .min_args=1,
-      .max_args=1,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "kptr",
-    { .min_args=1,
-      .max_args=1,
-       } },
-  { "kstack",
-    { .min_args=0,
-      .max_args=2,
-       } },
-  { "ksym",
-    { .min_args=1,
-      .max_args=1,
-       } },
-  { "stack_len",
-    { .min_args=1,
-      .max_args=1,
-
-    } },
-  { "lhist",
-    { .min_args=6,
-      .max_args=6,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const ast::Call&)>([]([[maybe_unused]] const ast::Call &call) -> SizedType { return CreateLhist(); })
-        },
-        map_key_spec{ .map_index=0 },
-        arg_type_spec{ .type=Type::integer },
-        arg_type_spec{ .type=Type::integer, .literal=true },
-        arg_type_spec{ .type=Type::integer, .literal=true },
-        arg_type_spec{ .type=Type::integer, .literal=true } } } },
-  { "tseries",
-    { .min_args=5,
-      .max_args=6,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const ast::Call&)>([]([[maybe_unused]] const ast::Call &call) -> SizedType { return CreateTSeries(); })
-        },
-        map_key_spec{ .map_index=0 },
-        arg_type_spec{ .type=Type::integer },
-        arg_type_spec{ .type=Type::integer, .literal=true },
-        arg_type_spec{ .type=Type::integer, .literal=true },
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "macaddr",
-    { .min_args=1,
-      .max_args=1,
-       } },
-  { "max",
-    { .min_args=3,
-      .max_args=3,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const ast::Call&)>([](const ast::Call &call) -> SizedType {
-            return CreateMax(call.vargs.at(2).type().IsSigned());
-          })
-        },
-        map_key_spec{ .map_index=0 },
-        arg_type_spec{ .type=Type::integer } } } },
-  { "min",
-    { .min_args=3,
-      .max_args=3,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const ast::Call&)>([](const ast::Call &call) -> SizedType {
-            return CreateMin(call.vargs.at(2).type().IsSigned());
-          })
-        },
-        map_key_spec{ .map_index=0 },
-        arg_type_spec{ .type=Type::integer } } } },
-  { "nsecs",
-    { .min_args=0,
-      .max_args=1,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::timestamp_mode } } } },
-  { "ntop",
-    { .min_args=1,
-      .max_args=2,
-       } },
-  { "offsetof",
-    { .min_args=2,
-      .max_args=2,
-       } },
-  { "path",
-    { .min_args=1,
-      .max_args=2,
-
-      .arg_types={
-        arg_type_spec{ .skip_check=true },
-        arg_type_spec{ .type=Type::integer, .literal=true } } } },
-  { "percpu_kaddr",
-    { .min_args=1,
-      .max_args=2,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true },
-        arg_type_spec{ .type=Type::integer } } } },
-  { "print",
-    { .min_args=1,
-      .max_args=3,
-      .arg_types={
-        // This may be a pure map or not.
-        arg_type_spec{ .skip_check=true },
-        arg_type_spec{ .type=Type::integer, .literal=true },
-        arg_type_spec{ .type=Type::integer, .literal=true } } } },
-
-  { "printf",
-    { .min_args=1,
-      .max_args=128,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "pton",
-    { .min_args=1,
-      .max_args=1,
-       } },
-  { "reg",
-    { .min_args=1,
-      .max_args=1,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "sizeof",
-    { .min_args=1,
-      .max_args=1,
-       } },
-  { "skboutput",
-    { .min_args=4,
-      .max_args=4,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true }, // pcap file name
-        arg_type_spec{ .type=Type::pointer },      // *skb
-        arg_type_spec{ .type=Type::integer },      // cap length
-        // cap offset, default is 0
-        // some tracepoints like dev_queue_xmit will output ethernet header,
-        // set offset to 14 bytes can exclude this header
-        arg_type_spec{ .type=Type::integer } } } },
-  { "stats",
-    { .min_args=3,
-      .max_args=3,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const ast::Call&)>([](const ast::Call &call) -> SizedType {
-            return CreateStats(call.vargs.at(2).type().IsSigned());
-          })
-        },
-        map_key_spec{ .map_index=0 },
-        arg_type_spec{ .type=Type::integer } } } },
-  { "str",
-    { .min_args=1,
-      .max_args=2,
-
-      .arg_types={
-        arg_type_spec{ .skip_check=true },
-        arg_type_spec{ .type=Type::integer } } } },
-  { "strftime",
-    { .min_args=2,
-      .max_args=2,
-
-      .arg_types={
-          arg_type_spec{ .type=Type::string, .literal=true },
-          arg_type_spec{ .type=Type::integer } } } },
-  { "strncmp",
-    { .min_args=3,
-      .max_args=3,
-
-      .arg_types={
-          arg_type_spec{ .type=Type::string },
-          arg_type_spec{ .type=Type::string },
-          arg_type_spec{ .type=Type::integer, .literal=true } } } },
-  { "sum",
-    { .min_args=3,
-      .max_args=3,
-      .arg_types={
-        map_type_spec{
-          .type = std::function<SizedType(const ast::Call&)>([](const ast::Call &call) -> SizedType {
-            return CreateSum(call.vargs.at(2).type().IsSigned());
-          })
-        },
-        map_key_spec{ .map_index=0 },
-        arg_type_spec{ .type=Type::integer } } } },
-  { "system",
-    { .min_args=1,
-      .max_args=128,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "time",
-    { .min_args=0,
-      .max_args=1,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "__builtin_uaddr",
-    { .min_args=1,
-      .max_args=1,
-
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "unwatch",
-    { .min_args=1,
-      .max_args=1,
-      .arg_types={
-        arg_type_spec{ .type=Type::integer } } } },
-  { "uptr",
-    { .min_args=1,
-      .max_args=1,
-       } },
-  { "ustack",
-    { .min_args=0,
-      .max_args=2,
-       } },
-  { "usym",
-    { .min_args=1,
-      .max_args=1,
-       } },
-  { "warnf",
-    { .min_args=1,
-      .max_args=128,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true } } } },
-  { "zero",
-    { .min_args=1,
-      .max_args=1,
-      .arg_types={
-        map_type_spec{},
-      } } },
-  { "pid",
-    { .min_args=0,
-      .max_args=1 },
-  },
-  { "socket_cookie",
-    { .min_args=1,
-      .max_args=1,
-      .arg_types={
-        arg_type_spec{ .type=Type::pointer }, // struct sock *
-      } } },
-  { "fail",
-    { .min_args=1,
-      .max_args=128,
-      .arg_types={
-        arg_type_spec{ .type=Type::string, .literal=true },
-      } } },
+static std::unordered_set<std::string> VOID_RETURNING_FUNCS = {
+  "join", "printf", "errorf", "warnf", "system", "cat",     "debugf",
+  "exit", "print",  "clear",  "zero",  "time",   "unwatch", "fail"
 };
-// clang-format on
-
-// These are types which aren't valid for scratch variables
-// e.g. this is not valid `let $x: sum_t;`
-static bool IsValidVarDeclType(const SizedType &ty)
-{
-  switch (ty.GetTy()) {
-    case Type::avg_t:
-    case Type::count_t:
-    case Type::hist_t:
-    case Type::lhist_t:
-    case Type::tseries_t:
-    case Type::max_t:
-    case Type::min_t:
-    case Type::stats_t:
-    case Type::sum_t:
-    case Type::voidtype:
-      return false;
-    case Type::integer:
-    case Type::kstack_t:
-    case Type::ustack_t:
-    case Type::timestamp:
-    case Type::ksym_t:
-    case Type::usym_t:
-    case Type::inet:
-    case Type::username:
-    case Type::string:
-    case Type::buffer:
-    case Type::pointer:
-    case Type::array:
-    case Type::mac_address:
-    case Type::c_struct:
-    case Type::tuple:
-    case Type::record:
-    case Type::cgroup_path_t:
-    case Type::none:
-    case Type::timestamp_mode:
-    case Type::boolean:
-      return true;
-  }
-  return false; // unreachable
-}
 
 // These are special map aggregation types that cannot be assigned
 // to scratch variables or from one map to another e.g. these are both invalid:
@@ -717,8 +287,8 @@ static bool IsValidVarDeclType(const SizedType &ty)
 // However, if the assigned map already contains integers, we implicitly cast
 // the aggregation into an integer to retrieve its value, so this is valid:
 // `@a = count(); @b = 0; @b = @a`
-bool SemanticAnalyser::is_valid_assignment(const Expression &expr,
-                                           bool map_without_type)
+bool TypeResolver::is_valid_assignment(const Expression &expr,
+                                       bool map_without_type)
 {
   // Prevent assigning aggregations to another map.
   if (expr.type().IsMultiKeyMapTy()) {
@@ -727,31 +297,21 @@ bool SemanticAnalyser::is_valid_assignment(const Expression &expr,
     return false;
   } else if (expr.type().IsCastableMapTy() && map_without_type) {
     return false;
-  } else if (is_final_pass() && expr.type().IsNoneTy()) {
+  } else if (is_final_pass() &&
+             (expr.type().IsNoneTy() || expr.type().IsVoidTy())) {
     return false;
   }
   return true;
 }
 
-void SemanticAnalyser::visit(String &string)
+void TypeResolver::visit(String &string)
 {
-  // Skip check for printf()'s format string (1st argument) and create the
-  // string with the original size. This is because format string is not part of
-  // bpf byte code.
-  if ((func_ == "printf" || func_ == "errorf" || func_ == "warnf") &&
-      func_arg_idx_ == 0)
-    return;
-
-  const auto str_len = bpftrace_.config_->max_strlen;
-  if (!is_compile_time_func(func_) && string.value.size() > str_len - 1) {
-    string.addError() << "String is too long (over " << str_len
-                      << " bytes): " << string.value;
-  }
-  // @a = buf("hi", 2). String allocated on bpf stack. See codegen
+  // Some strings are not part of bpf bytecode, like printf args
+  // so this address space will be ignored
   string.string_type.SetAS(AddrSpace::kernel);
 }
 
-void SemanticAnalyser::visit(Identifier &identifier)
+void TypeResolver::visit(Identifier &identifier)
 {
   if (c_definitions_.enums.contains(identifier.ident)) {
     const auto &enum_name = std::get<1>(c_definitions_.enums[identifier.ident]);
@@ -772,18 +332,6 @@ void SemanticAnalyser::visit(Identifier &identifier)
     } else {
       identifier.addError() << "Invalid timestamp mode: " << identifier.ident;
     }
-  } else if (func_ == "pid" || func_ == "tid") {
-    if (identifier.ident != "curr_ns" && identifier.ident != "init") {
-      identifier.addError()
-          << "Invalid PID namespace mode: " << identifier.ident
-          << " (expects: curr_ns or init)";
-    }
-  } else if (func_ == "signal") {
-    if (identifier.ident != "current_pid" &&
-        identifier.ident != "current_tid") {
-      identifier.addError() << "Invalid signal target: " << identifier.ident
-                            << " (expects: current_pid or current_tid)";
-    }
   } else {
     ConfigParser<StackMode> parser;
     StackMode mode;
@@ -792,13 +340,11 @@ void SemanticAnalyser::visit(Identifier &identifier)
       identifier.ident_type = CreateStack(true, StackType{ .mode = mode });
     } else if (is_type_name_) {
       identifier.ident_type = bpftrace_.btf_->get_stype(identifier.ident);
-    } else {
-      identifier.addError() << "Unknown identifier: '" + identifier.ident + "'";
     }
   }
 }
 
-AddrSpace SemanticAnalyser::find_addrspace(ProbeType pt)
+AddrSpace TypeResolver::find_addrspace(ProbeType pt)
 {
   switch (pt) {
     case ProbeType::kprobe:
@@ -831,7 +377,7 @@ AddrSpace SemanticAnalyser::find_addrspace(ProbeType pt)
   return {}; // unreached
 }
 
-void SemanticAnalyser::visit(Builtin &builtin)
+void TypeResolver::visit(Builtin &builtin)
 {
   if (builtin.ident == "ctx") {
     auto *probe = get_probe(builtin, builtin.ident);
@@ -840,6 +386,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
     ProbeType pt = probetype(probe->attach_points[0]->provider);
     bpf_prog_type bt = progtype(pt);
     std::string func = probe->attach_points[0]->func;
+    builtin.builtin_type = CreatePointer(CreateNone());
     switch (bt) {
       case BPF_PROG_TYPE_KPROBE: {
         auto record = bpftrace_.structs.Lookup("struct pt_regs");
@@ -847,8 +394,6 @@ void SemanticAnalyser::visit(Builtin &builtin)
           builtin.builtin_type = CreatePointer(
               CreateCStruct("struct pt_regs", record), AddrSpace::kernel);
           builtin.builtin_type.MarkCtxAccess();
-        } else {
-          builtin.builtin_type = CreatePointer(CreateNone());
         }
         break;
       }
@@ -894,16 +439,15 @@ void SemanticAnalyser::visit(Builtin &builtin)
     if (probe == nullptr)
       return;
     ProbeType type = probe->get_probetype();
-
-    if (type == ProbeType::kretprobe || type == ProbeType::uretprobe) {
-      builtin.builtin_type = CreateUInt64();
-    } else if (type == ProbeType::fentry || type == ProbeType::fexit) {
+    if (type == ProbeType::fentry || type == ProbeType::fexit) {
       const auto *arg = bpftrace_.structs.GetProbeArg(*probe,
                                                       RETVAL_FIELD_NAME);
       if (arg) {
         builtin.builtin_type = arg->type;
       } else
         builtin.addError() << "Can't find a field " << RETVAL_FIELD_NAME;
+    } else {
+      builtin.builtin_type = CreateUInt64();
     }
     // For kretprobe, fentry, fexit -> AddrSpace::kernel
     // For uretprobe -> AddrSpace::user
@@ -931,23 +475,19 @@ void SemanticAnalyser::visit(Builtin &builtin)
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
       return;
-
-    ProbeType type = probetype(probe->attach_points[0]->provider);
-    if (type == ProbeType::kprobe || type == ProbeType::kretprobe)
-      builtin.builtin_type = CreateKSym();
-    else if (type == ProbeType::uprobe || type == ProbeType::uretprobe)
+    ProbeType type = probe->get_probetype();
+    if (type == ProbeType::uprobe || type == ProbeType::uretprobe) {
       builtin.builtin_type = CreateUSym();
-    else if (type == ProbeType::fentry || type == ProbeType::fexit) {
+    } else {
       builtin.builtin_type = CreateKSym();
     }
   } else if (builtin.is_argx()) {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
       return;
-    ProbeType pt = probetype(probe->attach_points[0]->provider);
-    AddrSpace addrspace = find_addrspace(pt);
     builtin.builtin_type = CreateUInt64();
-    builtin.builtin_type.SetAS(addrspace);
+    builtin.builtin_type.SetAS(
+        find_addrspace(probetype(probe->attach_points[0]->provider)));
   } else if (builtin.ident == "__builtin_username") {
     builtin.builtin_type = CreateUsername();
   } else if (builtin.ident == "__builtin_usermode") {
@@ -990,21 +530,14 @@ void SemanticAnalyser::visit(Builtin &builtin)
       builtin.builtin_type.MarkCtxAccess();
     }
   } else {
-    builtin.addError() << "Unknown builtin variable: '" << builtin.ident << "'";
+    LOG(BUG) << "Unknown builtin variable: '" << builtin.ident << "'";
   }
 }
 
-void SemanticAnalyser::visit(Call &call)
+void TypeResolver::visit(Call &call)
 {
-  // Check for unsafe-ness first. It is likely the most pertinent issue
-  // (and should be at the top) for any function call.
-  if (bpftrace_.safe_mode_ && is_unsafe_func(call.func)) {
-    call.addError() << call.func
-                    << "() is an unsafe function being used in safe mode";
-  }
-
   struct func_setter {
-    func_setter(SemanticAnalyser &analyser, const std::string &s)
+    func_setter(TypeResolver &analyser, const std::string &s)
         : analyser_(analyser), old_func_(analyser_.func_)
     {
       analyser_.func_ = s;
@@ -1013,170 +546,81 @@ void SemanticAnalyser::visit(Call &call)
     ~func_setter()
     {
       analyser_.func_ = old_func_;
-      analyser_.func_arg_idx_ = -1;
     }
 
   private:
-    SemanticAnalyser &analyser_;
+    TypeResolver &analyser_;
     std::string old_func_;
   };
 
   func_setter scope_bound_func_setter{ *this, call.func };
 
-  for (size_t i = 0; i < call.vargs.size(); ++i) {
-    func_arg_idx_ = i;
-    visit(call.vargs.at(i));
+  for (auto &varg : call.vargs) {
+    visit(varg);
   }
 
-  if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
-    for (auto *ap : probe->attach_points) {
-      if (!ap->check_available(call.func)) {
-        call.addError() << call.func << " can not be used with \""
-                        << ap->provider << "\" probes";
+  if (getAssignRewriteFuncs().contains(call.func)) {
+    if (auto *map = call.vargs.at(0).as<Map>()) {
+      if (call.func == "sum" || call.func == "min" || call.func == "max" ||
+          call.func == "avg" || call.func == "stats") {
+        if (call.vargs.size() != 3) {
+          // This is an error in a later pass.
+          return;
+        }
       }
-    }
-  }
-
-  if (!check_call(call)) {
-    return;
-  }
-
-  if (call.func == "hist") {
-    if (call.vargs.size() == 3) {
-      call.vargs.emplace_back(ctx_.make_node<Integer>(call.loc, 0)); // default
-                                                                     // bits is
-                                                                     // 0
+      if (call.func == "avg") {
+        check_map_value(*map,
+                        call,
+                        CreateAvg(call.vargs.at(2).type().IsSigned()));
+      } else if (call.func == "count") {
+        check_map_value(*map, call, CreateCount());
+      } else if (call.func == "hist") {
+        check_map_value(*map, call, CreateHist());
+      } else if (call.func == "lhist") {
+        check_map_value(*map, call, CreateLhist());
+      } else if (call.func == "tseries") {
+        check_map_value(*map, call, CreateTSeries());
+      } else if (call.func == "max") {
+        check_map_value(*map,
+                        call,
+                        CreateMax(call.vargs.at(2).type().IsSigned()));
+      } else if (call.func == "min") {
+        check_map_value(*map,
+                        call,
+                        CreateMin(call.vargs.at(2).type().IsSigned()));
+      } else if (call.func == "stats") {
+        check_map_value(*map,
+                        call,
+                        CreateStats(call.vargs.at(2).type().IsSigned()));
+      } else if (call.func == "sum") {
+        check_map_value(*map,
+                        call,
+                        CreateSum(call.vargs.at(2).type().IsSigned()));
+      }
+      // This reconciles the argument if the other one is a map, but otherwise
+      // we don't specifically emit an error. `map_type_spec` above does that.
+      reconcile_map_key(map, call.vargs.at(1));
     } else {
-      const auto *bits = call.vargs.at(3).as<Integer>();
-      if (!bits) {
-        // Bug here as the validity of the integer literal is already checked by
-        // check_arg above.
-        LOG(BUG) << call.func << ": invalid bits value, need integer literal";
-      } else if (bits->value > 5) {
-        call.addError() << call.func << ": bits " << bits->value
-                        << " must be 0..5";
-      }
+      call.vargs.at(0).node().addError()
+          << call.func << "() expects a map argument";
     }
+  }
 
-    call.return_type = CreateHist();
-  } else if (call.func == "lhist") {
-    if (is_final_pass()) {
-      Expression &min_arg = call.vargs.at(3);
-      Expression &max_arg = call.vargs.at(4);
-      Expression &step_arg = call.vargs.at(5);
-      auto *min = min_arg.as<Integer>();
-      auto *max = max_arg.as<Integer>();
-      auto *step = step_arg.as<Integer>();
-
-      if (!min) {
-        call.addError() << call.func
-                        << ": invalid min value (must be non-negative literal)";
-        return;
+  if (getRawMapArgFuncs().contains(call.func) && !call.vargs.empty()) {
+    if (auto *map = call.vargs.at(0).as<Map>()) {
+      if (!get_map_type(*map) && !is_first_pass()) {
+        map->addError() << "Undefined map: " + map->ident;
       }
-      if (!max) {
-        call.addError() << call.func
-                        << ": invalid max value (must be non-negative literal)";
-        return;
-      }
-      if (!step) {
-        call.addError() << call.func << ": invalid step value";
-        return;
-      }
-
-      if (step->value <= 0) {
-        call.addError() << "lhist() step must be >= 1 (" << step->value
-                        << " provided)";
-      } else {
-        int buckets = (max->value - min->value) / step->value;
-        if (buckets > 1000) {
-          call.addError()
-              << "lhist() too many buckets, must be <= 1000 (would need "
-              << buckets << ")";
-        }
-      }
-      if (min->value > max->value) {
-        call.addError() << "lhist() min must be less than max (provided min "
-                        << min->value << " and max " << max->value << ")";
-      }
-      if ((max->value - min->value) < step->value) {
-        call.addError()
-            << "lhist() step is too large for the given range (provided step "
-            << step->value << " for range " << (max->value - min->value) << ")";
-      }
+    } else if (call.func != "print") {
+      call.vargs.at(0).node().addError()
+          << call.func << "() expects a map argument";
     }
-  } else if (call.func == "tseries") {
-    const static std::set<std::string> ALLOWED_AGG_FUNCS = {
-      "avg",
-      "sum",
-      "max",
-      "min",
-    };
-    if (is_final_pass()) {
-      Expression &interval_ns_arg = call.vargs.at(3);
-      Expression &num_intervals_arg = call.vargs.at(4);
+  }
 
-      auto *interval_ns = interval_ns_arg.as<Integer>();
-      auto *num_intervals = num_intervals_arg.as<Integer>();
-
-      if (!interval_ns) {
-        call.addError()
-            << call.func
-            << ": invalid interval_ns value (must be non-negative literal)";
-        return;
-      }
-      if (!num_intervals) {
-        call.addError()
-            << call.func
-            << ": invalid num_intervals value (must be non-negative literal)";
-        return;
-      }
-
-      if (interval_ns->value <= 0) {
-        call.addError() << "tseries() interval_ns must be >= 1 ("
-                        << interval_ns->value << " provided)";
-        return;
-      }
-
-      if (num_intervals->value <= 0) {
-        call.addError() << "tseries() num_intervals must be >= 1 ("
-                        << num_intervals->value << " provided)";
-        return;
-      } else if (num_intervals->value > 1000000) {
-        call.addError() << "tseries() num_intervals must be < 1000000 ("
-                        << num_intervals->value << " provided)";
-      }
-
-      if (call.vargs.size() == 6) {
-        auto &aggregator = *call.vargs.at(5).as<String>();
-        if (!ALLOWED_AGG_FUNCS.contains(aggregator.value)) {
-          auto &err = call.addError();
-          err << "tseries() expects one of the following aggregation "
-                 "functions: ";
-          size_t i = 0;
-          for (const std::string &agg : ALLOWED_AGG_FUNCS) {
-            err << agg;
-            if (i++ != ALLOWED_AGG_FUNCS.size() - 1) {
-              err << ", ";
-            }
-          }
-          err << " (\"" << aggregator.value << "\" provided)";
-        }
-      }
-    }
-
-    call.return_type = CreateVoid();
-  } else if (call.func == "count" || call.func == "sum" || call.func == "min" ||
-             call.func == "max" || call.func == "avg" || call.func == "stats") {
+  if (getAssignRewriteFuncs().contains(call.func) ||
+      VOID_RETURNING_FUNCS.contains(call.func)) {
     call.return_type = CreateVoid();
   } else if (call.func == "str") {
-    auto &arg = call.vargs.at(0);
-    const auto &t = arg.type();
-    if (!t.IsStringTy() && !t.IsIntegerTy() && !t.IsPtrTy()) {
-      call.addError()
-          << call.func
-          << "() expects a string, integer or a pointer type as first "
-          << "argument (" << t << " provided)";
-    }
     auto strlen = bpftrace_.config_->max_strlen;
     if (call.vargs.size() == 2) {
       if (auto *integer = call.vargs.at(1).as<Integer>()) {
@@ -1203,40 +647,19 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type.SetAS(AddrSpace::kernel);
   } else if (call.func == "buf") {
     const uint64_t max_strlen = bpftrace_.config_->max_strlen;
-    if (max_strlen >
-        std::numeric_limits<decltype(AsyncEvent::Buf::length)>::max()) {
-      call.addError() << "BPFTRACE_MAX_STRLEN too large to use on buffer ("
-                      << max_strlen << " > "
-                      << std::numeric_limits<uint32_t>::max() << ")";
-    }
-
-    auto &arg = call.vargs.at(0);
-    if (is_final_pass() && !(arg.type().IsIntTy() || arg.type().IsStringTy() ||
-                             arg.type().IsPtrTy() || arg.type().IsArrayTy())) {
-      call.addError()
-          << call.func
-          << "() expects an integer, string, or array argument but saw "
-          << typestr(arg.type().GetTy());
-    }
-
     // Subtract out metadata headroom
     uint32_t max_buffer_size = max_strlen - sizeof(AsyncEvent::Buf);
     uint32_t buffer_size = max_buffer_size;
 
     if (call.vargs.size() == 1) {
-      if (arg.type().IsArrayTy())
+      auto &arg = call.vargs.at(0);
+      if (arg.type().IsArrayTy()) {
         buffer_size = arg.type().GetNumElements() *
                       arg.type().GetElementTy().GetSize();
-      else if (is_final_pass())
-        call.addError() << call.func
-                        << "() expects a length argument for non-array type "
-                        << typestr(arg.type().GetTy());
-    } else {
+      }
+    } else if (call.vargs.size() == 2) {
       if (auto *integer = call.vargs.at(1).as<Integer>()) {
         buffer_size = integer->value;
-      } else if (auto *integer = call.vargs.at(1).as<NegativeInteger>()) {
-        call.addError() << call.func << "cannot use negative length ("
-                        << integer->value << ")";
       }
     }
 
@@ -1256,13 +679,12 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type.SetAS(AddrSpace::kernel);
   } else if (call.func == "ksym" || call.func == "usym") {
     // allow symbol lookups on casts (eg, function pointers)
-    auto &arg = call.vargs.at(0);
-    const auto &type = arg.type();
-    if (!type.IsIntegerTy() && !type.IsPtrTy()) {
-      call.addError() << call.func
-                      << "() expects an integer or pointer argument";
-    } else if (type.IsIntegerTy() && type.GetSize() != 8) {
-      create_int_cast(call.vargs.at(0), CreateInt64());
+    if (!call.vargs.empty()) {
+      auto &arg = call.vargs.at(0);
+      const auto &type = arg.type();
+      if (type.IsIntegerTy() && type.GetSize() != 8) {
+        create_int_cast(call.vargs.at(0), CreateInt64());
+      }
     }
 
     if (call.func == "ksym")
@@ -1270,60 +692,33 @@ void SemanticAnalyser::visit(Call &call)
     else if (call.func == "usym")
       call.return_type = CreateUSym();
   } else if (call.func == "ntop") {
-    int index = 0;
-    if (call.vargs.size() == 2) {
-      check_arg(call, Type::integer, 0);
-      index = 1;
-    }
-
-    auto &arg = call.vargs.at(index);
-    if (!arg.type().IsIntTy() && !arg.type().IsStringTy() &&
-        !arg.type().IsArrayTy())
-      call.addError() << call.func
-                      << "() expects an integer or array argument, got "
-                      << arg.type().GetTy();
-
-    // Kind of:
-    //
-    // struct {
-    //   int af_type;
-    //   union {
-    //     char[4] inet4;
-    //     char[16] inet6;
-    //   }
-    // }
     int buffer_size = 24;
-    auto type = arg.type();
-
-    if ((arg.type().IsArrayTy() || arg.type().IsStringTy()) &&
-        type.GetSize() != 4 && type.GetSize() != 16)
-      call.addError() << call.func
-                      << "() argument must be 4 or 16 bytes in size";
-
     call.return_type = CreateInet(buffer_size);
   } else if (call.func == "pton") {
     int af_type = 0, addr_size = 0;
     std::string addr;
-    if (auto *str = call.vargs.at(0).as<String>()) {
-      addr = str->value;
-      // use '.' and ':' to determine the address family
-      if (addr.find(".") != std::string::npos) {
-        af_type = AF_INET;
-        addr_size = 4;
-      } else if (addr.find(":") != std::string::npos) {
-        af_type = AF_INET6;
-        addr_size = 16;
+    if (call.vargs.size() == 1) {
+      if (auto *str = call.vargs.at(0).as<String>()) {
+        addr = str->value;
+        // use '.' and ':' to determine the address family
+        if (addr.find(".") != std::string::npos) {
+          af_type = AF_INET;
+          addr_size = 4;
+        } else if (addr.find(":") != std::string::npos) {
+          af_type = AF_INET6;
+          addr_size = 16;
+        } else {
+          call.addError()
+              << call.func
+              << "() expects an string argument of an IPv4/IPv6 address, got "
+              << addr;
+          return;
+        }
       } else {
-        call.addError()
-            << call.func
-            << "() expects an string argument of an IPv4/IPv6 address, got "
-            << addr;
+        call.addError() << call.func << "() expects an string literal, got "
+                        << call.vargs.at(0).type();
         return;
       }
-    } else {
-      call.addError() << call.func << "() expects an string literal, got "
-                      << call.vargs.at(0).type();
-      return;
     }
 
     std::vector<char> dst(addr_size);
@@ -1337,25 +732,7 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type = CreateArray(addr_size, CreateUInt8());
     call.return_type.SetAS(AddrSpace::kernel);
     call.return_type.is_internal = true;
-  } else if (call.func == "join") {
-    call.return_type = CreateNone();
-
-    if (!is_final_pass())
-      return;
-
-    auto &arg = call.vargs.at(0);
-    if (!(arg.type().IsIntTy() || arg.type().IsPtrTy())) {
-      call.addError() << "() only supports int or pointer arguments" << " ("
-                      << arg.type().GetTy() << " provided)";
-    }
   } else if (call.func == "reg") {
-    auto reg_name = call.vargs.at(0).as<String>()->value;
-    auto offset = arch::Host::register_to_pt_regs_offset(reg_name);
-    if (!offset) {
-      call.addError() << "'" << reg_name
-                      << "' is not a valid register on this architecture"
-                      << " (" << arch::Host::Machine << ")";
-    }
     call.return_type = CreateUInt64();
     if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
       ProbeType pt = probe->get_probetype();
@@ -1369,11 +746,6 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type = CreateUInt64();
     call.return_type.SetAS(AddrSpace::kernel);
   } else if (call.func == "percpu_kaddr") {
-    const auto &symbol = call.vargs.at(0).as<String>()->value;
-    if (bpftrace_.btf_->get_var_type(symbol).IsNoneTy()) {
-      call.addError() << "Could not resolve variable \"" << symbol
-                      << "\" from BTF";
-    }
     if (call.vargs.size() == 2 && call.vargs.at(1).type() != CreateUInt32()) {
       create_int_cast(call.vargs.at(1), CreateUInt32());
     }
@@ -1384,36 +756,27 @@ void SemanticAnalyser::visit(Call &call)
     if (probe == nullptr)
       return;
 
-    if (!check_symbol(call, 0))
-      return;
+    struct symbol sym = {};
 
-    std::vector<int> sizes;
-    auto name = call.vargs.at(0).as<String>()->value;
-    for (auto *ap : probe->attach_points) {
-      struct symbol sym = {};
-      int err = bpftrace_.resolve_uname(name, &sym, ap->target);
-      if (err < 0 || sym.address == 0) {
-        call.addError() << "Could not resolve symbol: " << ap->target << ":"
-                        << name;
-      }
-      sizes.push_back(sym.size);
-    }
+    if (!call.vargs.empty() && call.vargs.at(0).is<String>()) {
+      if (check_symbol(call)) {
+        auto name = call.vargs.at(0).as<String>()->value;
+        const auto &target = probe->attach_points[0]->target;
 
-    for (size_t i = 1; i < sizes.size(); i++) {
-      if (sizes.at(0) != sizes.at(i)) {
-        call.addError() << "Symbol size mismatch between probes. Symbol \""
-                        << name << "\" has size " << sizes.at(0)
-                        << " for probe \"" << probe->attach_points.at(0)->name()
-                        << "\" but size " << sizes.at(i) << " for probe \""
-                        << probe->attach_points.at(i)->name() << "\"";
+        int err = bpftrace_.resolve_uname(name, &sym, target);
+        if (err < 0 || sym.address == 0) {
+          call.addError() << "Could not resolve symbol: " << target << ":"
+                          << name;
+        }
       }
     }
+
     size_t pointee_size = 0;
-    switch (sizes.at(0)) {
+    switch (sym.size) {
       case 1:
       case 2:
       case 4:
-        pointee_size = sizes.at(0) * 8;
+        pointee_size = sym.size * 8;
         break;
       default:
         pointee_size = 64;
@@ -1421,224 +784,44 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
   } else if (call.func == "cgroupid") {
     call.return_type = CreateUInt64();
-  } else if (call.func == "printf" || call.func == "errorf" ||
-             call.func == "warnf" || call.func == "system" ||
-             call.func == "cat" || call.func == "debugf") {
-    if (is_final_pass()) {
-      const auto &fmt = call.vargs.at(0).as<String>()->value;
-      std::vector<SizedType> args;
-      for (size_t i = 1; i < call.vargs.size(); i++) {
-        const auto &arg_type = call.vargs[i].type();
-        args.push_back(arg_type);
-      }
-      FormatString fs(fmt);
-      auto ok = fs.check(args);
-      if (!ok) {
-        call.addError() << ok.takeError();
-      }
-      // The `debugf` call is a builtin, and is subject to more much rigorous
-      // checks. We've already validate the basic counts, etc. but we need to
-      // apply these additional constraints which includes a limited surface.
-      if (call.func == "debugf") {
-        call.addWarning()
-            << "The debugf() builtin is not recommended for production use. "
-               "For more information see bpf_trace_printk in bpf-helpers(7).";
-        // bpf_trace_printk cannot use more than three arguments, see
-        // bpf-helpers(7).
-        constexpr int PRINTK_MAX_ARGS = 3;
-        if (args.size() > PRINTK_MAX_ARGS) {
-          call.addError() << "cannot use more than " << PRINTK_MAX_ARGS
-                          << " conversion specifiers";
-        }
-        for (size_t i = 0; i < args.size(); i++) {
-          // bpf_trace_printk_format_types is a subset of printf_format_types
-          // that contains valid types for bpf_trace_printk() see iovisor/bcc
-          // BTypeVisitor::checkFormatSpecifiers.
-          static const std::unordered_map<std::string, Type>
-              bpf_trace_printk_format_types = { { "d", Type::integer },
-                                                { "u", Type::integer },
-                                                { "x", Type::integer },
-                                                { "p", Type::integer },
-                                                { "s", Type::string } };
-          auto it = bpf_trace_printk_format_types.find(fs.specs[i].specifier);
-          if (it == bpf_trace_printk_format_types.end()) {
-            call.vargs.at(0).node().addError()
-                << "Invalid format specifier for `debugf`: "
-                << fs.specs[i].specifier;
-            continue;
-          }
-          if (args[i].GetTy() != it->second) {
-            call.vargs.at(i + 1).node().addError()
-                << "Type does not match format specifier: "
-                << fs.specs[i].specifier;
-            continue;
-          }
-        }
-      }
-    }
-  } else if (call.func == "exit") {
-    // Leave as `none`.
-  } else if (call.func == "print") {
-    if (auto *map = call.vargs.at(0).as<Map>()) {
-      if (is_final_pass()) {
-        // N.B. that print is parameteric in the type, so this is not checked
-        // by `check_arg` as there is no spec for the first argument.
-        if (map->type().IsNoneTy()) {
-          map->addError() << "Undefined map: " + map->ident;
-        } else {
-          if (in_loop()) {
-            call.addWarning() << "Due to it's asynchronous nature using "
-                                 "'print()' in a loop can "
-                                 "lead to unexpected behavior. The map will "
-                                 "likely be updated "
-                                 "before the runtime can 'print' it.";
-          }
-          if (map->value_type.IsStatsTy() && call.vargs.size() > 1) {
-            call.addWarning()
-                << "print()'s top and div arguments are ignored when used on "
-                   "stats() maps.";
-          }
-        }
-      }
-    }
-    // Note that IsPrintableTy() is somewhat disingenuous here. Printing a
-    // non-map value requires being able to serialize the entire value, so
-    // map-backed types like count(), min(), max(), etc. cannot be printed
-    // through the non-map printing mechanism.
-    //
-    // We rely on the fact that semantic analysis enforces types like count(),
-    // min(), max(), etc. to be assigned directly to a map.
-    else if (call.vargs.at(0).type().IsMultiKeyMapTy()) {
-      call.addError()
-          << "Map type " << call.vargs.at(0).type()
-          << " cannot print the value of individual keys. You must print "
-             "the whole map.";
-    } else if (call.vargs.at(0).type().IsPrintableTy()) {
-      if (call.vargs.size() != 1)
-        call.addError() << "Non-map print() only takes 1 argument, "
-                        << call.vargs.size() << " found";
-    } else {
-      if (is_final_pass())
-        call.addError() << call.vargs.at(0).type() << " type passed to "
-                        << call.func << "() is not printable";
-    }
   } else if (call.func == "cgroup_path") {
     call.return_type = CreateCgroupPath();
-  } else if (call.func == "clear") {
-    // Leave as `none`.
-  } else if (call.func == "zero") {
-    // Leave as `none`.
   } else if (call.func == "stack_len") {
-    if (!call.vargs.at(0).type().IsStack()) {
-      call.addError() << "len() expects a map or stack to be provided";
-    }
     call.return_type = CreateInt64();
-  } else if (call.func == "time") {
-    // Leave as `none`.
   } else if (call.func == "strftime") {
     call.return_type = CreateTimestamp();
-    if (is_final_pass()) {
-      auto &arg = call.vargs.at(1);
-      call.return_type.ts_mode = arg.type().ts_mode;
-      if (call.return_type.ts_mode == TimestampMode::monotonic) {
-        call.addError() << "strftime() can not take a monotonic timestamp";
-      }
-    }
   } else if (call.func == "kstack") {
     check_stack_call(call, true);
   } else if (call.func == "ustack") {
     check_stack_call(call, false);
   } else if (call.func == "path") {
-    auto *probe = get_probe(call, call.func);
-    if (probe == nullptr)
-      return;
-
-    if (!bpftrace_.feature_->has_d_path()) {
-      call.addError()
-          << "BPF_FUNC_d_path not available for your kernel version";
-    }
-
-    // Argument for path can be both record and pointer.
-    // It's pointer when it's passed directly from the probe
-    // argument, like: path(args.path))
-    // It's record when it's referenced as object pointer
-    // member, like: path(args.filp->f_path))
-    auto &arg = call.vargs.at(0);
-    if (arg.type().GetTy() != Type::c_struct &&
-        arg.type().GetTy() != Type::pointer) {
-      call.addError() << "path() only supports pointer or record argument ("
-                      << arg.type().GetTy() << " provided)";
-    }
-
     auto call_type_size = bpftrace_.config_->max_strlen;
     if (call.vargs.size() == 2) {
       if (auto *size = call.vargs.at(1).as<Integer>()) {
         call_type_size = size->value;
-      } else {
-        call.addError() << call.func
-                        << ": invalid size value, need non-negative literal";
       }
     }
-
     call.return_type = SizedType(Type::string, call_type_size);
-
-    for (auto *attach_point : probe->attach_points) {
-      ProbeType type = probetype(attach_point->provider);
-      if (type != ProbeType::fentry && type != ProbeType::fexit &&
-          type != ProbeType::iter)
-        call.addError() << "The path function can only be used with "
-                        << "'fentry', 'fexit', 'iter' probes";
-    }
   } else if (call.func == "strncmp") {
-    if (!call.vargs.at(2).is<Integer>()) {
-      call.addError() << "Builtin strncmp requires a non-negative literal";
-    }
     call.return_type = CreateUInt64();
   } else if (call.func == "kptr" || call.func == "uptr") {
-    // kptr should accept both integer or pointer. Consider case: kptr($1)
-    auto &arg = call.vargs.at(0);
-    if (!arg.type().IsIntTy() && !arg.type().IsPtrTy()) {
-      call.addError() << call.func << "() only supports "
-                      << "integer or pointer arguments (" << arg.type().GetTy()
-                      << " provided)";
-      return;
-    }
-
     auto as = (call.func == "kptr" ? AddrSpace::kernel : AddrSpace::user);
     call.return_type = call.vargs.front().type();
     call.return_type.SetAS(as);
   } else if (call.func == "macaddr") {
-    auto &arg = call.vargs.at(0);
-    if (!arg.type().IsIntTy() && !arg.type().IsArrayTy() &&
-        !arg.type().IsByteArray() && !arg.type().IsPtrTy())
-      call.addError() << call.func
-                      << "() only supports array or pointer arguments" << " ("
-                      << arg.type().GetTy() << " provided)";
-
-    if (arg.is<String>())
-      call.addError() << call.func
-                      << "() does not support literal string arguments";
-
-    // N.B. When converting from BTF, we can treat string types as 7 bytes in
-    // order to signal to userspace that they are well-formed. However, we can
-    // convert from anything as long as there are at least 6 bytes to read.
-    const auto &type = arg.type();
-    if ((type.IsArrayTy() || type.IsByteArray()) && type.GetSize() < 6) {
-      call.addError() << call.func
-                      << "() argument must be at least 6 bytes in size";
-    }
-
     call.return_type = CreateMacAddress();
-  } else if (call.func == "unwatch") {
-    // Leave as `none`.
   } else if (call.func == "bswap") {
-    auto &arg = call.vargs.at(0);
-    if (!arg.type().IsIntTy()) {
-      call.addError() << call.func << "() only supports integer arguments ("
-                      << arg.type().GetTy() << " provided)";
-      return;
+    auto int_bit_width = 1;
+    if (!call.vargs.empty()) {
+      auto &arg = call.vargs.at(0);
+      if (!arg.type().IsIntTy()) {
+        call.addError() << call.func << "() only supports integer arguments ("
+                        << arg.type().GetTy() << " provided)";
+        return;
+      }
+      int_bit_width = arg.type().GetIntBitWidth();
     }
-    call.return_type = CreateUInt(arg.type().GetIntBitWidth());
+    call.return_type = CreateUInt(int_bit_width);
   } else if (call.func == "skboutput") {
     call.return_type = CreateUInt32();
   } else if (call.func == "nsecs") {
@@ -1647,81 +830,11 @@ void SemanticAnalyser::visit(Call &call)
     if (call.vargs.size() == 1) {
       call.return_type.ts_mode = call.vargs.at(0).type().ts_mode;
     }
-
-    if (call.return_type.ts_mode == TimestampMode::tai &&
-        !bpftrace_.feature_->has_helper_ktime_get_tai_ns()) {
-      call.addError()
-          << "Kernel does not support tai timestamp, please try sw_tai";
-    }
-    if (call.return_type.ts_mode == TimestampMode::sw_tai &&
-        !bpftrace_.delta_taitime_.has_value()) {
-      call.addError() << "Failed to initialize sw_tai in "
-                         "userspace. This is very unexpected.";
-    }
   } else if (call.func == "pid" || call.func == "tid") {
     call.return_type = CreateUInt32();
-    if (call.vargs.size() == 1) {
-      auto &arg = call.vargs.at(0);
-      if (!(arg.as<Identifier>())) {
-        call.addError() << call.func
-                        << "() only supports curr_ns and init as the argument ("
-                        << arg.type().GetTy() << " provided)";
-      }
-    }
   } else if (call.func == "socket_cookie") {
-    auto logError = [&]<typename T>(T name) {
-      call.addError() << call.func
-                      << "() only supports 'struct sock *' as the argument ("
-                      << name << " provided)";
-    };
-
-    const auto &type = call.vargs.at(0).type();
-    if (!type.IsPtrTy() || !type.GetPointeeTy().IsCStructTy()) {
-      logError(type.GetTy());
-      return;
-    }
-    if (!type.GetPointeeTy().IsCompatible(CreateCStruct("struct sock"))) {
-      logError("'" + type.GetPointeeTy().GetName() + " *'");
-      return;
-    }
     call.return_type = CreateUInt64();
-  } else if (call.func == "fail") {
-    // This is basically a static_assert failure. It will halt the compilation.
-    // We expect to hit this path only when using the `typeof` folds.
-    bool fail_valid = true;
-    std::vector<output::Primitive> args;
-    for (size_t i = 0; i < call.vargs.size(); ++i) {
-      if (!call.vargs[i].is_literal()) {
-        fail_valid = false;
-        call.addError() << "fail() arguments need to be literals";
-      } else {
-        if (i != 0) {
-          if (auto *val = call.vargs[i].as<String>()) {
-            args.emplace_back(val->value);
-          } else if (auto *val = call.vargs[i].as<Integer>()) {
-            args.emplace_back(val->value);
-          } else if (auto *val = call.vargs[i].as<NegativeInteger>()) {
-            args.emplace_back(val->value);
-          } else if (auto *val = call.vargs[i].as<Boolean>()) {
-            args.emplace_back(val->value);
-          }
-        } else {
-          if (!call.vargs[0].is<String>()) {
-            call.addError()
-                << "first argument to fail() must be a string literal";
-          }
-        }
-      }
-    }
-
-    if (fail_valid) {
-      FormatString fs(call.vargs[0].as<String>()->value);
-      call.addError() << fs.format(args);
-    }
   } else {
-    // Check here if this corresponds to an external function. We convert the
-    // external type metadata into the internal `SizedType` representation and
-    // check that they are exactly equal.
     auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
     if (!maybe_func) {
       call.addError() << "Unknown function: '" << call.func << "'";
@@ -1755,83 +868,13 @@ void SemanticAnalyser::visit(Call &call)
       return;
     }
     call.return_type = *compat_return_type;
-    // Convert all arguments.
-    auto argument_types = proto->argument_types();
-    if (!argument_types) {
-      call.addError() << "Unable to read argument types: "
-                      << argument_types.takeError();
-      return;
-    }
-    // Check the argument count.
-    if (argument_types->size() != call.vargs.size()) {
-      call.addError() << "Function `" << call.func << "` requires "
-                      << argument_types->size() << " arguments, got only "
-                      << call.vargs.size();
-      return;
-    }
-    std::vector<std::pair<std::string, SizedType>> args;
-    for (size_t i = 0; i < argument_types->size(); i++) {
-      const auto &[name, type] = argument_types->at(i);
-      auto compat_arg_type = getCompatType(type);
-      if (!compat_arg_type) {
-        // If the required type is a **pointer**, and the provided type is
-        // a **pointer**, then we let it slide. Just assume the user knows
-        // what they are doing. The verifier will catch them out otherwise.
-        if (type.is<btf::Pointer>() && call.vargs[i].type().IsPtrTy()) {
-          args.emplace_back(name, call.vargs[i].type());
-          continue;
-        }
-        call.addError() << "Unable to convert argument type, "
-                        << "function requires '" << type << "', " << "found '"
-                        << typestr(call.vargs[i].type())
-                        << "': " << compat_arg_type.takeError();
-        continue;
-      }
-      args.emplace_back(name, std::move(*compat_arg_type));
-    }
-    if (args.size() != argument_types->size()) {
-      return; // Already emitted errors.
-    }
-    // Check all the individual arguments.
-    bool ok = true;
-    for (size_t i = 0; i < args.size(); i++) {
-      const auto &[name, type] = args[i];
-      if (type != call.vargs[i].type()) {
-        if (!name.empty()) {
-          call.vargs[i].node().addError()
-              << "Expected " << typestr(type) << " for argument `" << name
-              << "` got " << typestr(call.vargs[i].type());
-        } else {
-          call.vargs[i].node().addError()
-              << "Expected " << typestr(type) << " got "
-              << typestr(call.vargs[i].type());
-        }
-        ok = false;
-      }
-    }
-    // Build our full proto as an error message.
-    std::stringstream fullmsg;
-    fullmsg << "Function `" << call.func << "` requires arguments (";
-    bool first = true;
-    for (const auto &[name, type] : args) {
-      if (!first) {
-        fullmsg << ", ";
-      }
-      fullmsg << typestr(type);
-      first = false;
-    }
-    fullmsg << ")";
-    if (!ok) {
-      call.addError() << fullmsg.str();
-      return;
-    }
   }
 }
 
-std::optional<size_t> SemanticAnalyser::check(Sizeof &szof)
+std::optional<size_t> TypeResolver::check(Sizeof &szof)
 {
   is_type_name_ = true;
-  Visitor<SemanticAnalyser>::visit(szof);
+  Visitor<TypeResolver>::visit(szof);
   is_type_name_ = false;
 
   if (std::holds_alternative<SizedType>(szof.record)) {
@@ -1850,7 +893,7 @@ std::optional<size_t> SemanticAnalyser::check(Sizeof &szof)
   return std::nullopt;
 }
 
-void SemanticAnalyser::visit(Sizeof &szof)
+void TypeResolver::visit(Sizeof &szof)
 {
   AssignMapDisallowed<"sizeof">().visit(szof.record);
 
@@ -1860,12 +903,10 @@ void SemanticAnalyser::visit(Sizeof &szof)
   }
 }
 
-std::optional<size_t> SemanticAnalyser::check(Offsetof &offof)
+std::optional<size_t> TypeResolver::check(Offsetof &offof)
 {
-  AssignMapDisallowed<"offsetof">().visit(offof.record);
-
   is_type_name_ = true;
-  Visitor<SemanticAnalyser>::visit(offof);
+  Visitor<TypeResolver>::visit(offof);
   is_type_name_ = false;
 
   auto check_type = [&](SizedType cstruct) -> std::optional<size_t> {
@@ -1908,33 +949,64 @@ std::optional<size_t> SemanticAnalyser::check(Offsetof &offof)
   return std::nullopt;
 }
 
-void SemanticAnalyser::visit(Offsetof &offof)
+void TypeResolver::visit(Offsetof &offof)
 {
+  AssignMapDisallowed<"offsetof">().visit(offof.record);
+
   const auto v = check(offof);
   if (!v && is_final_pass()) {
     offof.addError() << "offsetof not resolved, is type complete?";
   }
 }
 
-void SemanticAnalyser::visit(Typeof &typeof)
+void TypeResolver::visit(Typeof &typeof)
 {
   AssignMapDisallowed<"typeof or typeinfo">().visit(typeof.record);
 
-  is_type_name_ = true;
-  Visitor<SemanticAnalyser>::visit(typeof);
-  is_type_name_ = false;
-
   if (std::holds_alternative<SizedType>(typeof.record)) {
     resolve_struct_type(std::get<SizedType>(typeof.record), typeof);
+  } else {
+    const auto &expr = std::get<Expression>(typeof.record);
+    if (auto *ident = expr.as<Identifier>()) {
+      auto stype = bpftrace_.btf_->get_stype(ident->ident);
+      if (!stype.IsNoneTy()) {
+        typeof.record = stype;
+      }
+    }
   }
+
+  is_type_name_ = true;
+  Visitor<TypeResolver>::visit(typeof);
+  is_type_name_ = false;
 }
 
-void SemanticAnalyser::visit(Typeinfo &typeinfo)
+void TypeResolver::visit(Typeinfo &typeinfo)
 {
-  Visitor<SemanticAnalyser>::visit(typeinfo);
+  Visitor<TypeResolver>::visit(typeinfo);
 }
 
-void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
+bool TypeResolver::check_symbol(const Call &call)
+{
+  auto *arg = call.vargs.at(0).as<String>();
+  if (!arg) {
+    call.addError() << call.func
+                    << "() expects a string literal as the first argument";
+    return false;
+  }
+
+  std::string re = "^[a-zA-Z0-9./_-]+$";
+  bool is_valid = std::regex_match(arg->value, std::regex(re));
+  if (!is_valid) {
+    call.addError() << call.func
+                    << "() expects a string that is a valid symbol (" << re
+                    << ") as input (\"" << arg << "\" provided)";
+    return false;
+  }
+
+  return true;
+}
+
+void TypeResolver::check_stack_call(Call &call, bool kernel)
 {
   call.return_type = CreateStack(kernel);
   StackType stack_type;
@@ -1950,12 +1022,10 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
         if (!ok) {
           ident->addError() << "Error parsing stack mode: " << ok.takeError();
         }
-      } else if (check_arg(call, Type::integer, 0, true)) {
-        if (auto *limit = call.vargs.at(0).as<Integer>()) {
-          stack_type.limit = limit->value;
-        } else {
-          call.addError() << call.func << ": invalid limit value";
-        }
+      } else if (auto *limit = call.vargs.at(0).as<Integer>()) {
+        stack_type.limit = limit->value;
+      } else {
+        call.addError() << call.func << ": invalid limit value";
       }
       break;
     }
@@ -1970,12 +1040,10 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
         // If two arguments are provided, then the first must be a stack mode.
         call.addError() << "Expected stack mode as first argument";
       }
-      if (check_arg(call, Type::integer, 1, true)) {
-        if (auto *limit = call.vargs.at(1).as<Integer>()) {
-          stack_type.limit = limit->value;
-        } else {
-          call.addError() << call.func << ": invalid limit value";
-        }
+      if (auto *limit = call.vargs.at(1).as<Integer>()) {
+        stack_type.limit = limit->value;
+      } else {
+        call.addError() << call.func << ": invalid limit value";
       }
       break;
     }
@@ -1994,7 +1062,7 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
   call.return_type = CreateStack(kernel, stack_type);
 }
 
-Probe *SemanticAnalyser::get_probe(Node &node, std::string name)
+Probe *TypeResolver::get_probe(Node &node, std::string name)
 {
   auto *probe = dynamic_cast<Probe *>(top_level_node_);
   if (probe == nullptr) {
@@ -2009,27 +1077,7 @@ Probe *SemanticAnalyser::get_probe(Node &node, std::string name)
   return probe;
 }
 
-void SemanticAnalyser::visit(MapDeclStatement &decl)
-{
-  const auto bpf_type = get_bpf_map_type(decl.bpf_type);
-  if (!bpf_type) {
-    auto &err = decl.addError();
-    err << "Invalid bpf map type: " << decl.bpf_type;
-    auto &hint = err.addHint();
-    add_bpf_map_types_hint(hint);
-  } else {
-    bpf_map_type_.insert({ decl.ident, *bpf_type });
-  }
-
-  if (is_final_pass()) {
-    auto map_key_search_val = map_key_.find(decl.ident);
-    if (map_key_search_val == map_key_.end()) {
-      decl.addWarning() << "Unused map: " << decl.ident;
-    }
-  }
-}
-
-void SemanticAnalyser::visit(Map &map)
+void TypeResolver::visit(Map &map)
 {
   if (map_metadata_.bad_indexed_access.contains(&map)) {
     map.addError()
@@ -2047,23 +1095,8 @@ void SemanticAnalyser::visit(Map &map)
   if (key != map_key_.end()) {
     map.key_type = key->second;
   }
-
-  // Note that the naked `Map` node actually gets no type, the type
-  // is applied to the node at the `MapAccess` level.
-  if (is_final_pass()) {
-    auto found_kind = bpf_map_type_.find(map.ident);
-    if (found_kind != bpf_map_type_.end()) {
-      if (!bpf_map_types_compatible(map.value_type, found_kind->second)) {
-        auto map_type = get_bpf_map_type(map.value_type);
-        map.addError() << "Incompatible map types. Type from declaration: "
-                       << get_bpf_map_type_str(found_kind->second)
-                       << ". Type from value/key type: "
-                       << get_bpf_map_type_str(map_type);
-      }
-    }
-  }
 }
-void SemanticAnalyser::visit(MapAddr &map_addr)
+void TypeResolver::visit(MapAddr &map_addr)
 {
   if (!map_val_.contains(map_addr.map->ident)) {
     if (!is_first_pass()) {
@@ -2077,14 +1110,14 @@ void SemanticAnalyser::visit(MapAddr &map_addr)
   }
 }
 
-void SemanticAnalyser::visit(Variable &var)
+void TypeResolver::visit(Variable &var)
 {
   if (auto *found = find_variable(var.ident)) {
     var.var_type = found->type;
   }
 }
 
-void SemanticAnalyser::visit(VariableAddr &var_addr)
+void TypeResolver::visit(VariableAddr &var_addr)
 {
   if (auto *found = find_variable(var_addr.var->ident)) {
     var_addr.var->var_type = found->type;
@@ -2098,46 +1131,12 @@ void SemanticAnalyser::visit(VariableAddr &var_addr)
   }
 }
 
-void SemanticAnalyser::visit(ArrayAccess &arr)
+void TypeResolver::visit(ArrayAccess &arr)
 {
   visit(arr.expr);
   visit(arr.indexpr);
 
   const SizedType &type = arr.expr.type();
-
-  if (is_final_pass()) {
-    if (!type.IsArrayTy() && !type.IsPtrTy() && !type.IsStringTy()) {
-      arr.addError() << "The array index operator [] can only be "
-                        "used on arrays and pointers, found "
-                     << type.GetTy() << ".";
-      return;
-    }
-
-    if (type.IsPtrTy() && type.GetPointeeTy().GetSize() == 0) {
-      arr.addError() << "The array index operator [] cannot be used "
-                        "on a pointer to an unsized type (void *).";
-    }
-
-    if (auto *integer = arr.indexpr.as<Integer>()) {
-      auto num = [&]() -> size_t {
-        if (type.IsArrayTy()) {
-          return type.GetNumElements();
-        } else if (type.IsStringTy()) {
-          return type.GetSize();
-        } else {
-          return 0;
-        }
-      }();
-      if (num != 0 && static_cast<size_t>(integer->value) >= num) {
-        arr.addError() << "the index " << integer->value
-                       << " is out of bounds for array of size " << num;
-      }
-    } else if (!arr.indexpr.type().IsIntTy() || arr.indexpr.type().IsSigned()) {
-      arr.addError() << "The array index operator [] only "
-                        "accepts positive (unsigned) integer indices. Got: "
-                     << arr.indexpr.type();
-    }
-  }
 
   if (type.IsArrayTy())
     arr.element_type = type.GetElementTy();
@@ -2158,34 +1157,21 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
   }
 }
 
-void SemanticAnalyser::visit(TupleAccess &acc)
+void TypeResolver::visit(TupleAccess &acc)
 {
   visit(acc.expr);
   const SizedType &type = acc.expr.type();
 
   if (!type.IsTupleTy()) {
-    if (is_final_pass()) {
-      acc.addError() << "Can not access index '" << acc.index
-                     << "' on expression of type '" << type << "'";
-    }
     return;
   }
 
-  bool valid_idx = acc.index < type.GetFields().size();
-
-  // We may not have inferred the full type of the tuple yet in early passes
-  // so wait until the final pass.
-  if (!valid_idx && is_final_pass()) {
-    acc.addError() << "Invalid tuple index: " << acc.index << ". Found "
-                   << type.GetFields().size() << " elements in tuple.";
-  }
-
-  if (valid_idx) {
+  if (acc.index < type.GetFields().size()) {
     acc.element_type = type.GetField(acc.index).type;
   }
 }
 
-void SemanticAnalyser::binop_int(Binop &binop)
+void TypeResolver::binop_int(Binop &binop)
 {
   SizedType leftTy = binop.left.type();
   SizedType rightTy = binop.right.type();
@@ -2280,8 +1266,8 @@ void SemanticAnalyser::binop_int(Binop &binop)
   }
 }
 
-void SemanticAnalyser::create_int_cast(Expression &exp,
-                                       const SizedType &target_type)
+void TypeResolver::create_int_cast(Expression &exp,
+                                   const SizedType &target_type)
 {
   // We don't need a cast if it's a literal
   if (target_type.IsIntegerTy()) {
@@ -2304,8 +1290,8 @@ void SemanticAnalyser::create_int_cast(Expression &exp,
   visit(exp);
 }
 
-void SemanticAnalyser::create_string_cast(Expression &exp,
-                                          const SizedType &target_type)
+void TypeResolver::create_string_cast(Expression &exp,
+                                      const SizedType &target_type)
 {
   if (exp.type().GetSize() == target_type.GetSize()) {
     return;
@@ -2318,9 +1304,24 @@ void SemanticAnalyser::create_string_cast(Expression &exp,
   visit(exp);
 }
 
-void SemanticAnalyser::create_tuple_cast(Expression &exp,
-                                         const SizedType &curr_type,
-                                         const SizedType &target_type)
+void TypeResolver::apply_element_cast(Expression &elem,
+                                      const SizedType &curr_type,
+                                      const SizedType &target_type)
+{
+  if (target_type.IsIntTy() && curr_type != target_type) {
+    create_int_cast(elem, target_type);
+  } else if (target_type.IsStringTy()) {
+    create_string_cast(elem, target_type);
+  } else if (target_type.IsTupleTy()) {
+    create_tuple_cast(elem, curr_type, target_type);
+  } else if (target_type.IsRecordTy()) {
+    create_record_cast(elem, curr_type, target_type);
+  }
+}
+
+void TypeResolver::create_tuple_cast(Expression &exp,
+                                     const SizedType &curr_type,
+                                     const SizedType &target_type)
 {
   if (auto *block_expr = exp.as<BlockExpr>()) {
     create_tuple_cast(block_expr->expr, curr_type, target_type);
@@ -2357,9 +1358,9 @@ void SemanticAnalyser::create_tuple_cast(Expression &exp,
   visit(exp);
 }
 
-void SemanticAnalyser::create_record_cast(Expression &exp,
-                                          const SizedType &curr_type,
-                                          const SizedType &target_type)
+void TypeResolver::create_record_cast(Expression &exp,
+                                      const SizedType &curr_type,
+                                      const SizedType &target_type)
 {
   if (auto *block_expr = exp.as<BlockExpr>()) {
     create_record_cast(block_expr->expr, curr_type, target_type);
@@ -2406,42 +1407,7 @@ void SemanticAnalyser::create_record_cast(Expression &exp,
   visit(exp);
 }
 
-void SemanticAnalyser::apply_element_cast(Expression &elem,
-                                          const SizedType &curr_type,
-                                          const SizedType &target_type)
-{
-  if (target_type.IsIntTy() && curr_type != target_type) {
-    create_int_cast(elem, target_type);
-  } else if (target_type.IsStringTy()) {
-    create_string_cast(elem, target_type);
-  } else if (target_type.IsTupleTy()) {
-    create_tuple_cast(elem, curr_type, target_type);
-  } else if (target_type.IsRecordTy()) {
-    create_record_cast(elem, curr_type, target_type);
-  }
-}
-
-void SemanticAnalyser::binop_array(Binop &binop)
-{
-  const auto &lht = binop.left.type();
-  const auto &rht = binop.right.type();
-  if (binop.op != Operator::EQ && binop.op != Operator::NE) {
-    binop.addError() << "The " << opstr(binop)
-                     << " operator cannot be used on arrays.";
-  }
-
-  if (lht.GetNumElements() != rht.GetNumElements()) {
-    binop.addError()
-        << "Only arrays of same size support comparison operators.";
-  }
-
-  if (!lht.GetElementTy().IsIntegerTy() || lht != rht) {
-    binop.addError()
-        << "Only arrays of same sized integer support comparison operators.";
-  }
-}
-
-void SemanticAnalyser::binop_ptr(Binop &binop)
+void TypeResolver::binop_ptr(Binop &binop)
 {
   const auto &lht = binop.left.type();
   const auto &rht = binop.right.type();
@@ -2524,7 +1490,7 @@ void SemanticAnalyser::binop_ptr(Binop &binop)
   }
 }
 
-void SemanticAnalyser::visit(Binop &binop)
+void TypeResolver::visit(Binop &binop)
 {
   visit(binop.left);
   visit(binop.right);
@@ -2594,30 +1560,10 @@ void SemanticAnalyser::visit(Binop &binop)
 
   if (is_int_binop) {
     binop_int(binop);
-  } else if (lht.IsArrayTy() && rht.IsArrayTy()) {
-    binop_array(binop);
-  } else if (lht.IsPtrTy() || rht.IsPtrTy()) {
-    // This case is caught earlier, just here for readability of the if/else
-    // flow
-  }
-  // Compare type here, not the sized type as we it needs to work on strings
-  // of different lengths
-  else if (!lht.IsCompatible(rht)) {
-    auto &err = binop.addError();
-    err << "Type mismatch for '" << opstr(binop) << "': comparing " << lht
-        << " with " << rht;
-    err.addContext(binop.left.loc()) << "left (" << lht << ")";
-    err.addContext(binop.right.loc()) << "right (" << rht << ")";
-  }
-  // Also allow combination like reg("sp") + 8
-  else if (binop.op != Operator::EQ && binop.op != Operator::NE) {
-    binop.addError() << "The " << opstr(binop)
-                     << " operator can not be used on expressions of types "
-                     << lht << ", " << rht;
   }
 }
 
-void SemanticAnalyser::visit(Unop &unop)
+void TypeResolver::visit(Unop &unop)
 {
   if (unop.op == Operator::PRE_INCREMENT ||
       unop.op == Operator::PRE_DECREMENT ||
@@ -2630,9 +1576,6 @@ void SemanticAnalyser::visit(Unop &unop)
       // it is done on an integer. Maps are always coerced into larger
       // integers, so this should not conflict with different assignments.
       assign_map_type(*acc->map, CreateInt64(), acc->map);
-    } else if (!unop.expr.is<Variable>()) {
-      unop.addError() << "The " << opstr(unop)
-                      << " operator must be applied to a map or variable";
     }
   }
 
@@ -2651,22 +1594,6 @@ void SemanticAnalyser::visit(Unop &unop)
   }
 
   const SizedType &type = unop.expr.type();
-  if (is_final_pass()) {
-    bool invalid = false;
-    // Unops are only allowed on ints (e.g. ~$x), dereference only on pointers
-    // and context (we allow args->field for backwards compatibility)
-    if (type.IsBoolTy()) {
-      invalid = unop.op != Operator::LNOT;
-    } else if (!type.IsIntegerTy() &&
-               !((type.IsPtrTy() || type.IsCtxAccess()) && valid_ptr_op)) {
-      invalid = true;
-    }
-    if (invalid) {
-      unop.addError() << "The " << opstr(unop)
-                      << " operator can not be used on expressions of type '"
-                      << type << "'";
-    }
-  }
 
   if (unop.op == Operator::MUL) {
     if (type.IsPtrTy()) {
@@ -2707,7 +1634,7 @@ void SemanticAnalyser::visit(Unop &unop)
   }
 }
 
-void SemanticAnalyser::visit(IfExpr &if_expr)
+void TypeResolver::visit(IfExpr &if_expr)
 {
   // In order to evaluate literals and resolved type operators, we need to fold
   // the condition. This is handled in the `Expression` visitor. Branches that
@@ -2717,7 +1644,7 @@ void SemanticAnalyser::visit(IfExpr &if_expr)
   // necessary to resolve types, that is a cycle in the dependency graph, the
   // `if` condition must be resolvable first. If the condition *is* resolvable
   // and is a constant, then we prune the dead code paths and will never use
-  // them for semantic analysis.
+  // them.
   if (auto *comptime = if_expr.cond.as<Comptime>()) {
     visit(comptime->expr);
     if (is_final_pass()) {
@@ -2800,26 +1727,13 @@ void SemanticAnalyser::visit(IfExpr &if_expr)
   }
 }
 
-void SemanticAnalyser::visit(Unroll &unroll)
+void TypeResolver::visit(Unroll &unroll)
 {
   visit(unroll.expr);
-
-  auto *integer = unroll.expr.as<Integer>();
-  if (!integer) {
-    unroll.addError() << "invalid unroll value";
-    return;
-  }
-
-  if (integer->value > static_cast<uint64_t>(100)) {
-    unroll.addError() << "unroll maximum value is 100";
-  } else if (integer->value < static_cast<uint64_t>(1)) {
-    unroll.addError() << "unroll minimum value is 1";
-  }
-
   visit(unroll.block);
 }
 
-void SemanticAnalyser::visit(Jump &jump)
+void TypeResolver::visit(Jump &jump)
 {
   if (jump.ident == JumpType::RETURN) {
     visit(jump.return_value);
@@ -2831,9 +1745,6 @@ void SemanticAnalyser::visit(Jump &jump)
           update_int_type(jump.return_value->type(),
                           *jump.return_value,
                           CreateInt64());
-        } else if (is_final_pass()) {
-          jump.addError() << "Probe return values can only be integers. Found "
-                          << ty;
         }
       }
     } else if (auto *subprog = dynamic_cast<Subprog *>(top_level_node_)) {
@@ -2864,20 +1775,14 @@ void SemanticAnalyser::visit(Jump &jump)
   }
 }
 
-void SemanticAnalyser::visit(While &while_block)
+void TypeResolver::visit(While &while_block)
 {
   visit(while_block.cond);
-
-  loop_depth_++;
   visit(while_block.block);
-  loop_depth_--;
 }
 
-void SemanticAnalyser::visit(For &f)
+void TypeResolver::visit(For &f)
 {
-  if (f.iterable.is<Range>() && !bpftrace_.feature_->has_helper_loop()) {
-    f.addError() << "Missing required kernel feature: loop";
-  }
   if (auto *map = f.iterable.as<Map>()) {
     if (!is_first_pass() && !map_val_.contains(map->ident)) {
       map->addError() << "Undefined map: " << map->ident;
@@ -2983,16 +1888,6 @@ void SemanticAnalyser::visit(For &f)
       map->addError() << "Loop expression does not support type: "
                       << map->type();
     }
-  } else if (auto *range = f.iterable.as<Range>()) {
-    if (is_final_pass()) {
-      if (!range->start.type().IsIntTy()) {
-        range->addError()
-            << "Loop range requires an integer for the start value";
-      }
-      if (!range->end.type().IsIntTy()) {
-        range->addError() << "Loop range requires an integer for the end value";
-      }
-    }
   }
 
   if (!ctx_.diagnostics().ok()) {
@@ -3059,22 +1954,9 @@ void SemanticAnalyser::visit(For &f)
     .can_resize = true,
   };
 
-  loop_depth_++;
   visit(f.block);
-  loop_depth_--;
 
   scope_stack_.pop_back();
-
-  // Currently, we do not pass BPF context to the callback so disable builtins
-  // which require ctx access.
-  CollectNodes<Builtin> builtins;
-  builtins.visit(f.block);
-  for (const Builtin &builtin : builtins.nodes()) {
-    if (builtin.builtin_type.IsCtxAccess()) {
-      builtin.addError() << "'" << builtin.ident
-                         << "' builtin is not allowed in a for-loop";
-    }
-  }
 
   // Finally, create the context tuple now that all variables inside the loop
   // have been visited.
@@ -3089,7 +1971,7 @@ void SemanticAnalyser::visit(For &f)
   f.ctx_type = CreateCStruct(Struct::CreateRecord(ctx_types, ctx_idents));
 }
 
-void SemanticAnalyser::visit(FieldAccess &acc)
+void TypeResolver::visit(FieldAccess &acc)
 {
   visit(acc.expr);
 
@@ -3182,17 +2064,14 @@ void SemanticAnalyser::visit(FieldAccess &acc)
     }
     acc.field_type.is_internal = type.is_internal;
     acc.field_type.SetAS(acc.expr.type().GetAS());
-
-    // The kernel uses the first 8 bytes to store `struct pt_regs`. Any
-    // access to the first 8 bytes results in verifier error.
-    if (record->is_tracepoint_args && field.offset < 8)
-      acc.addError()
-          << "BPF does not support accessing common tracepoint fields";
   }
 }
 
-void SemanticAnalyser::visit(MapAccess &acc)
+void TypeResolver::visit(MapAccess &acc)
 {
+  visit(acc.map);
+  visit(acc.key);
+
   if (map_metadata_.bad_scalar_access.contains(acc.map)) {
     acc.addError() << acc.map->ident
                    << " used as a map with an explicit key (non-scalar map), "
@@ -3200,17 +2079,10 @@ void SemanticAnalyser::visit(MapAccess &acc)
     return;
   }
 
-  visit(acc.map);
-  visit(acc.key);
   reconcile_map_key(acc.map, acc.key);
 
   auto search_val = map_val_.find(acc.map->ident);
   if (search_val != map_val_.end()) {
-    if (acc.map->type().IsCastableMapTy() &&
-        !bpftrace_.feature_->has_helper_map_lookup_percpu_elem()) {
-      acc.addError()
-          << "Missing required kernel feature: map_lookup_percpu_elem";
-    }
     acc.map->value_type = search_val->second;
   } else {
     // If there is no record of any assignment after the first pass
@@ -3223,7 +2095,7 @@ void SemanticAnalyser::visit(MapAccess &acc)
   }
 }
 
-void SemanticAnalyser::reconcile_map_key(Map *map, Expression &key_expr)
+void TypeResolver::reconcile_map_key(Map *map, Expression &key_expr)
 {
   SizedType new_key_type = create_key_type(key_expr.type(), key_expr.node());
 
@@ -3277,14 +2149,14 @@ void SemanticAnalyser::reconcile_map_key(Map *map, Expression &key_expr)
       }
     }
   } else {
-    if (!new_key_type.IsNoneTy()) {
+    if (!new_key_type.IsNoneTy() && !new_key_type.IsVoidTy()) {
       map_key_.insert({ map->ident, new_key_type });
       map->key_type = new_key_type;
     }
   }
 }
 
-void SemanticAnalyser::visit(Cast &cast)
+void TypeResolver::visit(Cast &cast)
 {
   visit(cast.expr);
   visit(cast.typeof);
@@ -3292,61 +2164,26 @@ void SemanticAnalyser::visit(Cast &cast)
   const auto &resolved_ty = cast.type();
   if (resolved_ty.IsNoneTy()) {
     pass_tracker_.inc_num_unresolved();
-    if (is_final_pass()) {
-      cast.addError() << "Incomplete cast, unknown type";
-    }
-    return; // Revisit next cycle.
+    return; // Revisit later.
   }
 
   auto rhs = cast.expr.type();
-  if (rhs.IsCStructTy()) {
-    cast.addError() << "Cannot cast from struct type \"" << cast.expr.type()
-                    << "\"";
-  } else if (rhs.IsNoneTy()) {
-    if (is_final_pass()) {
-      cast.addError() << "Cannot cast from \"" << cast.expr.type() << "\" type";
-    } else {
-      return; // Revisit later.
-    }
+  if (rhs.IsNoneTy()) {
+    return; // Revisit later.
   }
 
   // Resolved the type because we may mutate it below, for various reasons.
   cast.typeof->record = resolved_ty;
   auto &ty = std::get<SizedType>(cast.typeof->record);
 
-  auto logError = [&]() {
-    cast.addError() << "Cannot cast from \"" << rhs << "\" to \"" << ty << "\"";
-  };
-
-  if (ty.IsStringTy() && rhs.IsStringTy()) {
-    if (ty.GetSize() < rhs.GetSize()) {
-      logError();
-    }
-    return;
-  }
-
-  if (!ty.IsIntTy() && !ty.IsPtrTy() && !ty.IsBoolTy() &&
-      (!ty.IsPtrTy() || ty.GetElementTy().IsIntTy() ||
-       ty.GetElementTy().IsCStructTy()) &&
-      // we support casting integers to int arrays
-      !(ty.IsArrayTy() && ty.GetElementTy().IsBoolTy()) &&
-      !(ty.IsArrayTy() && ty.GetElementTy().IsIntTy())) {
-    logError();
-  }
-
   if (ty.IsArrayTy()) {
     if (ty.GetNumElements() == 0) {
-      if (ty.GetElementTy().GetSize() == 0)
-        cast.addError() << "Could not determine size of the array";
-      else {
-        if (rhs.GetSize() % ty.GetElementTy().GetSize() != 0) {
-          cast.addError() << "Cannot determine array size: the element size is "
-                             "incompatible with the cast integer size";
+      if (ty.GetElementTy().GetSize() != 0) {
+        if (rhs.GetSize() % ty.GetElementTy().GetSize() == 0) {
+          // cast to unsized array (e.g. int8[]), determine size from RHS
+          auto num_elems = rhs.GetSize() / ty.GetElementTy().GetSize();
+          ty = CreateArray(num_elems, ty.GetElementTy());
         }
-
-        // cast to unsized array (e.g. int8[]), determine size from RHS
-        auto num_elems = rhs.GetSize() / ty.GetElementTy().GetSize();
-        ty = CreateArray(num_elems, ty.GetElementTy());
       }
     }
 
@@ -3359,46 +2196,18 @@ void SemanticAnalyser::visit(Cast &cast)
           create_int_cast(cast.expr,
                           CreateInteger(ty.GetSize() * 8,
                                         ty.GetElementTy().IsSigned()));
-        } else if (ty.GetSize() != rhs.GetSize()) {
-          logError();
-        }
-      }
-    } else {
-      if ((!rhs.IsBoolTy() && !rhs.IsStringTy()) ||
-          ty.GetSize() != rhs.GetSize()) {
-        logError();
-      }
-    }
-  }
-
-  if (ty.IsEnumTy()) {
-    if (!c_definitions_.enum_defs.contains(ty.GetName())) {
-      cast.addError() << "Unknown enum: " << ty.GetName();
-    } else {
-      if (auto *integer = cast.expr.as<Integer>()) {
-        if (!c_definitions_.enum_defs[ty.GetName()].contains(integer->value)) {
-          cast.addError() << "Enum: " << ty.GetName()
-                          << " doesn't contain a variant value of "
-                          << integer->value;
         }
       }
     }
   }
 
-  if (!rhs.IsPtrTy() && !rhs.IsCastableMapTy() && !rhs.IsIntTy() &&
-      is_final_pass()) {
-    if (ty.IsBoolTy() && !rhs.IsStringTy()) {
-      logError();
+  if (ty.IsArrayTy() && rhs.IsIntTy() &&
+      (ty.GetElementTy().IsIntegerTy() || ty.GetElementTy().IsBoolTy())) {
+    if ((ty.GetSize() <= 8) && (ty.GetSize() > rhs.GetSize())) {
+      create_int_cast(cast.expr,
+                      CreateInteger(ty.GetSize() * 8,
+                                    ty.GetElementTy().IsSigned()));
     }
-
-    if (ty.IsIntTy() && !rhs.IsBoolTy() && !rhs.IsCtxAccess() &&
-        !rhs.IsArrayTy()) {
-      logError();
-    }
-  }
-
-  if ((rhs.IsArrayTy() && (!ty.IsIntTy() || ty.GetSize() != rhs.GetSize()))) {
-    logError();
   }
 
   if (cast.expr.type().IsCtxAccess() && !ty.IsIntTy()) {
@@ -3418,7 +2227,7 @@ void SemanticAnalyser::visit(Cast &cast)
   }
 }
 
-void SemanticAnalyser::visit(Tuple &tuple)
+void TypeResolver::visit(Tuple &tuple)
 {
   std::vector<SizedType> elements;
   for (auto &elem : tuple.elems) {
@@ -3428,9 +2237,6 @@ void SemanticAnalyser::visit(Tuple &tuple)
     if (elem.type().IsNoneTy()) {
       pass_tracker_.inc_num_unresolved();
       return;
-    } else if (elem.type().IsMultiKeyMapTy()) {
-      elem.node().addError()
-          << "Map type " << elem.type() << " cannot exist inside a tuple.";
     }
     elements.emplace_back(elem.type());
   }
@@ -3438,7 +2244,7 @@ void SemanticAnalyser::visit(Tuple &tuple)
   tuple.tuple_type = CreateTuple(Struct::CreateTuple(elements));
 }
 
-void SemanticAnalyser::visit(Record &record)
+void TypeResolver::visit(Record &record)
 {
   std::vector<SizedType> elements;
   std::vector<std::string_view> names;
@@ -3451,9 +2257,6 @@ void SemanticAnalyser::visit(Record &record)
     if (elem.type().IsNoneTy()) {
       pass_tracker_.inc_num_unresolved();
       return;
-    } else if (elem.type().IsMultiKeyMapTy()) {
-      elem.node().addError()
-          << "Map type " << elem.type() << " cannot exist inside a record.";
     }
     elements.emplace_back(elem.type());
   }
@@ -3461,10 +2264,10 @@ void SemanticAnalyser::visit(Record &record)
   record.record_type = CreateRecord(Struct::CreateRecord(elements, names));
 }
 
-void SemanticAnalyser::visit(Expression &expr)
+void TypeResolver::visit(Expression &expr)
 {
   // Visit and fold all other values.
-  Visitor<SemanticAnalyser>::visit(expr);
+  Visitor<TypeResolver>::visit(expr);
   fold(ctx_, expr);
 
   // Inline specific constant expressions.
@@ -3551,29 +2354,9 @@ void SemanticAnalyser::visit(Expression &expr)
   }
 }
 
-void SemanticAnalyser::visit(ExprStatement &expr)
+void TypeResolver::visit(ExprStatement &expr)
 {
   visit(expr.expr);
-
-  if (is_final_pass()) {
-    bool warn_discarded = true;
-    if (auto *unop = expr.expr.as<Unop>()) {
-      if (unop->op == Operator::PRE_INCREMENT ||
-          unop->op == Operator::PRE_DECREMENT ||
-          unop->op == Operator::POST_INCREMENT ||
-          unop->op == Operator::POST_DECREMENT) {
-        warn_discarded = false;
-      }
-    }
-
-    if (expr.expr.type().IsNoneTy() || expr.expr.type().IsVoidTy()) {
-      warn_discarded = false;
-    }
-
-    if (warn_discarded) {
-      expr.addWarning() << "Return value discarded.";
-    }
-  }
 }
 
 static const std::unordered_map<Type, std::string_view> AGGREGATE_HINTS{
@@ -3588,7 +2371,7 @@ static const std::unordered_map<Type, std::string_view> AGGREGATE_HINTS{
   { Type::stats_t, "stats(arg2)" },
 };
 
-void SemanticAnalyser::visit(AssignMapStatement &assignment)
+void TypeResolver::visit(AssignMapStatement &assignment)
 {
   visit(assignment.map_access);
   visit(assignment.expr);
@@ -3645,10 +2428,10 @@ void SemanticAnalyser::visit(AssignMapStatement &assignment)
     std::string ty = assignment.expr.type().GetName();
     std::string stored_ty = map_val_[map_ident].GetName();
     if (!stored_ty.empty() && stored_ty != ty) {
-      assignment.addError() << "Type mismatch for " << map_ident << ": "
-                            << "trying to assign value of type '" << ty
-                            << "' when map already contains a value of type '"
-                            << stored_ty << "'";
+      assignment.addError()
+          << "Type mismatch for " << map_ident << ": "
+          << "trying to assign value of type '" << ty
+          << "' when map already has a type '" << stored_ty << "'";
     } else {
       map_val_[map_ident] = assignment.expr.type();
       map_val_[map_ident].is_internal = true;
@@ -3691,7 +2474,7 @@ void SemanticAnalyser::visit(AssignMapStatement &assignment)
   }
 }
 
-void SemanticAnalyser::visit(AssignVarStatement &assignment)
+void TypeResolver::visit(AssignVarStatement &assignment)
 {
   visit(assignment.expr);
 
@@ -3710,7 +2493,7 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
 
   const auto &var_ident = assignment.var()->ident;
 
-  if (!is_valid_assignment(assignment.expr, false)) {
+  if (!is_valid_assignment(assignment.expr)) {
     if (is_final_pass()) {
       assignment.addError() << "Value '" << assignment.expr.type()
                             << "' cannot be assigned to a scratch variable.";
@@ -3816,31 +2599,15 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
 
   const auto &storedTy = variables_[var_scope][var_ident].type;
   assignment.var()->var_type = storedTy;
-
-  if (is_final_pass()) {
-    if (storedTy.IsNoneTy())
-      assignment.addError()
-          << "Invalid expression for assignment: " << storedTy;
-  }
 }
 
-void SemanticAnalyser::visit(VarDeclStatement &decl)
+void TypeResolver::visit(VarDeclStatement &decl)
 {
   visit(decl.typeof);
   const std::string &var_ident = decl.var->ident;
 
   if (decl.typeof) {
-    const auto &ty = decl.typeof->type();
-    if (!ty.IsNoneTy()) {
-      if (!IsValidVarDeclType(ty)) {
-        decl.addError() << "Invalid variable declaration type: " << ty;
-      } else {
-        decl.var->var_type = ty;
-      }
-    } else if (is_final_pass()) {
-      // We couldn't resolve that specific type by now.
-      decl.addError() << "Type cannot be resolved: still none";
-    }
+    decl.var->var_type = decl.typeof->type();
   }
 
   if (is_first_pass() || is_final_pass()) {
@@ -3881,7 +2648,7 @@ void SemanticAnalyser::visit(VarDeclStatement &decl)
   variable_decls_[scope_stack_.back()].insert({ var_ident, decl });
 }
 
-void SemanticAnalyser::visit(BlockExpr &block)
+void TypeResolver::visit(BlockExpr &block)
 {
   scope_stack_.push_back(&block);
   visit(block.stmts);
@@ -3889,14 +2656,14 @@ void SemanticAnalyser::visit(BlockExpr &block)
   scope_stack_.pop_back();
 }
 
-void SemanticAnalyser::visit(Probe &probe)
+void TypeResolver::visit(Probe &probe)
 {
   top_level_node_ = &probe;
   visit(probe.attach_points);
   visit(probe.block);
 }
 
-void SemanticAnalyser::visit(Subprog &subprog)
+void TypeResolver::visit(Subprog &subprog)
 {
   // Note that we visit the subprogram and process arguments *after*
   // constructing the stack with the variable states. This is because the
@@ -3921,9 +2688,6 @@ void SemanticAnalyser::visit(Subprog &subprog)
   for (SubprogArg *arg : subprog.args) {
     if (arg->typeof->type().IsNoneTy()) {
       pass_tracker_.inc_num_unresolved();
-      if (is_final_pass()) {
-        arg->addError() << "Unable to resolve argument type.";
-      }
     }
   }
 
@@ -3934,15 +2698,11 @@ void SemanticAnalyser::visit(Subprog &subprog)
   visit(subprog.return_type);
   if (subprog.return_type->type().IsNoneTy()) {
     pass_tracker_.inc_num_unresolved();
-    if (is_final_pass()) {
-      subprog.return_type->addError()
-          << "Unable to resolve suitable return type.";
-    }
   }
   scope_stack_.pop_back();
 }
 
-void SemanticAnalyser::visit(Comptime &comptime)
+void TypeResolver::visit(Comptime &comptime)
 {
   visit(comptime.expr);
   // If something has not been resolved by the last pass, then we fail.
@@ -3953,7 +2713,7 @@ void SemanticAnalyser::visit(Comptime &comptime)
   }
 }
 
-int SemanticAnalyser::analyse()
+int TypeResolver::analyse()
 {
   std::string errors;
 
@@ -3999,234 +2759,53 @@ int SemanticAnalyser::analyse()
   return 1;
 }
 
-inline bool SemanticAnalyser::is_final_pass() const
+inline bool TypeResolver::is_final_pass() const
 {
   return pass_tracker_.is_final_pass();
 }
 
-bool SemanticAnalyser::is_first_pass() const
+bool TypeResolver::is_first_pass() const
 {
   return pass_tracker_.get_num_passes() == 1;
 }
 
-bool SemanticAnalyser::check_arg(Call &call,
-                                 size_t index,
-                                 const arg_type_spec &spec)
+void TypeResolver::check_map_value(Map &map, Call &call, SizedType type)
 {
-  if (spec.skip_check) {
-    return true;
-  }
-  return check_arg(call, spec.type, index, spec.literal);
-}
-
-bool SemanticAnalyser::check_arg(Call &call,
-                                 size_t index,
-                                 const map_type_spec &spec)
-{
-  if (auto *map = call.vargs.at(index).as<Map>()) {
-    if (spec.type) {
-      SizedType type = spec.type(call);
-      assign_map_type(*map, type, &call);
-      if (type.IsMinTy() || type.IsMaxTy() || type.IsAvgTy() ||
-          type.IsSumTy() || type.IsStatsTy()) {
-        // N.B. this keeps track of the integers passed to these map
-        // aggregation calls to ensure they are compatible
-        // (similar to the logic in update_int_type)
-        const auto &assignTy = call.vargs.at(2).type();
-        auto found = agg_map_val_.find(map->ident);
-        if (found != agg_map_val_.end()) {
-          auto &storedTy = found->second;
-          if (assignTy.IsSigned() != storedTy.IsSigned()) {
-            auto updatedTy = get_promoted_int(
-                storedTy, assignTy, std::nullopt, call.vargs.at(2));
-            if (!updatedTy) {
-              call.addError() << "Type mismatch for " << map->ident << ": "
-                              << "trying to assign value of type '" << assignTy
-                              << "' when map already contains a value of type '"
-                              << storedTy << "'";
-            } else {
-              storedTy.SetSize(updatedTy->GetSize());
-              storedTy.SetSign(true);
-            }
-          } else {
-            storedTy.SetSize(std::max(assignTy.GetSize(), storedTy.GetSize()));
-          }
+  assign_map_type(map, type, &call);
+  if (type.IsMinTy() || type.IsMaxTy() || type.IsAvgTy() || type.IsSumTy() ||
+      type.IsStatsTy()) {
+    // N.B. this keeps track of the integers passed to these map
+    // aggregation calls to ensure they are compatible
+    // (similar to the logic in update_int_type)
+    const auto &assignTy = call.vargs.at(2).type();
+    auto found = agg_map_val_.find(map.ident);
+    if (found != agg_map_val_.end()) {
+      auto &storedTy = found->second;
+      if (assignTy.IsSigned() != storedTy.IsSigned()) {
+        auto updatedTy = get_promoted_int(
+            storedTy, assignTy, std::nullopt, call.vargs.at(2));
+        if (!updatedTy) {
+          call.addError() << "Type mismatch for " << map.ident << ": "
+                          << "trying to assign value of type '" << assignTy
+                          << "' when map already has a type '" << storedTy
+                          << "'";
         } else {
-          agg_map_val_[map->ident] = assignTy;
+          storedTy.SetSize(updatedTy->GetSize());
+          storedTy.SetSign(true);
         }
+      } else {
+        storedTy.SetSize(std::max(assignTy.GetSize(), storedTy.GetSize()));
       }
+    } else {
+      agg_map_val_[map.ident] = assignTy;
     }
-    if (is_final_pass() && map->type().IsNoneTy()) {
-      map->addError() << "Undefined map: " + map->ident;
-    }
-    return true;
   }
-  call.vargs.at(index).node().addError()
-      << call.func << "() expects a map argument";
-  return false;
-}
-
-bool SemanticAnalyser::check_arg(Call &call,
-                                 size_t index,
-                                 const map_key_spec &spec)
-{
-  if (auto *map = call.vargs.at(spec.map_index).as<Map>()) {
-    // This reconciles the argument if the other one is a map, but otherwise
-    // we don't specifically emit an error. `map_type_spec` above does that.
-    reconcile_map_key(map, call.vargs.at(index));
-    return true;
-  } else {
-    return false;
+  if (is_final_pass() && map.type().IsNoneTy()) {
+    map.addError() << "Undefined map: " + map.ident;
   }
 }
 
-bool SemanticAnalyser::check_call(Call &call)
-{
-  auto spec = CALL_SPEC.find(call.func);
-  if (spec == CALL_SPEC.end()) {
-    return true;
-  }
-
-  auto ret = true;
-  if (spec->second.min_args != spec->second.max_args) {
-    ret = check_varargs(call, spec->second.min_args, spec->second.max_args);
-  } else {
-    ret = check_nargs(call, spec->second.min_args);
-  }
-
-  if (!ret) {
-    return ret;
-  }
-
-  for (size_t i = 0; i < spec->second.arg_types.size() && i < call.vargs.size();
-       ++i) {
-    std::visit([&](auto &v) { ret = ret && check_arg(call, i, v); },
-               spec->second.arg_types.at(i));
-  }
-
-  return ret;
-}
-
-// Checks the number of arguments passed to a function is correct.
-bool SemanticAnalyser::check_nargs(const Call &call, size_t expected_nargs)
-{
-  std::stringstream err;
-  auto nargs = call.vargs.size();
-  assert(nargs >= call.injected_args);
-  assert(expected_nargs >= call.injected_args);
-  nargs -= call.injected_args;
-  expected_nargs -= call.injected_args;
-
-  if (nargs != expected_nargs) {
-    if (expected_nargs == 0)
-      err << call.func << "() requires no arguments";
-    else if (expected_nargs == 1)
-      err << call.func << "() requires one argument";
-    else
-      err << call.func << "() requires " << expected_nargs << " arguments";
-
-    err << " (" << nargs << " provided)";
-    call.addError() << err.str();
-    return false;
-  }
-  return true;
-}
-
-// Checks the number of arguments passed to a function is within a specified
-// range.
-bool SemanticAnalyser::check_varargs(const Call &call,
-                                     size_t min_nargs,
-                                     size_t max_nargs)
-{
-  std::stringstream err;
-  auto nargs = call.vargs.size();
-  assert(nargs >= call.injected_args);
-  assert(min_nargs >= call.injected_args);
-  assert(max_nargs >= call.injected_args);
-  nargs -= call.injected_args;
-  min_nargs -= call.injected_args;
-  max_nargs -= call.injected_args;
-
-  if (nargs < min_nargs) {
-    if (min_nargs == 1)
-      err << call.func << "() requires at least one argument";
-    else
-      err << call.func << "() requires at least " << min_nargs << " arguments";
-
-    err << " (" << nargs << " provided)";
-    call.addError() << err.str();
-    return false;
-  } else if (nargs > max_nargs) {
-    if (max_nargs == 0)
-      err << call.func << "() requires no arguments";
-    else if (max_nargs == 1)
-      err << call.func << "() takes up to one argument";
-    else
-      err << call.func << "() takes up to " << max_nargs << " arguments";
-
-    err << " (" << nargs << " provided)";
-    call.addError() << err.str();
-    return false;
-  }
-
-  return true;
-}
-
-// Checks an argument passed to a function is of the correct type.
-//
-// This function does not check that the function has the correct number of
-// arguments. Either check_nargs() or check_varargs() should be called first
-// to validate this.
-bool SemanticAnalyser::check_arg(Call &call,
-                                 Type type,
-                                 size_t index,
-                                 bool want_literal)
-{
-  const auto &arg = call.vargs.at(index);
-
-  if (want_literal && (!arg.is_literal() || arg.type().GetTy() != type)) {
-    call.addError() << call.func << "() expects a " << type << " literal ("
-                    << arg.type().GetTy() << " provided)";
-    if (type == Type::string) {
-      // If the call requires a string literal and a positional parameter is
-      // given, tell user to use str()
-      auto *pos_param = arg.as<PositionalParameter>();
-      if (pos_param)
-        pos_param->addError() << "Use str($" << pos_param->n << ") to treat $"
-                              << pos_param->n << " as a string";
-    }
-    return false;
-  } else if (is_final_pass() && arg.type().GetTy() != type) {
-    call.addError() << call.func << "() only supports " << type
-                    << " arguments (" << arg.type().GetTy() << " provided)";
-    return false;
-  }
-  return true;
-}
-
-bool SemanticAnalyser::check_symbol(const Call &call,
-                                    int arg_num __attribute__((unused)))
-{
-  auto *arg = call.vargs.at(0).as<String>();
-  if (!arg) {
-    call.addError() << call.func
-                    << "() expects a string literal as the first argument";
-    return false;
-  }
-
-  std::string re = "^[a-zA-Z0-9./_-]+$";
-  bool is_valid = std::regex_match(arg->value, std::regex(re));
-  if (!is_valid) {
-    call.addError() << call.func
-                    << "() expects a string that is a valid symbol (" << re
-                    << ") as input (\"" << arg << "\" provided)";
-    return false;
-  }
-
-  return true;
-}
-
-SizedType *SemanticAnalyser::get_map_type(const Map &map)
+SizedType *TypeResolver::get_map_type(const Map &map)
 {
   const std::string &map_ident = map.ident;
   auto search = map_val_.find(map_ident);
@@ -4235,7 +2814,7 @@ SizedType *SemanticAnalyser::get_map_type(const Map &map)
   return &search->second;
 }
 
-SizedType *SemanticAnalyser::get_map_key_type(const Map &map)
+SizedType *TypeResolver::get_map_key_type(const Map &map)
 {
   if (auto it = map_key_.find(map.ident); it != map_key_.end()) {
     return &it->second;
@@ -4246,10 +2825,10 @@ SizedType *SemanticAnalyser::get_map_key_type(const Map &map)
 // Semantic analysis for assigning a value of the provided type to the given
 // map. The type within the passes `Map` node will be updated to reflect the
 // new type, if available.
-void SemanticAnalyser::assign_map_type(Map &map,
-                                       const SizedType &type,
-                                       const Node *loc_node,
-                                       AssignMapStatement *assignment)
+void TypeResolver::assign_map_type(Map &map,
+                                   const SizedType &type,
+                                   const Node *loc_node,
+                                   AssignMapStatement *assignment)
 {
   const std::string &map_ident = map.ident;
 
@@ -4325,10 +2904,10 @@ void SemanticAnalyser::assign_map_type(Map &map,
     }
     if (type_mismatch_error) {
       if (is_final_pass()) {
-        loc_node->addError() << "Type mismatch for " << map_ident << ": "
-                             << "trying to assign value of type '" << type
-                             << "' when map already contains a value of type '"
-                             << storedTy << "'";
+        loc_node->addError()
+            << "Type mismatch for " << map_ident << ": "
+            << "trying to assign value of type '" << type
+            << "' when map already has a type '" << storedTy << "'";
       }
     } else {
       map.value_type = storedTy;
@@ -4341,8 +2920,7 @@ void SemanticAnalyser::assign_map_type(Map &map,
   }
 }
 
-SizedType SemanticAnalyser::create_key_type(const SizedType &expr_type,
-                                            Node &node)
+SizedType TypeResolver::create_key_type(const SizedType &expr_type, Node &node)
 {
   SizedType new_key_type = expr_type;
   if (expr_type.IsTupleTy()) {
@@ -4352,9 +2930,7 @@ SizedType SemanticAnalyser::create_key_type(const SizedType &expr_type,
       elements.push_back(std::move(keytype));
     }
     new_key_type = CreateTuple(Struct::CreateTuple(elements));
-  }
-
-  if (expr_type.IsRecordTy()) {
+  } else if (expr_type.IsRecordTy()) {
     std::vector<SizedType> elements;
     std::vector<std::string_view> names;
     for (const auto &field : expr_type.GetFields()) {
@@ -4365,24 +2941,10 @@ SizedType SemanticAnalyser::create_key_type(const SizedType &expr_type,
     new_key_type = CreateRecord(Struct::CreateRecord(elements, names));
   }
 
-  if (new_key_type.IsPtrTy() && new_key_type.IsCtxAccess()) {
-    // map functions only accepts a pointer to a element in the stack
-    node.addError() << "context cannot be part of a map key";
-  }
-
-  if (new_key_type.IsHistTy() || new_key_type.IsLhistTy() ||
-      new_key_type.IsStatsTy() || new_key_type.IsTSeriesTy()) {
-    node.addError() << new_key_type << " cannot be part of a map key";
-  }
-
-  if (is_final_pass() && new_key_type.IsNoneTy()) {
-    node.addError() << "Invalid map key type: " << new_key_type;
-  }
-
   return new_key_type;
 }
 
-std::optional<SizedType> SemanticAnalyser::get_promoted_int(
+std::optional<SizedType> TypeResolver::get_promoted_int(
     const SizedType &leftTy,
     const SizedType &rightTy,
     const std::optional<Expression> &leftExpr,
@@ -4445,7 +3007,7 @@ std::optional<SizedType> SemanticAnalyser::get_promoted_int(
   return CreateInteger(new_size * 8, leftSigned);
 }
 
-std::optional<SizedType> SemanticAnalyser::get_promoted_tuple(
+std::optional<SizedType> TypeResolver::get_promoted_tuple(
     const SizedType &leftTy,
     const SizedType &rightTy)
 {
@@ -4496,7 +3058,7 @@ std::optional<SizedType> SemanticAnalyser::get_promoted_tuple(
   return CreateTuple(Struct::CreateTuple(new_elems));
 }
 
-std::optional<SizedType> SemanticAnalyser::get_promoted_record(
+std::optional<SizedType> TypeResolver::get_promoted_record(
     const SizedType &storedTy,
     const SizedType &assignTy)
 {
@@ -4555,7 +3117,7 @@ std::optional<SizedType> SemanticAnalyser::get_promoted_record(
 // and map key/value adjustment we can't modify/cast the left
 // but in cases of binops or if expressions we can modify/cast both
 // the left and the right expressions
-std::optional<SizedType> SemanticAnalyser::update_int_type(
+std::optional<SizedType> TypeResolver::update_int_type(
     const SizedType &rightTy,
     Expression &rightExpr,
     const SizedType &leftTy,
@@ -4581,7 +3143,7 @@ std::optional<SizedType> SemanticAnalyser::update_int_type(
   return *updatedTy;
 }
 
-void SemanticAnalyser::resolve_struct_type(SizedType &type, Node &node)
+void TypeResolver::resolve_struct_type(SizedType &type, Node &node)
 {
   SizedType inner_type = type;
   int pointer_level = 0;
@@ -4615,24 +3177,7 @@ void SemanticAnalyser::resolve_struct_type(SizedType &type, Node &node)
   }
 }
 
-Pass CreateSemanticPass()
-{
-  auto fn = [](ASTContext &ast,
-               BPFtrace &b,
-               CDefinitions &c_definitions,
-               MapMetadata &mm,
-               NamedParamDefaults &named_param_defaults,
-               TypeMetadata &types,
-               MacroRegistry &macro_registry) {
-    SemanticAnalyser semantics(
-        ast, b, c_definitions, mm, named_param_defaults, types, macro_registry);
-    semantics.analyse();
-  };
-
-  return Pass::create("Semantic", fn);
-};
-
-variable *SemanticAnalyser::find_variable(const std::string &var_ident)
+variable *TypeResolver::find_variable(const std::string &var_ident)
 {
   if (auto *scope = find_variable_scope(var_ident)) {
     return &variables_[scope][var_ident];
@@ -4640,8 +3185,7 @@ variable *SemanticAnalyser::find_variable(const std::string &var_ident)
   return nullptr;
 }
 
-Node *SemanticAnalyser::find_variable_scope(const std::string &var_ident,
-                                            bool safe)
+Node *TypeResolver::find_variable_scope(const std::string &var_ident, bool safe)
 {
   for (auto *scope : scope_stack_) {
     if (auto search_val = variables_[scope].find(var_ident);
@@ -4654,5 +3198,22 @@ Node *SemanticAnalyser::find_variable_scope(const std::string &var_ident,
   }
   return nullptr;
 }
+
+Pass CreateTypeResolverPass()
+{
+  auto fn = [](ASTContext &ast,
+               BPFtrace &b,
+               CDefinitions &c_definitions,
+               MapMetadata &mm,
+               NamedParamDefaults &named_param_defaults,
+               TypeMetadata &types,
+               MacroRegistry &macro_registry) {
+    TypeResolver type_resolver(
+        ast, b, c_definitions, mm, named_param_defaults, types, macro_registry);
+    type_resolver.analyse();
+  };
+
+  return Pass::create("TypeResolver", fn);
+};
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/type_resolver.h
+++ b/src/ast/passes/type_resolver.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateTypeResolverPass();
+
+} // namespace bpftrace::ast

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -113,7 +113,7 @@ Result<> FormatString::check(const std::vector<SizedType>& args) const
     { "p", any_integer },
   };
   for (size_t i = 0; i < specs.size(); i++) {
-    if (args[i].IsNoneTy()) {
+    if (args[i].IsNoneTy() || args[i].IsVoidTy()) {
       err << "unable to print none type for specifier: " << specs[i].specifier;
       return make_error<FormatError>(err.str());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,8 @@
 #include "ast/passes/printer.h"
 #include "ast/passes/recursion_check.h"
 #include "ast/passes/resource_analyser.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_checker.h"
+#include "ast/passes/type_resolver.h"
 #include "ast/passes/type_system.h"
 #include "ast/passes/variable_precheck.h"
 #include "benchmark.h"
@@ -346,7 +347,8 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateVariablePreCheckPass());
-  add(ast::CreateSemanticPass());
+  add(ast::CreateTypeResolverPass());
+  add(ast::CreateTypeCheckerPass());
   add(ast::CreateResourcePass());
 }
 
@@ -356,7 +358,8 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateVariablePreCheckPass());
-  add(ast::CreateSemanticPass());
+  add(ast::CreateTypeResolverPass());
+  add(ast::CreateTypeCheckerPass());
   add(ast::CreateResourcePass());
 }
 
@@ -897,7 +900,7 @@ int main(int argc, char* argv[])
                         .add(CreateParseBTFPass())
                         .add(ast::CreateMapSugarPass())
                         .add(ast::CreateNamedParamsPass())
-                        .add(ast::CreateSemanticPass())
+                        .add(ast::CreateTypeCheckerPass())
                         .run();
 
     if (!pmresult) {
@@ -1034,7 +1037,7 @@ int main(int argc, char* argv[])
         .add(CreateParseBTFPass())
         .add(ast::CreateMapSugarPass())
         .add(ast::CreateNamedParamsPass())
-        .add(ast::CreateSemanticPass());
+        .add(ast::CreateTypeCheckerPass());
 
     auto pmresult = pm.run();
     if (!pmresult) {

--- a/src/types.h
+++ b/src/types.h
@@ -308,8 +308,7 @@ public:
     assert(IsIntTy());
     // Truncate integers too large to fit in BPF registers (64-bits).
     bits = std::min<size_t>(bits, 64);
-    // Zero sized integers are not usually valid. However, during semantic
-    // analysis when we're inferring types, the first pass may not have
+    // Zero sized integers are not usually valid. However, during type resolution the first pass may not have
     // enough information to figure out the exact size of the integer. Later
     // passes infer the exact size.
     assert(bits == 0 || bits == 1 || bits == 8 || bits == 16 || bits == 32 ||

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ add_executable(bpftrace_test
   result.cpp
   required_resources.cpp
   scopeguard.cpp
-  semantic_analyser.cpp
+  type_checker.cpp
   temp.cpp
   tracepoint_format_parser.cpp
   types.cpp

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -2,7 +2,7 @@
 #include "ast/passes/clang_build.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/parser.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_checker.h"
 #include "ast/passes/type_system.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
@@ -23,7 +23,7 @@ BpfBytecode codegen(const std::string &input)
                 .add(ast::CreateLLVMInitPass())
                 .add(ast::CreateClangBuildPass())
                 .add(ast::CreateTypeSystemPass())
-                .add(ast::CreateSemanticPass())
+                .add(ast::CreateTypeCheckerPass())
                 .add(ast::AllCompilePasses())
                 .run();
   if (!ok) {

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -12,7 +12,7 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_checker.h"
 #include "ast/passes/type_system.h"
 #include "bpfmap.h"
 #include "bpftrace.h"
@@ -75,7 +75,7 @@ static auto parse_probe(const std::string &str, BPFtrace &bpftrace)
                 .add(ast::CreateClangParsePass())
                 .add(ast::CreateMapSugarPass())
                 .add(ast::CreateNamedParamsPass())
-                .add(ast::CreateSemanticPass())
+                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreateLLVMInitPass())
                 .add(ast::CreateCompilePass())
                 .run();

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -144,7 +144,7 @@ TEST(macro_expansion, maps)
 
 TEST(macro_expansion, misc)
 {
-  // semantic_analyser will catch this undefined call/macro
+  // type_checker will catch this undefined call/macro
   test("macro add3(x) { x + add5(x) } begin { print(add3(1)); }");
 }
 

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -6,7 +6,8 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_checker.h"
+#include "ast/passes/type_resolver.h"
 #include "ast/passes/type_system.h"
 #include "btf_common.h"
 #include "driver.h"
@@ -42,7 +43,8 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
                 .add(ast::CreateMapSugarPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(ast::CreateNamedParamsPass())
-                .add(ast::CreateSemanticPass())
+                .add(ast::CreateTypeResolverPass())
+                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreatePortabilityPass())
                 .run();
   ASSERT_TRUE(bool(ok));

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -9,7 +9,7 @@
 #include "ast/passes/named_param.h"
 #include "ast/passes/resolve_imports.h"
 #include "ast/passes/resource_analyser.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_checker.h"
 #include "ast/passes/type_system.h"
 #include "bpftrace.h"
 #include "btf.h"
@@ -53,7 +53,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
                 .add(ast::CreateLLVMInitPass())
                 .add(ast::CreateClangBuildPass())
                 .add(ast::CreateTypeSystemPass())
-                .add(ast::CreateSemanticPass())
+                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreateResourcePass())
                 .add(ast::AllCompilePasses())
                 .run();

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -1,6 +1,7 @@
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/parser.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_checker.h"
+#include "ast/passes/type_resolver.h"
 #include "ast/passes/type_system.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
@@ -28,7 +29,8 @@ void test(BPFtrace &bpftrace,
                 .put(get_mock_function_info())
                 .put(no_types)
                 .add(ast::AllParsePasses())
-                .add(ast::CreateSemanticPass())
+                .add(ast::CreateTypeResolverPass())
+                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreateResourcePass())
                 .run();
   ASSERT_TRUE(bool(ok)) << msg.str();

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -18,7 +18,8 @@
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
 #include "ast/passes/resolve_imports.h"
-#include "ast/passes/semantic_analyser.h"
+#include "ast/passes/type_checker.h"
+#include "ast/passes/type_resolver.h"
 #include "ast/passes/type_system.h"
 #include "ast_matchers.h"
 #include "bpftrace.h"
@@ -27,7 +28,7 @@
 #include "mocks.h"
 #include "struct.h"
 
-namespace bpftrace::test::semantic_analyser {
+namespace bpftrace::test::type_checker {
 
 using bpftrace::test::AssignMapStatement;
 using bpftrace::test::AssignVarStatement;
@@ -108,7 +109,7 @@ std::string_view clean_prefix(std::string_view view)
 // This exists as a test fixture because the types may refer to `bpftrace`, so
 // this objects lifetime must exceed the tests lifetime. This is easier with a
 // fixture, and allows us to have a single harness.
-class SemanticAnalyserHarness {
+class TypeCheckerHarness {
 public:
   template <typename... Ts>
     requires((std::is_same_v<std::decay_t<Ts>, Mock> ||
@@ -173,7 +174,8 @@ public:
                   .add(ast::CreateCMacroExpansionPass())
                   .add(ast::CreateMapSugarPass())
                   .add(ast::CreateNamedParamsPass())
-                  .add(ast::CreateSemanticPass())
+                  .add(ast::CreateTypeResolverPass())
+                  .add(ast::CreateTypeCheckerPass())
                   .run();
     EXPECT_TRUE(bool(ok));
 
@@ -214,10 +216,9 @@ private:
   std::optional<ast::TypeMetadata> types_;
 };
 
-class SemanticAnalyserTest : public SemanticAnalyserHarness,
-                             public testing::Test {};
+class TypeCheckerTest : public TypeCheckerHarness, public testing::Test {};
 
-TEST_F(SemanticAnalyserTest, builtin_variables)
+TEST_F(TypeCheckerTest, builtin_variables)
 {
   // Just check that each one exists as a builtin or macro
   test("kprobe:f { pid }");
@@ -252,7 +253,7 @@ kprobe:f { fake }
   test("fentry:f { func }", NoFeatures::Enable, Error{});
 }
 
-TEST_F(SemanticAnalyserTest, builtin_functions)
+TEST_F(TypeCheckerTest, builtin_functions)
 {
   // Just check that each function exists.
   // Each function should also get its own test case for more thorough testing
@@ -296,7 +297,7 @@ TEST_F(SemanticAnalyserTest, builtin_functions)
   test("kprobe:f { tid() }");
 }
 
-TEST_F(SemanticAnalyserTest, undefined_map)
+TEST_F(TypeCheckerTest, undefined_map)
 {
   test("kprobe:f / @mymap == 123 / { @mymap = 0 }");
   test("kprobe:f / @mymap == 123 / { 456; }", Error{ R"(
@@ -321,19 +322,19 @@ kprobe:f { zero(@x); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, consistent_map_values)
+TEST_F(TypeCheckerTest, consistent_map_values)
 {
   test("kprobe:f { @x = 0; @x = 1; }");
   test(
       R"(begin { $a = (3, "hello"); @m[1] = $a; $a = (1,"aaaaaaaaaa"); @m[2] = $a; })");
   test("kprobe:f { @x = 0; @x = \"a\"; }", Error{ R"(
-stdin:1:20-28: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already contains a value of type 'uint8'
+stdin:1:20-28: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already has a type 'uint8'
 kprobe:f { @x = 0; @x = "a"; }
                    ~~~~~~~~
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, consistent_map_keys)
+TEST_F(TypeCheckerTest, consistent_map_keys)
 {
   test("begin { @x = 0; @x; }");
   test("begin { @x[1] = 0; @x[2]; }");
@@ -404,7 +405,7 @@ begin { @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0.0] = 2; } }
       R"(begin { $a = (3, (uint8)5); $b = (4, (uint64)1234); @map[$a] = 1; @map[$b] = 2; })");
 }
 
-TEST_F(SemanticAnalyserTest, if_statements)
+TEST_F(TypeCheckerTest, if_statements)
 {
   test("kprobe:f { if(true) { 123 } }");
   test("kprobe:f { if(false) { 123 } }");
@@ -414,7 +415,7 @@ TEST_F(SemanticAnalyserTest, if_statements)
   test("kprobe:f { if((int32)pid) { 123 } }");
 }
 
-TEST_F(SemanticAnalyserTest, predicate_expressions)
+TEST_F(TypeCheckerTest, predicate_expressions)
 {
   test("kprobe:f / 999 / { 123 }");
   test("kprobe:f / true / { 123 }");
@@ -431,7 +432,7 @@ kprobe:f / @mymap / { @mymap = "str" }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, ternary_expressions)
+TEST_F(TypeCheckerTest, ternary_expressions)
 {
   // There are some supported types left out of this list
   // as they don't make sense or cause other errors e.g.
@@ -486,7 +487,7 @@ TEST_F(SemanticAnalyserTest, ternary_expressions)
   // Error location is incorrect: #3063
   test("kprobe:f { $x = pid < 10000 ? 3 : cat(\"/proc/uptime\"); exit(); }",
        Error{ R"(
-stdin:1:17-54: ERROR: Branches must return the same type: have 'uint8' and 'none'
+stdin:1:17-54: ERROR: Branches must return the same type: have 'uint8' and 'void'
 kprobe:f { $x = pid < 10000 ? 3 : cat("/proc/uptime"); exit(); }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -522,88 +523,88 @@ kprobe:f { @x = pid < 10000 ? kstack(raw) : kstack(perf) }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, mismatched_call_types)
+TEST_F(TypeCheckerTest, mismatched_call_types)
 {
   test("kprobe:f { @x = 1; @x = count(); }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'count_t' when map already contains a value of type 'uint8'
+stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'count_t' when map already has a type 'uint8'
 kprobe:f { @x = 1; @x = count(); }
                         ~~~~~~~
 )" });
   test("kprobe:f { @x = count(); @x "
        "= sum(pid); }",
        Error{ R"(
-stdin:1:31-39: ERROR: Type mismatch for @x: trying to assign value of type 'usum_t' when map already contains a value of type 'count_t'
+stdin:1:31-39: ERROR: Type mismatch for @x: trying to assign value of type 'usum_t' when map already has a type 'count_t'
 kprobe:f { @x = count(); @x = sum(pid); }
                               ~~~~~~~~
 )" });
   test("kprobe:f { @x = 1; @x = hist(0); }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'hist_t' when map already contains a value of type 'uint8'
+stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'hist_t' when map already has a type 'uint8'
 kprobe:f { @x = 1; @x = hist(0); }
                         ~~~~~~~
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, compound_left)
+TEST_F(TypeCheckerTest, compound_left)
 {
   test("kprobe:f { $a = 0; $a <<= 1 }");
   test("kprobe:f { @a <<= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_right)
+TEST_F(TypeCheckerTest, compound_right)
 {
   test("kprobe:f { $a = 0; $a >>= 1 }");
   test("kprobe:f { @a >>= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_plus)
+TEST_F(TypeCheckerTest, compound_plus)
 {
   test("kprobe:f { $a = 0; $a += 1 }");
   test("kprobe:f { @a += 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_minus)
+TEST_F(TypeCheckerTest, compound_minus)
 {
   test("kprobe:f { $a = 0; $a -= 1 }");
   test("kprobe:f { @a -= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_mul)
+TEST_F(TypeCheckerTest, compound_mul)
 {
   test("kprobe:f { $a = 0; $a *= 1 }");
   test("kprobe:f { @a *= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_div)
+TEST_F(TypeCheckerTest, compound_div)
 {
   test("kprobe:f { $a = 0; $a /= 1 }");
   test("kprobe:f { @a /= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_mod)
+TEST_F(TypeCheckerTest, compound_mod)
 {
   test("kprobe:f { $a = 0; $a %= 1 }");
   test("kprobe:f { @a %= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_band)
+TEST_F(TypeCheckerTest, compound_band)
 {
   test("kprobe:f { $a = 0; $a &= 1 }");
   test("kprobe:f { @a &= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_bor)
+TEST_F(TypeCheckerTest, compound_bor)
 {
   test("kprobe:f { $a = 0; $a |= 1 }");
   test("kprobe:f { @a |= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, compound_bxor)
+TEST_F(TypeCheckerTest, compound_bxor)
 {
   test("kprobe:f { $a = 0; $a ^= 1 }");
   test("kprobe:f { @a ^= 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, call_hist)
+TEST_F(TypeCheckerTest, call_hist)
 {
   test("kprobe:f { @x = hist(1); }");
   test("kprobe:f { @x = hist(1, 0); }");
@@ -650,7 +651,7 @@ kprobe:f { hist() ? 0 : 1; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, call_lhist)
+TEST_F(TypeCheckerTest, call_lhist)
 {
   test("kprobe:f { @ = lhist(5, 0, 10, 1); "
        "}");
@@ -711,7 +712,7 @@ kprobe:f { lhist() ? 0 : 1; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, call_lhist_posparam)
+TEST_F(TypeCheckerTest, call_lhist_posparam)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->add_param("0");
@@ -722,7 +723,7 @@ TEST_F(SemanticAnalyserTest, call_lhist_posparam)
   test("kprobe:f { @ = lhist(5, $1, $2, $4); }", Mock{ *bpftrace }, Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_tseries)
+TEST_F(TypeCheckerTest, call_tseries)
 {
   test("kprobe:f { @ = tseries(5, 10s, 1); }");
   test("kprobe:f { @ = tseries(-5, 10s, 1); }");
@@ -815,7 +816,7 @@ kprobe:f { @ = tseries(1, 10s, 5, "stats"); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, call_tseries_posparam)
+TEST_F(TypeCheckerTest, call_tseries_posparam)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->add_param("10s");
@@ -824,7 +825,7 @@ TEST_F(SemanticAnalyserTest, call_tseries_posparam)
   test("kprobe:f { @ = tseries(5, $1, $2); }", Mock{ *bpftrace });
 }
 
-TEST_F(SemanticAnalyserTest, call_count)
+TEST_F(TypeCheckerTest, call_count)
 {
   test("kprobe:f { @x = count(); }");
   test("kprobe:f { @x = count(1); }", Error{});
@@ -835,7 +836,7 @@ TEST_F(SemanticAnalyserTest, call_count)
   test("kprobe:f { count() ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_sum)
+TEST_F(TypeCheckerTest, call_sum)
 {
   test("kprobe:f { @x = sum(123); }");
   test("kprobe:f { @x = sum(); }", Error{});
@@ -847,7 +848,7 @@ TEST_F(SemanticAnalyserTest, call_sum)
   test("kprobe:f { sum(1) ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_min)
+TEST_F(TypeCheckerTest, call_min)
 {
   test("kprobe:f { @x = min(123); }");
   test("kprobe:f { @x = min(); }", Error{});
@@ -858,7 +859,7 @@ TEST_F(SemanticAnalyserTest, call_min)
   test("kprobe:f { min(1) ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_max)
+TEST_F(TypeCheckerTest, call_max)
 {
   test("kprobe:f { @x = max(123); }");
   test("kprobe:f { @x = max(); }", Error{});
@@ -869,7 +870,7 @@ TEST_F(SemanticAnalyserTest, call_max)
   test("kprobe:f { max(1) ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_avg)
+TEST_F(TypeCheckerTest, call_avg)
 {
   test("kprobe:f { @x = avg(123); }");
   test("kprobe:f { @x = avg(); }", Error{});
@@ -880,7 +881,7 @@ TEST_F(SemanticAnalyserTest, call_avg)
   test("kprobe:f { avg(1) ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_stats)
+TEST_F(TypeCheckerTest, call_stats)
 {
   test("kprobe:f { @x = stats(123); }");
   test("kprobe:f { @x = stats(); }", Error{});
@@ -891,7 +892,7 @@ TEST_F(SemanticAnalyserTest, call_stats)
   test("kprobe:f { stats(1) ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_delete)
+TEST_F(TypeCheckerTest, call_delete)
 {
   ast::TypeMetadata types;
 
@@ -1018,7 +1019,7 @@ ERROR: Type mismatch for $$delete_$key: trying to assign value of type '(string[
   test("kprobe:f { @x = 1; delete(@x[1]); }", Error{}, Types{ types });
 }
 
-TEST_F(SemanticAnalyserTest, call_exit)
+TEST_F(TypeCheckerTest, call_exit)
 {
   test("kprobe:f { exit(); }");
   test("kprobe:f { exit(1); }");
@@ -1042,7 +1043,7 @@ kprobe:f { $a = "1"; exit($a); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, call_print)
+TEST_F(TypeCheckerTest, call_print)
 {
   test("kprobe:f { @x = count(); print(@x); }");
   test("kprobe:f { @x = count(); print(@x, 5); }");
@@ -1065,7 +1066,7 @@ TEST_F(SemanticAnalyserTest, call_print)
        Warning{ "top and div arguments are ignored" });
 }
 
-TEST_F(SemanticAnalyserTest, call_print_map_item)
+TEST_F(TypeCheckerTest, call_print_map_item)
 {
   test(R"_(begin { @x[1] = 1; print(@x[1]); })_");
   test(R"_(begin { @x[1] = 1; @x[2] = 2; print(@x[2]); })_");
@@ -1095,7 +1096,7 @@ begin { @x[1] = hist(10); print(@x[1]); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, call_print_non_map)
+TEST_F(TypeCheckerTest, call_print_non_map)
 {
   test(R"(begin { print(1) })");
   test(R"(begin { print(comm) })");
@@ -1114,7 +1115,7 @@ TEST_F(SemanticAnalyserTest, call_print_non_map)
   test(R"(begin { print(ctx) })", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_clear)
+TEST_F(TypeCheckerTest, call_clear)
 {
   test("kprobe:f { @x = count(); clear(@x); }");
   test("kprobe:f { @x = count(); clear(@x, 1); }", Error{});
@@ -1131,7 +1132,7 @@ TEST_F(SemanticAnalyserTest, call_clear)
   test("kprobe:f { @x = count(); clear(@x) ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_zero)
+TEST_F(TypeCheckerTest, call_zero)
 {
   test("kprobe:f { @x = count(); zero(@x); }");
   test("kprobe:f { @x = count(); zero(@x, 1); }", Error{});
@@ -1148,7 +1149,7 @@ TEST_F(SemanticAnalyserTest, call_zero)
   test("kprobe:f { @x = count(); zero(@x) ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_has_key)
+TEST_F(TypeCheckerTest, call_has_key)
 {
   ast::TypeMetadata types;
 
@@ -1235,7 +1236,7 @@ kprobe:f { @a[1] = 1; has_key(@a, @a); }
 }
 
 // N.B. find uses mostly the same implementation as has_key
-TEST_F(SemanticAnalyserTest, call_find)
+TEST_F(TypeCheckerTest, call_find)
 {
   ast::TypeMetadata types;
 
@@ -1320,7 +1321,7 @@ TEST_F(SemanticAnalyserTest, call_find)
        Types{ types });
 }
 
-TEST_F(SemanticAnalyserTest, call_time)
+TEST_F(TypeCheckerTest, call_time)
 {
   test("kprobe:f { time(); }");
   test("kprobe:f { time(\"%M:%S\"); }");
@@ -1334,7 +1335,7 @@ TEST_F(SemanticAnalyserTest, call_time)
   test("kprobe:f { time() ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_strftime)
+TEST_F(TypeCheckerTest, call_strftime)
 {
   test("kprobe:f { strftime(\"%M:%S\", 1); }");
   test("kprobe:f { strftime(\"%M:%S\", nsecs); }");
@@ -1358,7 +1359,7 @@ TEST_F(SemanticAnalyserTest, call_strftime)
   test("kprobe:f { strftime(\"%M:%S\", nsecs(tai)); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_str)
+TEST_F(TypeCheckerTest, call_str)
 {
   test("kprobe:f { str(arg0); }");
   test("kprobe:f { @x = str(arg0); }");
@@ -1366,7 +1367,7 @@ TEST_F(SemanticAnalyserTest, call_str)
   test("kprobe:f { str(\"hello\"); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_str_2_lit)
+TEST_F(TypeCheckerTest, call_str_2_lit)
 {
   test("kprobe:f { str(arg0, 3); }");
   test("kprobe:f { str(arg0, -3); }", Error{});
@@ -1386,13 +1387,13 @@ TEST_F(SemanticAnalyserTest, call_str_2_lit)
   EXPECT_EQ(CreateString(4), x->var()->var_type);
 }
 
-TEST_F(SemanticAnalyserTest, call_str_2_expr)
+TEST_F(TypeCheckerTest, call_str_2_expr)
 {
   test("kprobe:f { str(arg0, arg1); }");
   test("kprobe:f { @x = str(arg0, arg1); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_str_state_leak_regression_test)
+TEST_F(TypeCheckerTest, call_str_state_leak_regression_test)
 {
   // Previously, the semantic analyser would
   // leak state in the first str() call.
@@ -1404,7 +1405,7 @@ TEST_F(SemanticAnalyserTest, call_str_state_leak_regression_test)
   test(R"PROG(kprobe:f { $x = str($1) == "asdf"; $y = str(arg0, 1) })PROG");
 }
 
-TEST_F(SemanticAnalyserTest, call_buf)
+TEST_F(TypeCheckerTest, call_buf)
 {
   test("kprobe:f { buf(arg0, 1); }");
   test("kprobe:f { buf(arg0, -1); }", Error{});
@@ -1417,19 +1418,19 @@ TEST_F(SemanticAnalyserTest, call_buf)
        "buf($foo->c); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_buf_lit)
+TEST_F(TypeCheckerTest, call_buf_lit)
 {
   test("kprobe:f { @x = buf(arg0, 3); }");
   test("kprobe:f { buf(arg0, \"hello\"); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_buf_expr)
+TEST_F(TypeCheckerTest, call_buf_expr)
 {
   test("kprobe:f { buf(arg0, arg1); }");
   test("kprobe:f { @x = buf(arg0, arg1); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_buf_posparam)
+TEST_F(TypeCheckerTest, call_buf_posparam)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->add_param("1");
@@ -1438,7 +1439,7 @@ TEST_F(SemanticAnalyserTest, call_buf_posparam)
   test("kprobe:f { buf(arg0, $2); }", Mock{ *bpftrace }, Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_ksym)
+TEST_F(TypeCheckerTest, call_ksym)
 {
   test("kprobe:f { ksym(arg0); }");
   test("kprobe:f { @x = ksym(arg0); }");
@@ -1446,7 +1447,7 @@ TEST_F(SemanticAnalyserTest, call_ksym)
   test("kprobe:f { ksym(\"hello\"); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_usym)
+TEST_F(TypeCheckerTest, call_usym)
 {
   test("kprobe:f { usym(arg0); }");
   test("kprobe:f { @x = usym(arg0); }");
@@ -1454,7 +1455,7 @@ TEST_F(SemanticAnalyserTest, call_usym)
   test("kprobe:f { usym(\"hello\"); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_ntop)
+TEST_F(TypeCheckerTest, call_ntop)
 {
   std::string structs = "struct inet { unsigned char "
                         "ipv4[4]; unsigned char "
@@ -1481,7 +1482,7 @@ TEST_F(SemanticAnalyserTest, call_ntop)
   test(structs + "kprobe:f { ntop(((struct inet*)0)->invalid); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_pton)
+TEST_F(TypeCheckerTest, call_pton)
 {
   test("kprobe:f { $addr_v4 = pton(\"127.0.0.1\"); }");
   test("kprobe:f { $addr_v4 = pton(\"127.0.0.1\"); $b1 = $addr_v4[0]; }");
@@ -1509,7 +1510,7 @@ TEST_F(SemanticAnalyserTest, call_pton)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_kaddr)
+TEST_F(TypeCheckerTest, call_kaddr)
 {
   test("kprobe:f { kaddr(\"avenrun\"); }");
   test("kprobe:f { @x = kaddr(\"avenrun\"); }");
@@ -1517,7 +1518,7 @@ TEST_F(SemanticAnalyserTest, call_kaddr)
   test("kprobe:f { kaddr(123); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_uaddr)
+TEST_F(TypeCheckerTest, call_uaddr)
 {
   test("u:/bin/sh:main { "
        "__builtin_uaddr(\"github.com/golang/"
@@ -1570,7 +1571,7 @@ TEST_F(SemanticAnalyserTest, call_uaddr)
   }
 }
 
-TEST_F(SemanticAnalyserTest, call_cgroupid)
+TEST_F(TypeCheckerTest, call_cgroupid)
 {
   // Handle args above default max-string
   // length (64)
@@ -1583,13 +1584,13 @@ TEST_F(SemanticAnalyserTest, call_cgroupid)
        "); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_probe)
+TEST_F(TypeCheckerTest, call_probe)
 {
   test("kprobe:f { @[probe] = count(); }");
   test("kprobe:f { printf(\"%s\", probe); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_cat)
+TEST_F(TypeCheckerTest, call_cat)
 {
   test("kprobe:f { cat(\"/proc/loadavg\"); }");
   test("kprobe:f { cat(\"/proc/%d/cmdline\", 1); }");
@@ -1602,7 +1603,7 @@ TEST_F(SemanticAnalyserTest, call_cat)
   test("kprobe:f { cat(\"/proc/loadavg\") ? 0 : 1; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_stack)
+TEST_F(TypeCheckerTest, call_stack)
 {
   test("kprobe:f { kstack() }");
   test("kprobe:f { ustack() }");
@@ -1664,7 +1665,7 @@ TEST_F(SemanticAnalyserTest, call_stack)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_macaddr)
+TEST_F(TypeCheckerTest, call_macaddr)
 {
   std::string structs = "struct mac { char addr[6]; }; "
                         "struct invalid { char addr[4]; }; ";
@@ -1686,7 +1687,7 @@ TEST_F(SemanticAnalyserTest, call_macaddr)
   test("kprobe:f { macaddr(\"foo\"); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_bswap)
+TEST_F(TypeCheckerTest, call_bswap)
 {
   test("kprobe:f { bswap(arg0); }");
 
@@ -1704,7 +1705,7 @@ TEST_F(SemanticAnalyserTest, call_bswap)
   test("kprobe:f { bswap(\"hello\"); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_cgroup_path)
+TEST_F(TypeCheckerTest, call_cgroup_path)
 {
   test("kprobe:f { cgroup_path(1) }");
   test("kprobe:f { cgroup_path(1, \"hello\") }");
@@ -1719,13 +1720,13 @@ TEST_F(SemanticAnalyserTest, call_cgroup_path)
   test("kprobe:f { printf(\"%d\", cgroup_path(1)) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, map_reassignment)
+TEST_F(TypeCheckerTest, map_reassignment)
 {
   test("kprobe:f { @x = 1; @x = 2; }");
   test("kprobe:f { @x = 1; @x = \"foo\"; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, variable_reassignment)
+TEST_F(TypeCheckerTest, variable_reassignment)
 {
   test("kprobe:f { $x = 1; $x = 2; }");
   test("kprobe:f { $x = 1; $x = \"foo\"; }", Error{});
@@ -1739,25 +1740,25 @@ kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = 1; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, map_use_before_assign)
+TEST_F(TypeCheckerTest, map_use_before_assign)
 {
   test("kprobe:f { @x = @y; @y = 2; }");
   test("kprobe:f { @y = 0; @y = @x; @x = 1; }");
 }
 
-TEST_F(SemanticAnalyserTest, maps_are_global)
+TEST_F(TypeCheckerTest, maps_are_global)
 {
   test("kprobe:f { @x = 1 } kprobe:func_1 { @y = @x }");
   test("kprobe:f { @x = 1 } kprobe:func_1 { @x = \"abc\" }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, variables_are_local)
+TEST_F(TypeCheckerTest, variables_are_local)
 {
   test("kprobe:f { $x = 1 } kprobe:func_1 { $x = \"abc\"; }");
   test("kprobe:f { $x = 1 } kprobe:func_1 { @y = $x }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, array_access)
+TEST_F(TypeCheckerTest, array_access)
 {
   test("kprobe:f { $s = arg0; @x = $s->y[0];}", Error{});
   test("kprobe:f { $s = 0; @x = $s->y[0];}", Error{});
@@ -1835,7 +1836,7 @@ TEST_F(SemanticAnalyserTest, array_access)
        Mock{ *bpftrace });
 }
 
-TEST_F(SemanticAnalyserTest, array_in_map)
+TEST_F(TypeCheckerTest, array_in_map)
 {
   test("struct MyStruct { int x[2]; int y[4]; } "
        "kprobe:f { @ = ((struct MyStruct *)arg0)->x; }");
@@ -1855,7 +1856,7 @@ TEST_F(SemanticAnalyserTest, array_in_map)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, array_as_map_key)
+TEST_F(TypeCheckerTest, array_as_map_key)
 {
   test("struct MyStruct { int x[2]; int y[4]; }"
        "kprobe:f { @x[((struct MyStruct *)arg0)->x] = 0; }");
@@ -1871,7 +1872,7 @@ TEST_F(SemanticAnalyserTest, array_as_map_key)
     })");
 }
 
-TEST_F(SemanticAnalyserTest, array_compare)
+TEST_F(TypeCheckerTest, array_compare)
 {
   test("#include <stdint.h>\n"
        "struct MyStruct { uint8_t x[4]; }"
@@ -1904,7 +1905,7 @@ TEST_F(SemanticAnalyserTest, array_compare)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, variable_type)
+TEST_F(TypeCheckerTest, variable_type)
 {
   auto ast = test("kprobe:f { $x = 1 }");
   auto st = CreateUInt8();
@@ -1913,7 +1914,7 @@ TEST_F(SemanticAnalyserTest, variable_type)
   EXPECT_EQ(st, assignment->var()->var_type);
 }
 
-TEST_F(SemanticAnalyserTest, unroll)
+TEST_F(TypeCheckerTest, unroll)
 {
   test(R"(kprobe:f { $i = 0; unroll(5) { printf("%d", $i); $i = $i + 1; } })");
   test(R"(kprobe:f { $i = 0; unroll(101) { printf("%d", $i); $i = $i + 1; } })",
@@ -1935,7 +1936,7 @@ TEST_F(SemanticAnalyserTest, unroll)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, map_integer_sizes)
+TEST_F(TypeCheckerTest, map_integer_sizes)
 {
   auto ast = test("kprobe:f { $x = (int32) -1; @x = $x; }");
 
@@ -1947,7 +1948,7 @@ TEST_F(SemanticAnalyserTest, map_integer_sizes)
   EXPECT_EQ(CreateInt32(), map_assignment->map_access->map->value_type);
 }
 
-TEST_F(SemanticAnalyserTest, binop_tuple)
+TEST_F(TypeCheckerTest, binop_tuple)
 {
   ast::TypeMetadata types;
 
@@ -2019,7 +2020,7 @@ TEST_F(SemanticAnalyserTest, binop_tuple)
       Types{ types });
 }
 
-TEST_F(SemanticAnalyserTest, binop_array)
+TEST_F(TypeCheckerTest, binop_array)
 {
   // These are variables so they don't get folded
   test(
@@ -2039,7 +2040,7 @@ TEST_F(SemanticAnalyserTest, binop_array)
       Error{});
 }
 
-TEST_F(SemanticAnalyserTest, unop_dereference)
+TEST_F(TypeCheckerTest, unop_dereference)
 {
   test("kprobe:f { *0; }");
   test("struct X { int n; } kprobe:f { $x = (struct X*)0; *$x; }");
@@ -2048,7 +2049,7 @@ TEST_F(SemanticAnalyserTest, unop_dereference)
   test("kprobe:f { *true; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, unop_not)
+TEST_F(TypeCheckerTest, unop_not)
 {
   std::string structs = "struct X { int x; };";
   test("kprobe:f { ~0; }");
@@ -2058,7 +2059,7 @@ TEST_F(SemanticAnalyserTest, unop_not)
   test("kprobe:f { ~true; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, unop_lnot)
+TEST_F(TypeCheckerTest, unop_lnot)
 {
   test("kprobe:f { !0; }");
   test("kprobe:f { !false; }");
@@ -2068,7 +2069,7 @@ TEST_F(SemanticAnalyserTest, unop_lnot)
   test("kprobe:f { !\"0\"; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, unop_increment_decrement)
+TEST_F(TypeCheckerTest, unop_increment_decrement)
 {
   test("kprobe:f { $x = 0; $x++; }");
   test("kprobe:f { $x = 0; $x--; }");
@@ -2087,7 +2088,7 @@ TEST_F(SemanticAnalyserTest, unop_increment_decrement)
   test("kprobe:f { --true; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf_errorf_warnf)
+TEST_F(TypeCheckerTest, printf_errorf_warnf)
 {
   std::vector<std::string> funcs = { "printf", "errorf", "warnf" };
   for (const auto &func : funcs) {
@@ -2117,7 +2118,7 @@ TEST_F(SemanticAnalyserTest, printf_errorf_warnf)
   }
 }
 
-TEST_F(SemanticAnalyserTest, debugf)
+TEST_F(TypeCheckerTest, debugf)
 {
   test("kprobe:f { debugf(\"warning\") }",
        Warning{ "The debugf() builtin is not "
@@ -2147,7 +2148,7 @@ TEST_F(SemanticAnalyserTest, debugf)
   }
 }
 
-TEST_F(SemanticAnalyserTest, system)
+TEST_F(TypeCheckerTest, system)
 {
   test("kprobe:f { system(\"ls\") }", UnsafeMode::Enable);
   test("kprobe:f { system(1234) }", UnsafeMode::Enable, Error{});
@@ -2157,7 +2158,7 @@ TEST_F(SemanticAnalyserTest, system)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf_format_int)
+TEST_F(TypeCheckerTest, printf_format_int)
 {
   test("kprobe:f { printf(\"int: %d\", 1234) }");
   test("kprobe:f { printf(\"int: %d\", pid) }");
@@ -2170,7 +2171,7 @@ TEST_F(SemanticAnalyserTest, printf_format_int)
   test("kprobe:f { printf(\"int: %X\", 1234) }");
 }
 
-TEST_F(SemanticAnalyserTest, printf_format_int_with_length)
+TEST_F(TypeCheckerTest, printf_format_int_with_length)
 {
   test("kprobe:f { printf(\"int: %d\", 1234) }");
   test("kprobe:f { printf(\"int: %u\", 1234) }");
@@ -2229,7 +2230,7 @@ TEST_F(SemanticAnalyserTest, printf_format_int_with_length)
   test("kprobe:f { printf(\"int: %tp\", 1234) }");
 }
 
-TEST_F(SemanticAnalyserTest, printf_format_string)
+TEST_F(TypeCheckerTest, printf_format_string)
 {
   test(R"(kprobe:f { printf("str: %s", "mystr") })");
   test("kprobe:f { printf(\"str: %s\", comm) }");
@@ -2242,52 +2243,52 @@ TEST_F(SemanticAnalyserTest, printf_format_string)
   test("kprobe:f { printf(\"%s\", arg0) }");
 }
 
-TEST_F(SemanticAnalyserTest, printf_bad_format_string)
+TEST_F(TypeCheckerTest, printf_bad_format_string)
 {
   test(R"(kprobe:f { printf("%d", "mystr") })", Error{});
   test("kprobe:f { printf(\"%d\", str(arg0)) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf_format_buf)
+TEST_F(TypeCheckerTest, printf_format_buf)
 {
   test(R"(kprobe:f { printf("%r", buf("mystr", 5)) })");
 }
 
-TEST_F(SemanticAnalyserTest, printf_bad_format_buf)
+TEST_F(TypeCheckerTest, printf_bad_format_buf)
 {
   test(R"(kprobe:f { printf("%r", "mystr") })", Error{});
   test("kprobe:f { printf(\"%r\", arg0) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf_format_buf_no_ascii)
+TEST_F(TypeCheckerTest, printf_format_buf_no_ascii)
 {
   test(R"(kprobe:f { printf("%rx", buf("mystr", 5)) })");
 }
 
-TEST_F(SemanticAnalyserTest, printf_bad_format_buf_no_ascii)
+TEST_F(TypeCheckerTest, printf_bad_format_buf_no_ascii)
 {
   test(R"(kprobe:f { printf("%rx", "mystr") })", Error{});
   test("kprobe:f { printf(\"%rx\", arg0) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf_format_buf_nonescaped_hex)
+TEST_F(TypeCheckerTest, printf_format_buf_nonescaped_hex)
 {
   test(R"(kprobe:f { printf("%rh", buf("mystr", 5)) })");
 }
 
-TEST_F(SemanticAnalyserTest, printf_bad_format_buf_nonescaped_hex)
+TEST_F(TypeCheckerTest, printf_bad_format_buf_nonescaped_hex)
 {
   test(R"(kprobe:f { printf("%rh", "mystr") })", Error{});
   test("kprobe:f { printf(\"%rh\", arg0) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf_format_multi)
+TEST_F(TypeCheckerTest, printf_format_multi)
 {
   test(R"(kprobe:f { printf("%d %d %s", 1, 2, "mystr") })");
   test(R"(kprobe:f { printf("%d %s %d", 1, 2, "mystr") })", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, join)
+TEST_F(TypeCheckerTest, join)
 {
   test("kprobe:f { join(arg0) }");
   test("kprobe:f { printf(\"%s\", join(arg0)) }", Error{});
@@ -2297,7 +2298,7 @@ TEST_F(SemanticAnalyserTest, join)
   test("kprobe:f { $x = join(arg0) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, join_delimiter)
+TEST_F(TypeCheckerTest, join_delimiter)
 {
   test("kprobe:f { join(arg0, \",\") }");
   test(R"(kprobe:f { printf("%s", join(arg0, ",")) })", Error{});
@@ -2307,7 +2308,7 @@ TEST_F(SemanticAnalyserTest, join_delimiter)
   test("kprobe:f { join(arg0, 3) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, variable_cast_types)
+TEST_F(TypeCheckerTest, variable_cast_types)
 {
   std::string structs = "struct type1 { int field; } struct "
                         "type2 { int field; }";
@@ -2318,7 +2319,7 @@ TEST_F(SemanticAnalyserTest, variable_cast_types)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, map_cast_types)
+TEST_F(TypeCheckerTest, map_cast_types)
 {
   std::string structs = "struct type1 { int field; } struct "
                         "type2 { int field; }";
@@ -2329,7 +2330,7 @@ TEST_F(SemanticAnalyserTest, map_cast_types)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, map_aggregations_implicit_cast)
+TEST_F(TypeCheckerTest, map_aggregations_implicit_cast)
 {
   // When assigning an aggregation to a map
   // containing integers, the aggregation is
@@ -2461,13 +2462,13 @@ kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                                 ~
 )" });
   test("kprobe:f { @ = count(); @ += 5 }", Error{ R"(
-stdin:1:25-31: ERROR: Type mismatch for @: trying to assign value of type 'uint64' when map already contains a value of type 'count_t'
+stdin:1:25-31: ERROR: Type mismatch for @: trying to assign value of type 'uint64' when map already has a type 'count_t'
 kprobe:f { @ = count(); @ += 5 }
                         ~~~~~~
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, map_aggregations_explicit_cast)
+TEST_F(TypeCheckerTest, map_aggregations_explicit_cast)
 {
   test("kprobe:f { @ = count(); print((1, (uint16)@)); }");
   test("kprobe:f { @ = sum(5); print((1, (uint16)@)); }");
@@ -2482,7 +2483,7 @@ kprobe:f { @ = hist(5); print((1, (uint16)@)); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, variable_casts_are_local)
+TEST_F(TypeCheckerTest, variable_casts_are_local)
 {
   std::string structs = "struct type1 { int field; } struct "
                         "type2 { int field; }";
@@ -2490,7 +2491,7 @@ TEST_F(SemanticAnalyserTest, variable_casts_are_local)
                  "kprobe:func_1 { $x = *(struct type2 *)cpu; }");
 }
 
-TEST_F(SemanticAnalyserTest, map_casts_are_global)
+TEST_F(TypeCheckerTest, map_casts_are_global)
 {
   std::string structs = "struct type1 { int field; } struct "
                         "type2 { int field; }";
@@ -2499,7 +2500,7 @@ TEST_F(SemanticAnalyserTest, map_casts_are_global)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, cast_unknown_type)
+TEST_F(TypeCheckerTest, cast_unknown_type)
 {
   test("begin { (struct faketype *)cpu }", Error{ R"(
 stdin:1:10-27: ERROR: Cannot resolve unknown type "struct faketype"
@@ -2510,13 +2511,10 @@ begin { (struct faketype *)cpu }
 stdin:1:10-18: ERROR: Cannot resolve unknown type "faketype"
 begin { (faketype)cpu }
          ~~~~~~~~
-stdin:1:9-19: ERROR: Cannot cast from "uint64" to "faketype"
-begin { (faketype)cpu }
-        ~~~~~~~~~~
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, cast_struct)
+TEST_F(TypeCheckerTest, cast_struct)
 {
   // Casting struct by value is forbidden
   test("struct mytype { int field; }\n"
@@ -2535,7 +2533,7 @@ struct mytype { int field; } begin { (struct mytype)cpu }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, cast_bool)
+TEST_F(TypeCheckerTest, cast_bool)
 {
   test("kprobe:f { $a = (bool)1; }");
   test("kprobe:f { $a = (bool)\"str\"; }");
@@ -2556,7 +2554,7 @@ kprobe:f { $a = (bool)pton("127.0.0.1"); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, cast_string)
+TEST_F(TypeCheckerTest, cast_string)
 {
   test("kprobe:f { $a = (string[10])\"hello\"; }");
 
@@ -2565,14 +2563,14 @@ TEST_F(SemanticAnalyserTest, cast_string)
   test("kprobe:f { $a = (string)5; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, field_access)
+TEST_F(TypeCheckerTest, field_access)
 {
   std::string structs = "struct type1 { int field; }";
   test(structs + "kprobe:f { $x = *(struct type1*)cpu; $x.field }");
   test(structs + "kprobe:f { @x = *(struct type1*)cpu; @x.field }");
 }
 
-TEST_F(SemanticAnalyserTest, field_access_wrong_field)
+TEST_F(TypeCheckerTest, field_access_wrong_field)
 {
   std::string structs = "struct type1 { int field; }";
   test(structs + "kprobe:f { ((struct type1 *)cpu)->blah }", Error{});
@@ -2580,13 +2578,13 @@ TEST_F(SemanticAnalyserTest, field_access_wrong_field)
   test(structs + "kprobe:f { @x = (struct type1 *)cpu; @x->blah }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, field_access_wrong_expr)
+TEST_F(TypeCheckerTest, field_access_wrong_expr)
 {
   std::string structs = "struct type1 { int field; }";
   test(structs + "kprobe:f { 1234->field }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, field_access_types)
+TEST_F(TypeCheckerTest, field_access_types)
 {
   std::string structs = "struct type1 { int field; char mystr[8]; }"
                         "struct type2 { int field; }";
@@ -2605,7 +2603,7 @@ TEST_F(SemanticAnalyserTest, field_access_types)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, field_access_pointer)
+TEST_F(TypeCheckerTest, field_access_pointer)
 {
   std::string structs = "struct type1 { int field; }";
   test(structs + "kprobe:f { ((struct type1*)0)->field }");
@@ -2613,7 +2611,7 @@ TEST_F(SemanticAnalyserTest, field_access_pointer)
   test(structs + "kprobe:f { *((struct type1*)0) }");
 }
 
-TEST_F(SemanticAnalyserTest, field_access_sub_struct)
+TEST_F(TypeCheckerTest, field_access_sub_struct)
 {
   std::string structs =
       "struct type2 { int field; } "
@@ -2631,7 +2629,7 @@ TEST_F(SemanticAnalyserTest, field_access_sub_struct)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, field_access_is_internal)
+TEST_F(TypeCheckerTest, field_access_is_internal)
 {
   BPFtrace bpftrace;
   std::string structs = "struct type1 { int x; }";
@@ -2654,7 +2652,7 @@ TEST_F(SemanticAnalyserTest, field_access_is_internal)
   }
 }
 
-TEST_F(SemanticAnalyserTest, struct_as_map_key)
+TEST_F(TypeCheckerTest, struct_as_map_key)
 {
   test("struct A { int x; } struct B { char x; } "
        "kprobe:f { @x[*((struct A *)arg0)] = 0; }");
@@ -2676,7 +2674,7 @@ stdin:4:12-13: ERROR: Argument mismatch for @x: trying to access with arguments:
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, per_cpu_map_as_map_key)
+TEST_F(TypeCheckerTest, per_cpu_map_as_map_key)
 {
   test("begin { @x = count(); @y[@x] = 1; }");
   test("begin { @x = sum(10); @y[@x] = 1; }");
@@ -2709,7 +2707,7 @@ begin { @x = stats(10); @y[@x] = 1; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, probe_short_name)
+TEST_F(TypeCheckerTest, probe_short_name)
 {
   test("t:sched:sched_one { 1 }");
   test("k:f { pid }");
@@ -2722,7 +2720,7 @@ TEST_F(SemanticAnalyserTest, probe_short_name)
   test("i:s:1 { 1 }");
 }
 
-TEST_F(SemanticAnalyserTest, positional_parameters)
+TEST_F(TypeCheckerTest, positional_parameters)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->add_param("123");
@@ -2760,14 +2758,14 @@ TEST_F(SemanticAnalyserTest, positional_parameters)
   test("kprobe:f { printf(\"%d\", $4); }", Mock{ *bpftrace }, Error{});
 }
 
-TEST_F(SemanticAnalyserTest, c_macros)
+TEST_F(TypeCheckerTest, c_macros)
 {
   test("#define A 1\nkprobe:f { printf(\"%d\", A); }");
   test("#define A A\nkprobe:f { printf(\"%d\", A); }", Error{});
   test("enum { A = 1 }\n#define A A\nkprobe:f { printf(\"%d\", A); }");
 }
 
-TEST_F(SemanticAnalyserTest, enums)
+TEST_F(TypeCheckerTest, enums)
 {
   // Anonymous enums have empty string names in libclang <= 15,
   // so this is an important test
@@ -2782,7 +2780,7 @@ TEST_F(SemanticAnalyserTest, enums)
   test("enum named { a = 1, b } kprobe:f { printf(\"%15s %-15s\", a, a); }");
 }
 
-TEST_F(SemanticAnalyserTest, enum_casts)
+TEST_F(TypeCheckerTest, enum_casts)
 {
   test("enum named { a = 1, b } kprobe:f { print((enum named)1); }");
   // We can't detect this issue because the cast expr is not a literal
@@ -2809,7 +2807,7 @@ enum named { a = 1, b } kprobe:f { $a = "str"; print((enum named)$a); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, signed_int_comparison_warnings)
+TEST_F(TypeCheckerTest, signed_int_comparison_warnings)
 {
   std::string cmp_sign = "comparison of integers of different signs";
   test("kretprobe:f /-1 < retval/ {}", Warning{ cmp_sign });
@@ -2832,7 +2830,7 @@ TEST_F(SemanticAnalyserTest, signed_int_comparison_warnings)
   test("kretprobe:f /retval < 1/ {}", NoWarning{ cmp_sign });
 }
 
-TEST_F(SemanticAnalyserTest, string_comparison)
+TEST_F(TypeCheckerTest, string_comparison)
 {
   test("struct MyStruct {char y[4]; } "
        "kprobe:f { $s = (struct MyStruct*)arg0; $s->y == \"abc\"}");
@@ -2850,7 +2848,7 @@ TEST_F(SemanticAnalyserTest, string_comparison)
        NoWarning{ msg });
 }
 
-TEST_F(SemanticAnalyserTest, string_index)
+TEST_F(TypeCheckerTest, string_index)
 {
   // String indexing produces an 8-bit signed integer.
   test("kprobe:f { $x = \"foo\"; $x[0] == 102; }");
@@ -2865,7 +2863,7 @@ kprobe:f { $x = "foo"; printf("%c is the fifth letter", $x[4]); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, signed_int_arithmetic_warnings)
+TEST_F(TypeCheckerTest, signed_int_arithmetic_warnings)
 {
   // Test type warnings for arithmetic
   std::string msg = "arithmetic on integers of different signs";
@@ -2881,7 +2879,7 @@ TEST_F(SemanticAnalyserTest, signed_int_arithmetic_warnings)
   test("kprobe:f { @ = arg0 / 1 }", NoWarning{ msg });
 }
 
-TEST_F(SemanticAnalyserTest, signed_int_division_warnings)
+TEST_F(TypeCheckerTest, signed_int_division_warnings)
 {
   std::string msg = "signed operands";
   test("kprobe:f { @x = -1; @y = @x / 1 }", Warning{ msg });
@@ -2895,7 +2893,7 @@ TEST_F(SemanticAnalyserTest, signed_int_division_warnings)
   test("kprobe:f { @x = (uint64)1; @y = -(@x / 1) }", NoWarning{ msg });
 }
 
-TEST_F(SemanticAnalyserTest, signed_int_modulo_warnings)
+TEST_F(TypeCheckerTest, signed_int_modulo_warnings)
 {
   std::string msg = "signed operands";
   test("kprobe:f { @x = -1; @y = @x % 1 }", Warning{ msg });
@@ -2906,14 +2904,14 @@ TEST_F(SemanticAnalyserTest, signed_int_modulo_warnings)
   test("kprobe:f { @x = (uint64)1; @y = -(@x % 1) }", NoWarning{ msg });
 }
 
-TEST_F(SemanticAnalyserTest, map_as_lookup_table)
+TEST_F(TypeCheckerTest, map_as_lookup_table)
 {
   // Initializing a map should not lead to usage issues
   test("begin { @[0] = \"abc\"; @[1] = \"def\" } "
        "kretprobe:f { printf(\"%s\\n\", @[(int64)retval])}");
 }
 
-TEST_F(SemanticAnalyserTest, cast_sign)
+TEST_F(TypeCheckerTest, cast_sign)
 {
   // The C struct parser should set the is_signed flag on signed types
   std::string prog = "struct t { int s; unsigned int us; "
@@ -2938,7 +2936,7 @@ TEST_F(SemanticAnalyserTest, cast_sign)
   EXPECT_EQ(CreateUInt64(), ul->var()->var_type);
 }
 
-TEST_F(SemanticAnalyserTest, binop_bool_and_int)
+TEST_F(TypeCheckerTest, binop_bool_and_int)
 {
   std::string operators[] = {
     "==", "!=", "<", "<=", ">",  ">=", "&&", "||", "+",
@@ -2958,7 +2956,7 @@ TEST_F(SemanticAnalyserTest, binop_bool_and_int)
   }
 }
 
-TEST_F(SemanticAnalyserTest, binop_arithmetic)
+TEST_F(TypeCheckerTest, binop_arithmetic)
 {
   // Make sure types are correct
   std::string prog_pre = "struct t { long l; unsigned long ul }; "
@@ -3008,7 +3006,7 @@ TEST_F(SemanticAnalyserTest, binop_arithmetic)
   }
 }
 
-TEST_F(SemanticAnalyserTest, binop_compare)
+TEST_F(TypeCheckerTest, binop_compare)
 {
   std::string prog_pre = "struct t { long l }; "
                          "kprobe:f { $t = ((struct t *)0xFF); ";
@@ -3048,7 +3046,7 @@ TEST_F(SemanticAnalyserTest, binop_compare)
   }
 }
 
-TEST_F(SemanticAnalyserTest, int_cast_types)
+TEST_F(TypeCheckerTest, int_cast_types)
 {
   test("kretprobe:f { @ = (int8)retval }");
   test("kretprobe:f { @ = (int16)retval }");
@@ -3060,7 +3058,7 @@ TEST_F(SemanticAnalyserTest, int_cast_types)
   test("kretprobe:f { @ = (uint64)retval }");
 }
 
-TEST_F(SemanticAnalyserTest, int_cast_usage)
+TEST_F(TypeCheckerTest, int_cast_usage)
 {
   test("kretprobe:f /(int32) retval < 0/ {}");
   test("kprobe:f /(int32) arg0 < 0/ {}");
@@ -3071,7 +3069,7 @@ TEST_F(SemanticAnalyserTest, int_cast_usage)
   test("kprobe:f { @=avg((int32)\"abc\") }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, intptr_cast_types)
+TEST_F(TypeCheckerTest, intptr_cast_types)
 {
   test("kretprobe:f { @ = *(int8*)retval }");
   test("kretprobe:f { @ = *(int16*)retval }");
@@ -3083,7 +3081,7 @@ TEST_F(SemanticAnalyserTest, intptr_cast_types)
   test("kretprobe:f { @ = *(uint64*)retval }");
 }
 
-TEST_F(SemanticAnalyserTest, intptr_cast_usage)
+TEST_F(TypeCheckerTest, intptr_cast_usage)
 {
   test("kretprobe:f /(*(int32*) retval) < 0/ {}");
   test("kprobe:f /(*(int32*) arg0) < 0/ {}");
@@ -3096,7 +3094,7 @@ TEST_F(SemanticAnalyserTest, intptr_cast_usage)
   test("kprobe:f { @=avg(*(int32*)123) }");
 }
 
-TEST_F(SemanticAnalyserTest, intarray_cast_types)
+TEST_F(TypeCheckerTest, intarray_cast_types)
 {
   test("kprobe:f { @ = (int8[8])1 }");
   test("kprobe:f { @ = (int8[4])1 }");
@@ -3119,7 +3117,7 @@ TEST_F(SemanticAnalyserTest, intarray_cast_types)
   test("struct Foo { int x; } kprobe:f { @ = (struct Foo [2])1 }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, bool_array_cast_types)
+TEST_F(TypeCheckerTest, bool_array_cast_types)
 {
   test("kprobe:f { @ = (bool[8])1 }");
   test("kprobe:f { @ = (bool[4])1 }");
@@ -3129,7 +3127,7 @@ TEST_F(SemanticAnalyserTest, bool_array_cast_types)
   test("kprobe:f { @ = (bool[64])1 }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, intarray_cast_usage)
+TEST_F(TypeCheckerTest, intarray_cast_usage)
 {
   test("kprobe:f { $a=(int8[8])1; }");
   test("kprobe:f { @=(int8[8])1; }");
@@ -3137,7 +3135,7 @@ TEST_F(SemanticAnalyserTest, intarray_cast_usage)
   test("kprobe:f { if (((int8[8])1)[0] == 1) {} }");
 }
 
-TEST_F(SemanticAnalyserTest, intarray_to_int_cast)
+TEST_F(TypeCheckerTest, intarray_to_int_cast)
 {
   test("#include <stdint.h>\n"
        "struct Foo { uint8_t x[8]; } "
@@ -3160,7 +3158,7 @@ TEST_F(SemanticAnalyserTest, intarray_to_int_cast)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, mixed_int_var_assignments)
+TEST_F(TypeCheckerTest, mixed_int_var_assignments)
 {
   test("kprobe:f { $x = (uint64)0; $x = (uint16)1; }");
   test("kprobe:f { $x = (int8)1; $x = 5; }");
@@ -3207,7 +3205,7 @@ kprobe:f { $x = -1; $x = 10223372036854775807; }
              Jump(ast::JumpType::RETURN) })) });
 }
 
-TEST_F(SemanticAnalyserTest, mixed_int_like_map_assignments)
+TEST_F(TypeCheckerTest, mixed_int_like_map_assignments)
 {
   test("kprobe:f { @x = (uint64)0; @x = (uint16)1; }");
   test("kprobe:f { @x = (int8)1; @x = 5; }");
@@ -3232,33 +3230,33 @@ TEST_F(SemanticAnalyserTest, mixed_int_like_map_assignments)
   test("kprobe:f { @x = stats((uint32)1); @x = stats(-1); }");
 
   test("kprobe:f { @x = sum((uint64)1); @x = sum(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
 kprobe:f { @x = sum((uint64)1); @x = sum(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = min((uint64)1); @x = min(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
 kprobe:f { @x = min((uint64)1); @x = min(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = max((uint64)1); @x = max(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
 kprobe:f { @x = max((uint64)1); @x = max(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = avg((uint64)1); @x = avg(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
 kprobe:f { @x = avg((uint64)1); @x = avg(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = stats((uint64)1); @x = stats(-1); }", Error{ R"(
-stdin:1:40-49: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
+stdin:1:40-49: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
 kprobe:f { @x = stats((uint64)1); @x = stats(-1); }
                                        ~~~~~~~~~
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, mixed_int_map_access)
+TEST_F(TypeCheckerTest, mixed_int_map_access)
 {
   test("kprobe:f { @x[1] = 1; @x[(int16)2] }");
   test("kprobe:f { @x[-1] = 1; @x[1] }");
@@ -3289,7 +3287,7 @@ ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when 
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, mixed_int_like_binop)
+TEST_F(TypeCheckerTest, mixed_int_like_binop)
 {
   test("kprobe:f { $a = 1 == -1; }", NoWarning{ "comparison of integers" });
   test("kprobe:f { $a = 1 == (int64)-1; }",
@@ -3370,7 +3368,7 @@ TEST_F(SemanticAnalyserTest, mixed_int_like_binop)
              Jump(ast::JumpType::RETURN) })) });
 }
 
-TEST_F(SemanticAnalyserTest, signal)
+TEST_F(TypeCheckerTest, signal)
 {
   ast::TypeMetadata types;
 
@@ -3497,7 +3495,7 @@ TEST_F(SemanticAnalyserTest, signal)
   }
 }
 
-TEST_F(SemanticAnalyserTest, strncmp)
+TEST_F(TypeCheckerTest, strncmp)
 {
   // Test strncmp builtin
   test(R"(i:s:1 { $a = "bar"; strncmp("foo", $a, 1) })");
@@ -3509,7 +3507,7 @@ TEST_F(SemanticAnalyserTest, strncmp)
   test(R"(i:s:1 { strncmp("a","a","foo") })", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, strncmp_posparam)
+TEST_F(TypeCheckerTest, strncmp_posparam)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->add_param("1");
@@ -3518,7 +3516,7 @@ TEST_F(SemanticAnalyserTest, strncmp_posparam)
   test(R"(i:s:1 { strncmp("foo", "bar", $2) })", Mock{ *bpftrace }, Error{});
 }
 
-TEST_F(SemanticAnalyserTest, override)
+TEST_F(TypeCheckerTest, override)
 {
   ast::TypeMetadata types;
 
@@ -3560,7 +3558,7 @@ TEST_F(SemanticAnalyserTest, override)
   test("p:hz:1 { override(-1); }", UnsafeMode::Enable, Error{}, Types{ types });
 }
 
-TEST_F(SemanticAnalyserTest, unwatch)
+TEST_F(TypeCheckerTest, unwatch)
 {
   test("i:s:1 { unwatch(12345) }");
   test("i:s:1 { unwatch(0x1234) }");
@@ -3575,7 +3573,7 @@ TEST_F(SemanticAnalyserTest, unwatch)
   test("i:s:1 { printf(\"%d\", unwatch(2)) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, struct_member_keywords)
+TEST_F(TypeCheckerTest, struct_member_keywords)
 {
   // These are valid builtins / existing keywords in scripts, and we ensure that
   // these are not parsed in that way and are instead treated as fields.
@@ -3591,7 +3589,7 @@ TEST_F(SemanticAnalyserTest, struct_member_keywords)
   }
 }
 
-TEST_F(SemanticAnalyserTest, jumps)
+TEST_F(TypeCheckerTest, jumps)
 {
   test("i:s:1 { return; }");
   // must be used in loops
@@ -3599,7 +3597,7 @@ TEST_F(SemanticAnalyserTest, jumps)
   test("i:s:1 { continue; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, while_loop)
+TEST_F(TypeCheckerTest, while_loop)
 {
   test("i:s:1 { $a = 1; while ($a < 10) { $a++ }}");
   test("i:s:1 { $a = 1; while (1) { if($a > 50) { break } $a++ }}");
@@ -3628,7 +3626,7 @@ i:s:1 {
        Warning{ "Unreachable" });
 }
 
-TEST_F(SemanticAnalyserTest, type_ctx)
+TEST_F(TypeCheckerTest, type_ctx)
 {
   std::string structs = "struct c {char c} struct x { long a; short b[4]; "
                         "struct c c; struct c *d;}";
@@ -3700,7 +3698,7 @@ TEST_F(SemanticAnalyserTest, type_ctx)
   test("t:sched:sched_one { @ = (uint64)ctx; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, double_pointer_basic)
+TEST_F(TypeCheckerTest, double_pointer_basic)
 {
   test(R"_(begin { $pp = (int8 **)0; $p = *$pp; $val = *$p; })_");
   test(R"_(begin { $pp = (int8 **)0; $val = **$pp; })_");
@@ -3709,7 +3707,7 @@ TEST_F(SemanticAnalyserTest, double_pointer_basic)
   test(structs + R"_(begin { $pp = (struct Foo **)0; $val = (*$pp)->x; })_");
 }
 
-TEST_F(SemanticAnalyserTest, double_pointer_int)
+TEST_F(TypeCheckerTest, double_pointer_int)
 {
   auto ast = test("kprobe:f { $pp = (int8 **)1; $p = *$pp; $val = *$p; }");
   auto &stmts = ast.root->probes.at(0)->block->stmts;
@@ -3738,7 +3736,7 @@ TEST_F(SemanticAnalyserTest, double_pointer_int)
   EXPECT_EQ(assignment->var()->var_type.GetIntBitWidth(), 8ULL);
 }
 
-TEST_F(SemanticAnalyserTest, double_pointer_struct)
+TEST_F(TypeCheckerTest, double_pointer_struct)
 {
   auto ast = test(
       "struct Foo { char x; long y; }"
@@ -3766,7 +3764,7 @@ TEST_F(SemanticAnalyserTest, double_pointer_struct)
   EXPECT_EQ(assignment->var()->var_type.GetIntBitWidth(), 8ULL);
 }
 
-TEST_F(SemanticAnalyserTest, pointer_arith)
+TEST_F(TypeCheckerTest, pointer_arith)
 {
   test(R"(begin { $t = (int32*) 32; $t = $t + 1 })");
   test(R"(begin { $t = (int32*) 32; $t +=1 })");
@@ -3818,7 +3816,7 @@ TEST_F(SemanticAnalyserTest, pointer_arith)
       Error{});
 }
 
-TEST_F(SemanticAnalyserTest, pointer_compare)
+TEST_F(TypeCheckerTest, pointer_compare)
 {
   test(R"(begin { $t = (int32*) 32; $c = $t < 1 })");
   test(R"(begin { $t = (int32*) 32; $c = $t > 1 })");
@@ -3844,7 +3842,7 @@ TEST_F(SemanticAnalyserTest, pointer_compare)
 }
 
 // Basic functionality test
-TEST_F(SemanticAnalyserTest, tuple)
+TEST_F(TypeCheckerTest, tuple)
 {
   test(R"(begin { $t = (1)})");
   test(R"(begin { $t = (1, 2); $v = $t;})");
@@ -3891,7 +3889,7 @@ begin { @x[1] = hist(10); $y = (1, @x[1]); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, tuple_indexing)
+TEST_F(TypeCheckerTest, tuple_indexing)
 {
   test(R"(begin { (1,2).0 })");
   test(R"(begin { (1,2).1 })");
@@ -3904,7 +3902,7 @@ TEST_F(SemanticAnalyserTest, tuple_indexing)
 }
 
 // More in depth inspection of AST
-TEST_F(SemanticAnalyserTest, tuple_assign_var)
+TEST_F(TypeCheckerTest, tuple_assign_var)
 {
   class SizedType ty = CreateTuple(
       Struct::CreateTuple({ CreateUInt8(), CreateString(6) }));
@@ -3921,7 +3919,7 @@ TEST_F(SemanticAnalyserTest, tuple_assign_var)
 }
 
 // More in depth inspection of AST
-TEST_F(SemanticAnalyserTest, tuple_assign_map)
+TEST_F(TypeCheckerTest, tuple_assign_map)
 {
   auto ast = test(R"(begin { @ = (1, 3, 3, 7); @ = (0, 0, 0, 0); })");
   auto &stmts = ast.root->probes.at(0)->block->stmts;
@@ -3940,7 +3938,7 @@ TEST_F(SemanticAnalyserTest, tuple_assign_map)
 }
 
 // More in depth inspection of AST
-TEST_F(SemanticAnalyserTest, tuple_nested)
+TEST_F(TypeCheckerTest, tuple_nested)
 {
   class SizedType ty_inner = CreateTuple(
       Struct::CreateTuple({ CreateUInt8(), CreateUInt8() }));
@@ -3954,7 +3952,7 @@ TEST_F(SemanticAnalyserTest, tuple_nested)
   EXPECT_EQ(ty, assignment->var()->var_type);
 }
 
-TEST_F(SemanticAnalyserTest, mixed_tuple)
+TEST_F(TypeCheckerTest, mixed_tuple)
 {
   // The same resizing rules should exist for ints and strings inside tuples
   test(R"(begin { $a = ((int16)1, "hi"); $a = ((uint16)2, "hellostr"); })");
@@ -4098,7 +4096,7 @@ TEST_F(SemanticAnalyserTest, mixed_tuple)
                 Jump(ast::JumpType::RETURN) })) })) });
 }
 
-TEST_F(SemanticAnalyserTest, multi_pass_type_inference_zero_size_int)
+TEST_F(TypeCheckerTest, multi_pass_type_inference_zero_size_int)
 {
   // The first pass on processing the Unop
   // does not have enough information to
@@ -4109,7 +4107,7 @@ TEST_F(SemanticAnalyserTest, multi_pass_type_inference_zero_size_int)
   test("begin { if (!@i) { @i++; } }");
 }
 
-TEST_F(SemanticAnalyserTest, call_kptr_uptr)
+TEST_F(TypeCheckerTest, call_kptr_uptr)
 {
   test("k:f { @  = kptr((int8*) arg0); }");
   test("k:f { $a = kptr((int8*) arg0); }");
@@ -4124,7 +4122,7 @@ TEST_F(SemanticAnalyserTest, call_kptr_uptr)
   test("k:f { $a = uptr(arg0); }");
 }
 
-TEST_F(SemanticAnalyserTest, call_path)
+TEST_F(TypeCheckerTest, call_path)
 {
   test("kprobe:f { $k = path( arg0 ) }", Error{});
   test("kretprobe:f { $k = path( arg0 ) }", Error{});
@@ -4137,7 +4135,7 @@ TEST_F(SemanticAnalyserTest, call_path)
   test("end { $k = path( 1 ) }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, call_offsetof)
+TEST_F(TypeCheckerTest, call_offsetof)
 {
   test("struct Foo { int x; long l; char c; } \
         begin { @x = offsetof(struct Foo, x); }");
@@ -4208,12 +4206,12 @@ struct Foo { struct Bar { int a; } bar; }               begin { @x = offsetof(st
   test("begin { @x = offsetof(struct __notexiststruct__, x.y.z); }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, int_ident)
+TEST_F(TypeCheckerTest, int_ident)
 {
   test("begin { sizeof(int32) }");
 }
 
-TEST_F(SemanticAnalyserTest, string_size)
+TEST_F(TypeCheckerTest, string_size)
 {
   // Size of the variable should be the size of the larger string (incl. null)
   auto ast = test(R"(begin { $x = "hi"; $x = "hello"; })");
@@ -4263,7 +4261,7 @@ TEST_F(SemanticAnalyserTest, string_size)
   ASSERT_EQ(var_assign->var()->var_type.GetField(0).type.GetSize(), 6UL);
 }
 
-TEST_F(SemanticAnalyserTest, call_nsecs)
+TEST_F(TypeCheckerTest, call_nsecs)
 {
   test("begin { $ns = nsecs(); }");
   test("begin { $ns = nsecs(monotonic); }");
@@ -4277,7 +4275,7 @@ begin { $ns = nsecs(xxx); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, call_pid_tid)
+TEST_F(TypeCheckerTest, call_pid_tid)
 {
   test("begin { $i = tid(); }");
   test("begin { $i = pid(); }");
@@ -4297,7 +4295,7 @@ begin { $i = tid(1); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, subprog_return)
+TEST_F(TypeCheckerTest, subprog_return)
 {
   test("fn f(): void { return; }");
   test("fn f(): uint8 { return 1; }");
@@ -4316,7 +4314,7 @@ fn f(): int64 { return; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, subprog_arguments)
+TEST_F(TypeCheckerTest, subprog_arguments)
 {
   test("fn f($a : int64): int64 { return $a; }");
   // Error location is incorrect: #3063
@@ -4327,7 +4325,7 @@ fn f($a : int64): string { return $a; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, subprog_map)
+TEST_F(TypeCheckerTest, subprog_map)
 {
   test("fn f(): void { @a = 0; }");
   test("fn f(): uint64 { @a = 0; return @a + 1; }");
@@ -4335,14 +4333,14 @@ TEST_F(SemanticAnalyserTest, subprog_map)
   test("fn f(): uint64 { @a[0] = 0; return @a[0] + 1; }");
 }
 
-TEST_F(SemanticAnalyserTest, subprog_builtin)
+TEST_F(TypeCheckerTest, subprog_builtin)
 {
   test("fn f(): void { print(\"Hello world\"); }");
   test("fn f(): uint8 { return sizeof(int64); }");
   test("fn f(): uint64 { return nsecs; }");
 }
 
-TEST_F(SemanticAnalyserTest, subprog_builtin_disallowed)
+TEST_F(TypeCheckerTest, subprog_builtin_disallowed)
 {
   // Error location is incorrect: #3063
   test("fn f(): int64 { return func; }", Error{ R"(
@@ -4350,10 +4348,9 @@ ERROR: Builtin __builtin_func not supported outside probe
 )" });
 }
 
-class SemanticAnalyserBTFTest : public SemanticAnalyserHarness,
-                                public test_btf {};
+class TypeCheckerBTFTest : public TypeCheckerHarness, public test_btf {};
 
-TEST_F(SemanticAnalyserBTFTest, fentry)
+TEST_F(TypeCheckerBTFTest, fentry)
 {
   test("fentry:func_1 { 1 }");
   test("fexit:func_1 { 1 }");
@@ -4374,13 +4371,13 @@ fexit:func_1 { $x = args.foo; }
   test("fentry:func_1 { $x = args->a; }");
 }
 
-TEST_F(SemanticAnalyserBTFTest, short_name)
+TEST_F(TypeCheckerBTFTest, short_name)
 {
   test("f:func_1 { 1 }");
   test("fr:func_1 { 1 }");
 }
 
-TEST_F(SemanticAnalyserBTFTest, call_path)
+TEST_F(TypeCheckerBTFTest, call_path)
 {
   test("fentry:func_1 { @k = path( args.foo1 ) }");
   test("fexit:func_1 { @k = path( retval->foo1 ) }");
@@ -4389,7 +4386,7 @@ TEST_F(SemanticAnalyserBTFTest, call_path)
   test("fentry:func_1 { path(args.foo1, -1); }", Error{});
 }
 
-TEST_F(SemanticAnalyserBTFTest, call_skb_output)
+TEST_F(TypeCheckerBTFTest, call_skb_output)
 {
   test("fentry:func_1 { $ret = skboutput(\"one.pcap\", args.foo1, 1500, 0); "
        "}");
@@ -4427,7 +4424,7 @@ kprobe:func_1 { $ret = skboutput("one.pcap", arg1, 1500, 0); }
 )" });
 }
 
-TEST_F(SemanticAnalyserBTFTest, call_percpu_kaddr)
+TEST_F(TypeCheckerBTFTest, call_percpu_kaddr)
 {
   test("kprobe:f { percpu_kaddr(\"process_counts\"); }");
   test("kprobe:f { percpu_kaddr(\"process_counts\", 0); }");
@@ -4445,7 +4442,7 @@ kprobe:f { percpu_kaddr("nonsense"); }
 )" });
 }
 
-TEST_F(SemanticAnalyserBTFTest, call_socket_cookie)
+TEST_F(TypeCheckerBTFTest, call_socket_cookie)
 {
   test("fentry:tcp_shutdown { $ret = socket_cookie(args.sk); }");
   test("fexit:tcp_shutdown { $ret = socket_cookie(args.sk); }");
@@ -4456,7 +4453,7 @@ fentry:tcp_shutdown { $ret = socket_cookie(); }
                              ~~~~~~~~~~~~~~~
 )" });
   test("fentry:tcp_shutdown { $ret = socket_cookie(args.how); }", Error{ R"(
-stdin:1:30-53: ERROR: socket_cookie() only supports 'struct sock *' as the argument (int provided)
+stdin:1:30-53: ERROR: socket_cookie() only supports pointer arguments (int provided)
 fentry:tcp_shutdown { $ret = socket_cookie(args.how); }
                              ~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -4473,7 +4470,7 @@ kprobe:tcp_shutdown { $ret = socket_cookie((struct sock *)arg0); }
 )" });
 }
 
-TEST_F(SemanticAnalyserBTFTest, rawtracepoint)
+TEST_F(TypeCheckerBTFTest, rawtracepoint)
 {
   test("rawtracepoint:event_rt { args.first_real_arg }");
 
@@ -4485,7 +4482,7 @@ rawtracepoint:event_rt { args.bad_arg }
 }
 
 // Sanity check for kfunc/kretfunc aliases
-TEST_F(SemanticAnalyserBTFTest, kfunc)
+TEST_F(TypeCheckerBTFTest, kfunc)
 {
   test("kfunc:func_1 { 1 }");
   test("kretfunc:func_1 { 1 }");
@@ -4507,12 +4504,12 @@ kretfunc:func_1 { $x = args.foo; }
   test("kfunc:func_1 { $x = args->a; }");
 }
 
-TEST_F(SemanticAnalyserBTFTest, ntop)
+TEST_F(TypeCheckerBTFTest, ntop)
 {
   test(R"(fentry:func_arrays { printf("%s\n", ntop(args.arr.char_arr2)); })");
 }
 
-TEST_F(SemanticAnalyserTest, btf_type_tags)
+TEST_F(TypeCheckerTest, btf_type_tags)
 {
   auto bpftrace = get_mock_bpftrace();
   auto type = bpftrace->structs.Add("struct Foo", 16);
@@ -4535,7 +4532,7 @@ kprobe:f { ((struct Foo *)arg0)->field_with_bad_tag }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map_one_key)
+TEST_F(TypeCheckerTest, for_loop_map_one_key)
 {
   test("begin { @map[0] = 1; for ($kv : @map) { print($kv); } }",
        ExpectedAST{ Program().WithProbe(
@@ -4549,7 +4546,7 @@ TEST_F(SemanticAnalyserTest, for_loop_map_one_key)
                    Jump(ast::JumpType::RETURN) })) });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map_two_keys)
+TEST_F(TypeCheckerTest, for_loop_map_two_keys)
 {
   test("begin { @map[0,0] = 1; for ($kv : @map) { print($kv); } }",
        ExpectedAST{ Program().WithProbe(Probe(
@@ -4564,7 +4561,7 @@ TEST_F(SemanticAnalyserTest, for_loop_map_two_keys)
              Jump(ast::JumpType::RETURN) })) });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map)
+TEST_F(TypeCheckerTest, for_loop_map)
 {
   test("begin { @map[0] = 1; for ($kv : @map) { print($kv); } }");
   test("begin { @map[0] = 1; for ($kv : @map) { print($kv.0); } }");
@@ -4572,7 +4569,7 @@ TEST_F(SemanticAnalyserTest, for_loop_map)
   test("begin {@map1[@map2] = 1; @map2 = 1; for ($kv : @map1) {print($kv);}}");
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map_declared_after)
+TEST_F(TypeCheckerTest, for_loop_map_declared_after)
 {
   // Regression test: What happens with
   // @map[$kv.0] when @map hasn't been
@@ -4580,7 +4577,7 @@ TEST_F(SemanticAnalyserTest, for_loop_map_declared_after)
   test("begin { for ($kv : @map) { @map[$kv.0] } @map[0] = 1; }");
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map_no_key)
+TEST_F(TypeCheckerTest, for_loop_map_no_key)
 {
   // Error location is incorrect: #3063
   test("begin { @map = 1; for ($kv : @map) { } }", Error{ R"(
@@ -4590,7 +4587,7 @@ begin { @map = 1; for ($kv : @map) { } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map_undefined)
+TEST_F(TypeCheckerTest, for_loop_map_undefined)
 {
   // Error location is incorrect: #3063
   test("begin { for ($kv : @map) { } }", Error{ R"(
@@ -4600,7 +4597,7 @@ begin { for ($kv : @map) { } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map_undefined2)
+TEST_F(TypeCheckerTest, for_loop_map_undefined2)
 {
   // Error location is incorrect: #3063
   test("begin { @map[0] = 1; for ($kv : @undef) { @map[$kv.0]; } }", Error{ R"(
@@ -4610,7 +4607,7 @@ begin { @map[0] = 1; for ($kv : @undef) { @map[$kv.0]; } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_map_restricted_types)
+TEST_F(TypeCheckerTest, for_loop_map_restricted_types)
 {
   test("begin { @map[0] = hist(10); for ($kv : @map) { } }", Error{ R"(
 stdin:1:40-44: ERROR: Loop expression does not support type: hist_t
@@ -4636,7 +4633,7 @@ begin { @map[0] = stats(10); for ($kv : @map) { } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_variables_read_only)
+TEST_F(TypeCheckerTest, for_loop_variables_read_only)
 {
   test(
       R"(
@@ -4670,7 +4667,7 @@ TEST_F(SemanticAnalyserTest, for_loop_variables_read_only)
           })) });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_variables_modified_during_loop)
+TEST_F(TypeCheckerTest, for_loop_variables_modified_during_loop)
 {
   test(
       R"(
@@ -4705,7 +4702,7 @@ TEST_F(SemanticAnalyserTest, for_loop_variables_modified_during_loop)
           })) });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_variables_created_in_loop)
+TEST_F(TypeCheckerTest, for_loop_variables_created_in_loop)
 {
   test(R"(
     begin {
@@ -4729,7 +4726,7 @@ TEST_F(SemanticAnalyserTest, for_loop_variables_created_in_loop)
              Jump(ast::JumpType::RETURN) })) });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_variables_multiple)
+TEST_F(TypeCheckerTest, for_loop_variables_multiple)
 {
   test(
       R"(
@@ -4768,7 +4765,7 @@ TEST_F(SemanticAnalyserTest, for_loop_variables_multiple)
             Jump(ast::JumpType::RETURN) })) });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_invalid_expr)
+TEST_F(TypeCheckerTest, for_loop_invalid_expr)
 {
   // Error location is incorrect: #3063
   test("begin { for ($x : $var) { } }", Error{ R"(
@@ -4788,14 +4785,14 @@ begin { for ($x : "abc") { } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_control_flow)
+TEST_F(TypeCheckerTest, for_loop_control_flow)
 {
   test("begin { @map[0] = 1; for ($kv : @map) { break; } }");
   test("begin { @map[0] = 1; for ($kv : @map) { continue; } }");
   test("begin { @map[0] = 1; for ($kv : @map) { return; } }");
 }
 
-TEST_F(SemanticAnalyserTest, for_range_loop)
+TEST_F(TypeCheckerTest, for_range_loop)
 {
   // These are all technically valid,
   // although they may result in zero
@@ -4815,20 +4812,20 @@ TEST_F(SemanticAnalyserTest, for_range_loop)
   test(R"(begin { for ($i : ((int8)0)..((int8)5)) { printf("%d\n", $i); } })");
 }
 
-TEST_F(SemanticAnalyserTest, for_range_nested)
+TEST_F(TypeCheckerTest, for_range_nested)
 {
   test("begin { for ($i : 0..5) { "
        "for ($j : 0..$i) { printf(\"%d %d\\n\", $i, $j); } "
        "} }");
 }
 
-TEST_F(SemanticAnalyserTest, for_range_variable_use)
+TEST_F(TypeCheckerTest, for_range_variable_use)
 {
   test("begin { for ($i : 0..5) { @[$i] = "
        "$i * 2; } }");
 }
 
-TEST_F(SemanticAnalyserTest, for_range_invalid_types)
+TEST_F(TypeCheckerTest, for_range_invalid_types)
 {
   test(R"(begin { for ($i : "str"..5) { printf("%d", $i); } })", Error{ R"(
 stdin:1:23-27: ERROR: Loop range requires an integer for the start value
@@ -4843,23 +4840,20 @@ begin { for ($i : 0.."str") { printf("%d", $i); } }
 )" });
 
   test(R"(begin { for ($i : 0.0..5) { printf("%d", $i); } })", Error{ R"(
-stdin:1:21-22: ERROR: Can not access index '0' on expression of type 'uint8'
-begin { for ($i : 0.0..5) { printf("%d", $i); } }
-                    ~
 stdin:1:19-25: ERROR: Loop range requires an integer for the start value
 begin { for ($i : 0.0..5) { printf("%d", $i); } }
                   ~~~~~~
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_range_control_flow)
+TEST_F(TypeCheckerTest, for_range_control_flow)
 {
   test("begin { for ($i : 0..5) { break; } }");
   test("begin { for ($i : 0..5) { continue; } }");
   test("begin { for ($i : 0..5) { return; } }");
 }
 
-TEST_F(SemanticAnalyserTest, for_range_context_access)
+TEST_F(TypeCheckerTest, for_range_context_access)
 {
   test("kprobe:f { for ($i : 0..5) { arg0 } }", Error{ R"(
 stdin:1:30-34: ERROR: 'arg0' builtin is not allowed in a for-loop
@@ -4868,14 +4862,14 @@ kprobe:f { for ($i : 0..5) { arg0 } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_range_nested_range)
+TEST_F(TypeCheckerTest, for_range_nested_range)
 {
   test("begin { for ($i : 0..5) { for ($j : 0..$i) { "
        "printf(\"%d %d\\n\", $i, $j); "
        "} } }");
 }
 
-TEST_F(SemanticAnalyserTest, castable_map_missing_feature)
+TEST_F(TypeCheckerTest, castable_map_missing_feature)
 {
   test("k:f {  @a = count(); }", NoFeatures::Enable);
   test("k:f {  @a = count(); print(@a) }", NoFeatures::Enable);
@@ -4917,7 +4911,7 @@ begin { @a = count(); @b = 1; @b = @a; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_no_ctx_access)
+TEST_F(TypeCheckerTest, for_loop_no_ctx_access)
 {
   test("kprobe:f { @map[0] = 1; for ($kv : @map) { ctx } }", Error{ R"(
 stdin:1:44-47: ERROR: 'ctx' builtin is not allowed in a for-loop
@@ -4926,17 +4920,17 @@ kprobe:f { @map[0] = 1; for ($kv : @map) { ctx } }
 )" });
 }
 
-TEST_F(SemanticAnalyserBTFTest, args_builtin_mixed_probes)
+TEST_F(TypeCheckerBTFTest, args_builtin_mixed_probes)
 {
   test("fentry:func_1,rawtracepoint:event_rt { args }");
 }
 
-TEST_F(SemanticAnalyserBTFTest, binop_late_ptr_resolution)
+TEST_F(TypeCheckerBTFTest, binop_late_ptr_resolution)
 {
   test(R"(fentry:func_1 { if (@a[1] == args.foo1) { } @a[1] = args.foo1; })");
 }
 
-TEST_F(SemanticAnalyserBTFTest, anon_struct_resolution)
+TEST_F(TypeCheckerBTFTest, anon_struct_resolution)
 {
   test("fentry:func_anon_struct {\n"
        "  @a1 = args.AnonStruct.AnonTypedefArray[0].a;\n"
@@ -4948,7 +4942,7 @@ TEST_F(SemanticAnalyserBTFTest, anon_struct_resolution)
        "}");
 }
 
-TEST_F(SemanticAnalyserTest, buf_strlen_too_large)
+TEST_F(TypeCheckerTest, buf_strlen_too_large)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->config_->max_strlen = 9999999999;
@@ -4966,7 +4960,7 @@ uprobe:/bin/sh:f { buf(arg0) }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, variable_declarations)
+TEST_F(TypeCheckerTest, variable_declarations)
 {
   test("begin { let $a; $a = 1; }");
   test("begin { let $a: int16; $a = 1; }");
@@ -5043,7 +5037,7 @@ begin { $x = 2; if (pid) { let $x; } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, variable_address)
+TEST_F(TypeCheckerTest, variable_address)
 {
   test("begin { $a = 1; $b = &$a; @c = &$a; }");
 
@@ -5061,7 +5055,7 @@ begin { let $a; $b = &$a; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, map_address)
+TEST_F(TypeCheckerTest, map_address)
 {
   test("begin { @a = 1; @b[1] = 2; $x = &@a; $y = &@b; }");
 
@@ -5072,7 +5066,7 @@ begin { $x = &@a; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, block_scoping)
+TEST_F(TypeCheckerTest, block_scoping)
 {
   // if/else
   test("begin { $a = 1; if (pid) { $b = 2; "
@@ -5170,7 +5164,7 @@ TEST_F(SemanticAnalyserTest, block_scoping)
     })");
 }
 
-TEST_F(SemanticAnalyserTest, invalid_assignment)
+TEST_F(TypeCheckerTest, invalid_assignment)
 {
   test("begin { @a = hist(10); let $b = @a; }", Error{ R"(
 stdin:1:24-35: ERROR: Value 'hist_t' cannot be assigned to a scratch variable.
@@ -5220,7 +5214,7 @@ begin { @a = stats(10); @b = @a; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, no_maximum_passes)
+TEST_F(TypeCheckerTest, no_maximum_passes)
 {
   test("interval:s:1 { @j = @i; @i = @h; @h "
        "= @g; @g = @f; @f = @e; @e = @d; "
@@ -5229,7 +5223,7 @@ TEST_F(SemanticAnalyserTest, no_maximum_passes)
        "@a = 1; }");
 }
 
-TEST_F(SemanticAnalyserTest, block_expressions)
+TEST_F(TypeCheckerTest, block_expressions)
 {
   // Good, variable is not shadowed
   test("begin { let $x = { let $x = 1; $x }; print($x) }",
@@ -5246,7 +5240,7 @@ TEST_F(SemanticAnalyserTest, block_expressions)
            })) });
 }
 
-TEST_F(SemanticAnalyserTest, map_declarations)
+TEST_F(TypeCheckerTest, map_declarations)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->config_->unstable_map_decl = ConfigUnstable::enable;
@@ -5301,7 +5295,7 @@ HINT: Valid map types: percpulruhash, percpuhash, lruhash, hash
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, macros)
+TEST_F(TypeCheckerTest, macros)
 {
   auto bpftrace = get_mock_bpftrace();
 
@@ -5339,7 +5333,7 @@ macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, warning_for_empty_positional_parameters)
+TEST_F(TypeCheckerTest, warning_for_empty_positional_parameters)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->add_param("1");
@@ -5348,7 +5342,7 @@ TEST_F(SemanticAnalyserTest, warning_for_empty_positional_parameters)
        Mock{ *bpftrace });
 }
 
-TEST_F(SemanticAnalyserTest, warning_for_discared_expression_statement_value)
+TEST_F(TypeCheckerTest, warning_for_discared_expression_statement_value)
 {
   // Non exhaustive testing, just a few examples
   test("k:f { bswap(arg0); }", Warning{ "Return value discarded" });
@@ -5360,10 +5354,12 @@ TEST_F(SemanticAnalyserTest, warning_for_discared_expression_statement_value)
   test("k:f { _ = { 1 } }", NoWarning{ "Return value discarded" });
   test("k:f { print(1); }", NoWarning{ "Return value discarded" });
   test("k:f { $a = 1; }", NoWarning{ "Return value discarded" });
+  test("k:f { $a = 1; ++$a }", NoWarning{ "Return value discarded" });
+  test("k:f { $a = 1; $a++ }", NoWarning{ "Return value discarded" });
   test("k:f { @a[1] = count(); }", NoWarning{ "Return value discarded" });
 }
 
-TEST_F(SemanticAnalyserTest, external_function)
+TEST_F(TypeCheckerTest, external_function)
 {
   ast::TypeMetadata types;
 
@@ -5415,7 +5411,7 @@ kprobe:f { $x = (int32*)0; $x = foo((int32)1, (int64)2); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, printf_str_conversion)
+TEST_F(TypeCheckerTest, printf_str_conversion)
 {
   // %s just uses the default text output representation, and therefore can
   // print any type that can be serialized.
@@ -5425,7 +5421,7 @@ TEST_F(SemanticAnalyserTest, printf_str_conversion)
   test(R"(kprobe:f { $x = "foo"; printf("%s", $x) })");
 }
 
-TEST_F(SemanticAnalyserTest, fail)
+TEST_F(TypeCheckerTest, fail)
 {
   test(R"(kprobe:f { fail("always fail"); })", Error{ R"(
 stdin:1:12-31: ERROR: always fail
@@ -5448,7 +5444,7 @@ kprobe:f { if (false) { fail("always false"); } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, typeof_decls)
+TEST_F(TypeCheckerTest, typeof_decls)
 {
   test("kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = 2; }");
   test(R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = "bar"; })");
@@ -5496,7 +5492,7 @@ kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; }
   test(R"(kprobe:f { let $x; let $y : typeof($x); $y = "bar"; $x = "foo"; })");
 }
 
-TEST_F(SemanticAnalyserTest, typeof_subprog)
+TEST_F(TypeCheckerTest, typeof_subprog)
 {
   // Basic subprogram arguments can be defined relatively.
   test("fn foo($x : int64, $y : typeof($x)) : int8 { return 0; }");
@@ -5506,7 +5502,7 @@ TEST_F(SemanticAnalyserTest, typeof_subprog)
   test("fn foo($x : typeof($y), $y : int64) : typeof($x) { return 0; }");
 }
 
-TEST_F(SemanticAnalyserTest, typeof_casts)
+TEST_F(TypeCheckerTest, typeof_casts)
 {
   test(R"(kprobe:f { $x = (uint8)1; $y = (typeof($x))10; })");
   test(R"(kprobe:f { $x = (void*)0; $y = (typeof($x))1; })");
@@ -5535,7 +5531,7 @@ struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, if_comptime)
+TEST_F(TypeCheckerTest, if_comptime)
 {
   test(R"(kprobe:f { @a = 1; if (comptime false) { @a[1] = 1; } })");
   test(R"(kprobe:f { @a[1] = 1; if (comptime false) { @a = 1; } })");
@@ -5554,7 +5550,7 @@ kprobe:f { @a = 1; if comptime (@a > 1) { print(1); } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, comptime)
+TEST_F(TypeCheckerTest, comptime)
 {
   test(R"(begin { comptime (1 + 1) })");
   test(R"(begin { $x = 1; comptime (sizeof($x)) })");
@@ -5574,7 +5570,7 @@ begin { @x = 0; comptime (@x + 1) }
   test(R"(begin { @x[1] = 1; comptime (@x[1] + 1) })", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, typeinfo_if_comptime)
+TEST_F(TypeCheckerTest, typeinfo_if_comptime)
 {
   // We should be able to selectively analyze specific branches. Only the
   // correct type branch will be chosen, and we will not encounted a type
@@ -5594,7 +5590,7 @@ kprobe:f { $x = 1; if comptime (typeinfo($x) == typeinfo(1)) { fail("no integers
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, no_meta_used_warnings)
+TEST_F(TypeCheckerTest, no_meta_used_warnings)
 {
   test("begin { let $a; print(sizeof($a)); $a = 1; }",
        NoWarning{ "Variable used" });
@@ -5607,7 +5603,7 @@ TEST_F(SemanticAnalyserTest, no_meta_used_warnings)
        NoWarning{ "Variable used" });
 }
 
-TEST_F(SemanticAnalyserTest, no_meta_map_assignments)
+TEST_F(TypeCheckerTest, no_meta_map_assignments)
 {
   test("begin { let $b : typeof({ @a = 1; 1 }); }", Error{});
   test("begin { $b = typeinfo({ @a = 1; 1 }); }", Error{});
@@ -5617,7 +5613,7 @@ TEST_F(SemanticAnalyserTest, no_meta_map_assignments)
        Error{});
 }
 
-TEST_F(SemanticAnalyserTest, probe_return)
+TEST_F(TypeCheckerTest, probe_return)
 {
   test("begin { return 1; }");
   test("begin { $a = 1; return $a; }");
@@ -5635,7 +5631,7 @@ TEST_F(SemanticAnalyserTest, probe_return)
   test("begin { return \"tomato\"; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, record)
+TEST_F(TypeCheckerTest, record)
 {
   // Variables
   test(R"(begin { $t = (a=1)})");
@@ -5712,7 +5708,7 @@ begin { @x[1] = hist(10); $y = (a=1, b=@x[1]); }
   test(R"(begin { $t = (a=1, b=2); $t = (x=3, y=4); })", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, record_field_access)
+TEST_F(TypeCheckerTest, record_field_access)
 {
   test(R"(begin { (a=1,b=2).a })");
   test(R"(begin { (a=1,b=2).b })");
@@ -5723,7 +5719,7 @@ TEST_F(SemanticAnalyserTest, record_field_access)
   test(R"(begin { (a=1,b=2).c })", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, record_assign_var)
+TEST_F(TypeCheckerTest, record_assign_var)
 {
   class SizedType ty = CreateRecord(
       Struct::CreateRecord({ CreateUInt8(), CreateString(6) }, { "a", "b" }));
@@ -5742,7 +5738,7 @@ TEST_F(SemanticAnalyserTest, record_assign_var)
   EXPECT_EQ("a", assignment->expr.as<ast::Record>()->elems[1]->name);
 }
 
-TEST_F(SemanticAnalyserTest, record_mixed_types)
+TEST_F(TypeCheckerTest, record_mixed_types)
 {
   // The same resizing rules should exist for ints, strings, and tuples inside
   // records
@@ -5889,4 +5885,4 @@ TEST_F(SemanticAnalyserTest, record_mixed_types)
             Jump(ast::JumpType::RETURN) })) });
 }
 
-} // namespace bpftrace::test::semantic_analyser
+} // namespace bpftrace::test::type_checker


### PR DESCRIPTION
Stacked PRs:
 * __->__#4963


--- --- ---

### Split semantic_analyser


Create two separate passes:
- TypeResolver
- TypeChecker

TypeResolver attempts to resolve all
unresolved types but defers errors, when possible,
to the TypeChecker. This includes mismatches
when calling external/internal functions.

This is refactor is to reduce the size
and complexity of semantic_analyser and
create passes with more specific jobs.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>