### PR TITLE
Avoid C++ static_assert(false) failure with old GCC

### DIFF
--- a/tests/async_action.cpp
+++ b/tests/async_action.cpp
@@ -32,6 +32,10 @@ public:
   AsyncHandlers handlers;
 };
 
+// Workaround for type-dependent static_assert(false) for older (pre-C++23) compilers.
+template<typename T>
+constexpr bool always_false_v = false;
+
 // Process string type argument - handle const char*
 template <typename T, typename... R>
 void build_each_field(std::vector<Field> &fields,
@@ -46,7 +50,7 @@ void build_each_field(std::vector<Field> &fields,
   } else if constexpr (std::is_integral_v<T>) {
     ty = CreateInt(sizeof(T) * 8);
   } else {
-    static_assert(false, "unknown field type");
+    static_assert(always_false_v<T>, "unknown field type");
   }
   fields.push_back(Field{
       .name = "arg", .type = ty, .offset = offset, .bitfield = std::nullopt });


### PR DESCRIPTION
When building with some C++ compilers, such as GCC 11 (and probably earlier versions), the static_assert(false, ...) in an else branch of a template in tests/async_action.cpp triggers the assertion and fails to compile even if T is one of the accepted types (string or integer).

static_assert(false) seems to be a C++23 feature[1][2], not supported by older compilers, but we can replace it using the workaround mentioned in P2593R1, creating a template that is always false but is type dependent so it is not evaluated immediately.

[1]: https://isocpp.org/files/papers/P2593R1.html
[2]: https://github.com/cplusplus/papers/issues/1251
