### PR TITLE
types: make `SizedType` a concrete value for `GetPointeeTy` et al.

### DIFF
--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -327,7 +327,7 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype)
     auto *subrange = getOrCreateSubrange(0, stype.GetNumElements());
     return createArrayType(stype.GetSize() * 8,
                            0,
-                           GetType(*stype.GetElementTy()),
+                           GetType(stype.GetElementTy()),
                            getOrCreateArray({ subrange }));
   }
 
@@ -344,7 +344,7 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype)
     return CreateTSeriesStructType(stype);
 
   if (stype.IsPtrTy())
-    return createPointerType(GetType(*stype.GetPointeeTy()), 64);
+    return createPointerType(GetType(stype.GetPointeeTy()), 64);
 
   // Integer types and builtin types represented by integers
   switch (stype.GetSize()) {

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -377,7 +377,7 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   if (stype.IsByteArray() || stype.IsCStructTy()) {
     ty = ArrayType::get(getInt8Ty(), stype.GetSize());
   } else if (stype.IsArrayTy()) {
-    ty = ArrayType::get(GetType(*stype.GetElementTy()), stype.GetNumElements());
+    ty = ArrayType::get(GetType(stype.GetElementTy()), stype.GetNumElements());
   } else if (stype.IsTupleTy() || stype.IsRecordTy()) {
     std::vector<llvm::Type *> llvm_elems;
     std::string ty_name;
@@ -714,7 +714,7 @@ Value *IRBuilderBPF::createScratchBuffer(std::string_view global_var_name,
   // Note the 1st index is 0 because we're pointing to
   // ValueType var[MAX_CPU_ID + 1][num_elements]
   // More details on using GEP: https://llvm.org/docs/LangRef.html#id236
-  if (sized_type.GetElementTy()->GetElementTy()->IsArrayTy()) {
+  if (sized_type.GetElementTy().GetElementTy().IsArrayTy()) {
     return CreateGEP(
         GetType(sized_type),
         module_.getGlobalVariable(global_name),
@@ -1568,7 +1568,7 @@ Value *IRBuilderBPF::CreateIntegerArrayCmp(Value *val1,
   //    return true;
   //  }
 
-  auto elem_type = *val1_type.GetElementTy();
+  auto elem_type = val1_type.GetElementTy();
   const size_t num = val1_type.GetNumElements();
 
   Value *val1_elem_i, *val2_elem_i, *cmp;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -75,8 +75,8 @@ bool can_implicit_cast(const SizedType &from, const SizedType &to)
   if (from.FitsInto(to))
     return true;
 
-  if (from.IsStringTy() && to.IsPtrTy() && to.GetPointeeTy()->IsIntTy() &&
-      to.GetPointeeTy()->GetSize() == 1) {
+  if (from.IsStringTy() && to.IsPtrTy() && to.GetPointeeTy().IsIntTy() &&
+      to.GetPointeeTy().GetSize() == 1) {
     // Allow casting from string to int8* or uint8*
     return true;
   }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -45,9 +45,9 @@ std::string typestr(const SizedType &type)
     case Type::buffer:
       return typestr(type.GetTy()) + "[" + std::to_string(type.GetSize()) + "]";
     case Type::pointer:
-      return typestr(*type.GetPointeeTy()) + " *";
+      return typestr(type.GetPointeeTy()) + " *";
     case Type::array:
-      return typestr(*type.GetElementTy()) + "[" +
+      return typestr(type.GetElementTy()) + "[" +
              std::to_string(type.GetNumElements()) + "]";
     case Type::c_struct: {
       if (!type.IsAnonTy())
@@ -139,7 +139,7 @@ bool SizedType::IsCompatible(const SizedType &t) const
     return t.GetName() == GetName();
 
   if (IsPtrTy())
-    return GetPointeeTy()->IsCompatible(*t.GetPointeeTy());
+    return GetPointeeTy().IsCompatible(t.GetPointeeTy());
 
   if (IsIntegerTy()) {
     if (IsSigned() == t.IsSigned()) {
@@ -210,13 +210,13 @@ std::strong_ordering SizedType::operator<=>(const SizedType &t) const
   }
 
   if (IsPtrTy()) {
-    return *GetPointeeTy() <=> *t.GetPointeeTy();
+    return GetPointeeTy() <=> t.GetPointeeTy();
   }
 
   if (IsArrayTy()) {
     if (auto cmp = GetNumElements() <=> t.GetNumElements(); cmp != 0)
       return cmp;
-    return *GetElementTy() <=> *t.GetElementTy();
+    return GetElementTy() <=> t.GetElementTy();
   }
 
   if (IsTupleTy()) {

--- a/src/types.h
+++ b/src/types.h
@@ -356,16 +356,23 @@ public:
     return type_;
   }
 
-  const SizedType *GetElementTy() const
+  SizedType GetElementTy() const
   {
     assert(IsArrayTy());
-    return element_type_.get();
+    return *element_type_;
   }
 
-  const SizedType *GetPointeeTy() const
+  SizedType GetPointeeTy() const
   {
     assert(IsPtrTy());
-    return element_type_.get();
+    auto result = *element_type_;
+    if (as_ == AddrSpace::user) {
+      result.SetAS(AddrSpace::user);
+    }
+    if (as_ == AddrSpace::kernel && result.GetAS() != AddrSpace::none) {
+      result.SetAS(AddrSpace::kernel);
+    }
+    return result;
   }
 
   bool IsPtrTy() const

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -139,12 +139,12 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       return s;
     }
     case Type::array: {
-      size_t elem_size = type.GetElementTy()->GetSize();
+      size_t elem_size = type.GetElementTy().GetSize();
       output::Primitive::Array array;
       for (size_t i = 0; i < type.GetNumElements(); i++) {
         auto elem_data = value.slice(i * elem_size, elem_size);
         auto val = format(
-            bpftrace, c_definitions, *type.GetElementTy(), elem_data, div);
+            bpftrace, c_definitions, type.GetElementTy(), elem_data, div);
         if (!val) {
           return val.takeError();
         }

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -379,21 +379,13 @@ public:
                                    MatchResultListener* listener) {
       // For arrays, check element type.
       if (type_obj.IsArrayTy()) {
-        const SizedType* element_type = type_obj.GetElementTy();
-        if (!element_type) {
-          *listener << "array has no element type";
-          return false;
-        }
-        return element_matcher.MatchAndExplain(*element_type, listener);
+        const SizedType element_type = type_obj.GetElementTy();
+        return element_matcher.MatchAndExplain(element_type, listener);
       }
       // For pointers, check pointee type.
       else if (type_obj.IsPtrTy()) {
-        const SizedType* pointee_type = type_obj.GetPointeeTy();
-        if (!pointee_type) {
-          *listener << "pointer has no pointee type";
-          return false;
-        }
-        return element_matcher.MatchAndExplain(*pointee_type, listener);
+        const SizedType pointee_type = type_obj.GetPointeeTy();
+        return element_matcher.MatchAndExplain(pointee_type, listener);
       } else {
         *listener << "type is neither array nor pointer, cannot have element";
         return false;

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -215,7 +215,7 @@ TEST(clang_parser, integer_ptr)
   ASSERT_TRUE(foo->HasField("x"));
 
   EXPECT_TRUE(foo->GetField("x").type.IsPtrTy());
-  EXPECT_EQ(foo->GetField("x").type.GetPointeeTy()->GetIntBitWidth(),
+  EXPECT_EQ(foo->GetField("x").type.GetPointeeTy().GetIntBitWidth(),
             8 * sizeof(int));
   EXPECT_EQ(foo->GetField("x").offset, 0);
 }
@@ -233,9 +233,9 @@ TEST(clang_parser, string_ptr)
   ASSERT_TRUE(foo->HasField("str"));
 
   const auto &ty = foo->GetField("str").type;
-  const auto *pointee = ty.GetPointeeTy();
-  EXPECT_TRUE(pointee->IsIntTy());
-  EXPECT_EQ(pointee->GetIntBitWidth(), 8 * sizeof(char));
+  const auto pointee = ty.GetPointeeTy();
+  EXPECT_TRUE(pointee.IsIntTy());
+  EXPECT_EQ(pointee.GetIntBitWidth(), 8 * sizeof(char));
   EXPECT_EQ(foo->GetField("str").offset, 0);
 }
 
@@ -292,9 +292,9 @@ TEST(clang_parser, nested_struct_ptr_named)
 
   const auto &bar = foo->GetField("bar");
   EXPECT_TRUE(bar.type.IsPtrTy());
-  EXPECT_TRUE(bar.type.GetPointeeTy()->IsCStructTy());
-  EXPECT_EQ(bar.type.GetPointeeTy()->GetName(), "struct Bar");
-  EXPECT_EQ(bar.type.GetPointeeTy()->GetSize(), sizeof(int));
+  EXPECT_TRUE(bar.type.GetPointeeTy().IsCStructTy());
+  EXPECT_EQ(bar.type.GetPointeeTy().GetName(), "struct Bar");
+  EXPECT_EQ(bar.type.GetPointeeTy().GetSize(), sizeof(int));
   EXPECT_EQ(bar.offset, 0);
 }
 
@@ -703,11 +703,11 @@ TEST_F(clang_parser_btf, btf)
   auto foo1_field = foo3->GetField("foo1");
   auto foo2_field = foo3->GetField("foo2");
   EXPECT_TRUE(foo1_field.type.IsPtrTy());
-  EXPECT_EQ(foo1_field.type.GetPointeeTy()->GetName(), "struct Foo1");
+  EXPECT_EQ(foo1_field.type.GetPointeeTy().GetName(), "struct Foo1");
   EXPECT_EQ(foo1_field.offset, 0);
 
   EXPECT_TRUE(foo2_field.type.IsPtrTy());
-  EXPECT_EQ(foo2_field.type.GetPointeeTy()->GetName(), "struct Foo2");
+  EXPECT_EQ(foo2_field.type.GetPointeeTy().GetName(), "struct Foo2");
   EXPECT_EQ(foo2_field.offset, 8);
 }
 
@@ -734,20 +734,16 @@ TEST_F(clang_parser_btf, DISABLED_btf_arrays_multi_dim)
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetSize(), 24U);
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetNumElements(), 3);
 
-  EXPECT_TRUE(arrs->GetField("multi_dim").type.GetElementTy()->IsArrayTy());
-  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy()->GetSize(), 8U);
-  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy()->GetNumElements(),
+  EXPECT_TRUE(arrs->GetField("multi_dim").type.GetElementTy().IsArrayTy());
+  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy().GetSize(), 8U);
+  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy().GetNumElements(),
             2);
 
-  EXPECT_TRUE(arrs->GetField("multi_dim")
-                  .type.GetElementTy()
-                  ->GetElementTy()
-                  ->IsIntTy());
-  EXPECT_EQ(arrs->GetField("multi_dim")
-                .type.GetElementTy()
-                ->GetElementTy()
-                ->GetSize(),
-            4U);
+  EXPECT_TRUE(
+      arrs->GetField("multi_dim").type.GetElementTy().GetElementTy().IsIntTy());
+  EXPECT_EQ(
+      arrs->GetField("multi_dim").type.GetElementTy().GetElementTy().GetSize(),
+      4U);
 }
 
 TEST(clang_parser, btf_unresolved_typedef)
@@ -861,8 +857,8 @@ TEST(clang_parser, struct_qualifiers)
   EXPECT_EQ(SB->fields.size(), 2U);
 
   EXPECT_TRUE(SB->GetField("a").type.IsPtrTy());
-  EXPECT_TRUE(SB->GetField("a").type.GetPointeeTy()->IsCStructTy());
-  EXPECT_EQ(SB->GetField("a").type.GetPointeeTy()->GetName(), "struct a");
+  EXPECT_TRUE(SB->GetField("a").type.GetPointeeTy().IsCStructTy());
+  EXPECT_EQ(SB->GetField("a").type.GetPointeeTy().GetName(), "struct a");
 
   EXPECT_TRUE(SB->GetField("a2").type.IsCStructTy());
   EXPECT_EQ(SB->GetField("a2").type.GetName(), "struct a");

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -105,11 +105,11 @@ TEST_F(field_analyser_btf, btf_types)
   auto foo1_field = foo3->GetField("foo1");
   auto foo2_field = foo3->GetField("foo2");
   EXPECT_TRUE(foo1_field.type.IsPtrTy());
-  EXPECT_EQ(foo1_field.type.GetPointeeTy()->GetName(), "struct Foo1");
+  EXPECT_EQ(foo1_field.type.GetPointeeTy().GetName(), "struct Foo1");
   EXPECT_EQ(foo1_field.offset, 0);
 
   EXPECT_TRUE(foo2_field.type.IsPtrTy());
-  EXPECT_EQ(foo2_field.type.GetPointeeTy()->GetName(), "struct Foo2");
+  EXPECT_EQ(foo2_field.type.GetPointeeTy().GetName(), "struct Foo2");
   EXPECT_EQ(foo2_field.offset, 8);
 }
 
@@ -137,7 +137,7 @@ TEST_F(field_analyser_btf, btf_arrays)
 
   EXPECT_TRUE(arrs->GetField("int_arr").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("int_arr").type.GetNumElements(), 4);
-  EXPECT_TRUE(arrs->GetField("int_arr").type.GetElementTy()->IsIntTy());
+  EXPECT_TRUE(arrs->GetField("int_arr").type.GetElementTy().IsIntTy());
   EXPECT_EQ(arrs->GetField("int_arr").type.GetSize(), 16U);
   EXPECT_EQ(arrs->GetField("int_arr").offset, 0);
 
@@ -152,7 +152,7 @@ TEST_F(field_analyser_btf, btf_arrays)
   EXPECT_TRUE(arrs->GetField("ptr_arr").type.IsArrayTy());
   EXPECT_TRUE(arrs->GetField("ptr_arr").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("ptr_arr").type.GetNumElements(), 2);
-  EXPECT_TRUE(arrs->GetField("ptr_arr").type.GetElementTy()->IsPtrTy());
+  EXPECT_TRUE(arrs->GetField("ptr_arr").type.GetElementTy().IsPtrTy());
   EXPECT_EQ(arrs->GetField("ptr_arr").type.GetSize(), 2 * sizeof(uintptr_t));
   EXPECT_EQ(arrs->GetField("ptr_arr").offset, 40);
 
@@ -161,19 +161,19 @@ TEST_F(field_analyser_btf, btf_arrays)
   // below in 'field_analyser_btf.btf_arrays_multi_dim'.
   EXPECT_TRUE(arrs->GetField("multi_dim").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetNumElements(), 6);
-  EXPECT_TRUE(arrs->GetField("multi_dim").type.GetElementTy()->IsIntTy());
+  EXPECT_TRUE(arrs->GetField("multi_dim").type.GetElementTy().IsIntTy());
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetSize(), 24U);
   EXPECT_EQ(arrs->GetField("multi_dim").offset, 56);
 
   EXPECT_TRUE(arrs->GetField("zero").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("zero").type.GetNumElements(), 0);
-  EXPECT_TRUE(arrs->GetField("zero").type.GetElementTy()->IsIntTy());
+  EXPECT_TRUE(arrs->GetField("zero").type.GetElementTy().IsIntTy());
   EXPECT_EQ(arrs->GetField("zero").type.GetSize(), 0U);
   EXPECT_EQ(arrs->GetField("zero").offset, 80);
 
   EXPECT_TRUE(arrs->GetField("flexible").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("flexible").type.GetNumElements(), 0);
-  EXPECT_TRUE(arrs->GetField("flexible").type.GetElementTy()->IsIntTy());
+  EXPECT_TRUE(arrs->GetField("flexible").type.GetElementTy().IsIntTy());
   EXPECT_EQ(arrs->GetField("flexible").type.GetSize(), 0U);
   EXPECT_EQ(arrs->GetField("flexible").offset, 80);
 }
@@ -197,20 +197,16 @@ TEST_F(field_analyser_btf, DISABLED_btf_arrays_multi_dim)
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetSize(), 24U);
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetNumElements(), 3);
 
-  EXPECT_TRUE(arrs->GetField("multi_dim").type.GetElementTy()->IsArrayTy());
-  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy()->GetSize(), 8U);
-  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy()->GetNumElements(),
+  EXPECT_TRUE(arrs->GetField("multi_dim").type.GetElementTy().IsArrayTy());
+  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy().GetSize(), 8U);
+  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy().GetNumElements(),
             2);
 
-  EXPECT_TRUE(arrs->GetField("multi_dim")
-                  .type.GetElementTy()
-                  ->GetElementTy()
-                  ->IsIntTy());
-  EXPECT_EQ(arrs->GetField("multi_dim")
-                .type.GetElementTy()
-                ->GetElementTy()
-                ->GetSize(),
-            4U);
+  EXPECT_TRUE(
+      arrs->GetField("multi_dim").type.GetElementTy().GetElementTy().IsIntTy());
+  EXPECT_EQ(
+      arrs->GetField("multi_dim").type.GetElementTy().GetElementTy().GetSize(),
+      4U);
 }
 
 void test_arrays_compound_data(BPFtrace &bpftrace)
@@ -229,17 +225,17 @@ void test_arrays_compound_data(BPFtrace &bpftrace)
 
   // Check that referenced types n-levels deep are all parsed from BTF
 
-  const auto &foo3_ptr_type = *data_type.GetElementTy();
+  const auto &foo3_ptr_type = data_type.GetElementTy();
   ASSERT_TRUE(foo3_ptr_type.IsPtrTy());
 
-  const auto &foo3_type = *foo3_ptr_type.GetPointeeTy();
+  const auto &foo3_type = foo3_ptr_type.GetPointeeTy();
   ASSERT_TRUE(foo3_type.IsCStructTy());
   ASSERT_TRUE(foo3_type.HasField("foo1"));
 
   const auto &foo1_ptr_type = foo3_type.GetField("foo1").type;
   ASSERT_TRUE(foo1_ptr_type.IsPtrTy());
 
-  const auto &foo1_type = *foo1_ptr_type.GetPointeeTy();
+  const auto &foo1_type = foo1_ptr_type.GetPointeeTy();
   ASSERT_TRUE(foo1_type.IsCStructTy());
   ASSERT_TRUE(foo1_type.HasField("a"));
 }
@@ -325,27 +321,27 @@ TEST_F(field_analyser_btf, btf_types_anon_structs)
   EXPECT_TRUE(typedefarray.IsArrayTy());
   EXPECT_EQ(typedefarray.GetNumElements(), 8);
   EXPECT_EQ(typedefarray.GetSize(), 32);
-  EXPECT_TRUE(typedefarray.GetElementTy()->IsCStructTy());
-  EXPECT_TRUE(typedefarray.GetElementTy()->IsAnonTy());
-  EXPECT_TRUE(typedefarray.GetElementTy()->HasField("a"));
+  EXPECT_TRUE(typedefarray.GetElementTy().IsCStructTy());
+  EXPECT_TRUE(typedefarray.GetElementTy().IsAnonTy());
+  EXPECT_TRUE(typedefarray.GetElementTy().HasField("a"));
 
   ASSERT_TRUE(anonstruct->HasField("AnonArray"));
   auto structarray = anonstruct->GetField("AnonArray").type;
   EXPECT_TRUE(typedefarray.IsArrayTy());
   EXPECT_EQ(structarray.GetSize(), 96);
   EXPECT_EQ(structarray.GetNumElements(), 4);
-  EXPECT_TRUE(structarray.GetElementTy()->IsCStructTy());
-  EXPECT_TRUE(structarray.GetElementTy()->IsAnonTy());
-  EXPECT_TRUE(structarray.GetElementTy()->HasField("a"));
-  EXPECT_TRUE(structarray.GetElementTy()->HasField("b"));
+  EXPECT_TRUE(structarray.GetElementTy().IsCStructTy());
+  EXPECT_TRUE(structarray.GetElementTy().IsAnonTy());
+  EXPECT_TRUE(structarray.GetElementTy().HasField("a"));
+  EXPECT_TRUE(structarray.GetElementTy().HasField("b"));
 
-  ASSERT_TRUE(structarray.GetElementTy()->HasField("AnonSubArray"));
-  auto subarray = structarray.GetElementTy()->GetField("AnonSubArray").type;
+  ASSERT_TRUE(structarray.GetElementTy().HasField("AnonSubArray"));
+  auto subarray = structarray.GetElementTy().GetField("AnonSubArray").type;
   EXPECT_EQ(subarray.GetNumElements(), 2);
-  EXPECT_TRUE(subarray.GetElementTy()->IsCStructTy());
-  EXPECT_TRUE(subarray.GetElementTy()->IsAnonTy());
-  EXPECT_TRUE(subarray.GetElementTy()->HasField("c"));
-  EXPECT_TRUE(subarray.GetElementTy()->HasField("d"));
+  EXPECT_TRUE(subarray.GetElementTy().IsCStructTy());
+  EXPECT_TRUE(subarray.GetElementTy().IsAnonTy());
+  EXPECT_TRUE(subarray.GetElementTy().HasField("c"));
+  EXPECT_TRUE(subarray.GetElementTy().HasField("d"));
 }
 
 TEST_F(field_analyser_btf, btf_types_bitfields)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1631,9 +1631,9 @@ TEST_F(SemanticAnalyserTest, call_uaddr)
                   ->block->stmts.at(i)
                   .as<ast::AssignVarStatement>();
     EXPECT_TRUE(v->var()->var_type.IsPtrTy());
-    EXPECT_TRUE(v->var()->var_type.GetPointeeTy()->IsIntTy());
+    EXPECT_TRUE(v->var()->var_type.GetPointeeTy().IsIntTy());
     EXPECT_EQ((unsigned long int)sizes.at(i),
-              v->var()->var_type.GetPointeeTy()->GetIntBitWidth());
+              v->var()->var_type.GetPointeeTy().GetIntBitWidth());
   }
 }
 
@@ -3789,20 +3789,20 @@ TEST_F(SemanticAnalyserTest, double_pointer_int)
   // $pp = (int8 **)1;
   auto *assignment = stmts.at(0).as<ast::AssignVarStatement>();
   ASSERT_TRUE(assignment->var()->var_type.IsPtrTy());
-  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy()->IsPtrTy());
+  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy().IsPtrTy());
   ASSERT_TRUE(
-      assignment->var()->var_type.GetPointeeTy()->GetPointeeTy()->IsIntTy());
+      assignment->var()->var_type.GetPointeeTy().GetPointeeTy().IsIntTy());
   EXPECT_EQ(assignment->var()
                 ->var_type.GetPointeeTy()
-                ->GetPointeeTy()
-                ->GetIntBitWidth(),
+                .GetPointeeTy()
+                .GetIntBitWidth(),
             8ULL);
 
   // $p = *$pp;
   assignment = stmts.at(1).as<ast::AssignVarStatement>();
   ASSERT_TRUE(assignment->var()->var_type.IsPtrTy());
-  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy()->IsIntTy());
-  EXPECT_EQ(assignment->var()->var_type.GetPointeeTy()->GetIntBitWidth(), 8ULL);
+  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy().IsIntTy());
+  EXPECT_EQ(assignment->var()->var_type.GetPointeeTy().GetIntBitWidth(), 8ULL);
 
   // $val = *$p;
   assignment = stmts.at(2).as<ast::AssignVarStatement>();
@@ -3820,21 +3820,17 @@ TEST_F(SemanticAnalyserTest, double_pointer_struct)
   // $pp = (struct Foo **)1;
   auto *assignment = stmts.at(0).as<ast::AssignVarStatement>();
   ASSERT_TRUE(assignment->var()->var_type.IsPtrTy());
-  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy()->IsPtrTy());
-  ASSERT_TRUE(assignment->var()
-                  ->var_type.GetPointeeTy()
-                  ->GetPointeeTy()
-                  ->IsCStructTy());
-  EXPECT_EQ(
-      assignment->var()->var_type.GetPointeeTy()->GetPointeeTy()->GetName(),
-      "struct Foo");
+  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy().IsPtrTy());
+  ASSERT_TRUE(
+      assignment->var()->var_type.GetPointeeTy().GetPointeeTy().IsCStructTy());
+  EXPECT_EQ(assignment->var()->var_type.GetPointeeTy().GetPointeeTy().GetName(),
+            "struct Foo");
 
   // $p = *$pp;
   assignment = stmts.at(1).as<ast::AssignVarStatement>();
   ASSERT_TRUE(assignment->var()->var_type.IsPtrTy());
-  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy()->IsCStructTy());
-  EXPECT_EQ(assignment->var()->var_type.GetPointeeTy()->GetName(),
-            "struct Foo");
+  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy().IsCStructTy());
+  EXPECT_EQ(assignment->var()->var_type.GetPointeeTy().GetName(), "struct Foo");
 
   // $val = $p->x;
   assignment = stmts.at(2).as<ast::AssignVarStatement>();
@@ -5229,7 +5225,7 @@ TEST_F(SemanticAnalyserTest, variable_address)
 
   auto *assignment = stmts.at(1).as<ast::AssignVarStatement>();
   ASSERT_TRUE(assignment->var()->var_type.IsPtrTy());
-  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy()->IsIntTy());
+  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy().IsIntTy());
 
   test("begin { $a = 1; $b = &$c; }", Error{ R"(
 stdin:1:23-25: ERROR: Undefined or undeclared variable: $c

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -105,8 +105,8 @@ TEST_F(tracepoint_format_parser, tracepoint_struct)
   EXPECT_TRUE(type->HasField("buf"));
   auto buf = type->GetField("buf");
   EXPECT_TRUE(buf.type.IsPtrTy());
-  EXPECT_TRUE(buf.type.GetPointeeTy()->IsIntTy());
-  EXPECT_EQ(buf.type.GetPointeeTy()->GetSize(), 1);
+  EXPECT_TRUE(buf.type.GetPointeeTy().IsIntTy());
+  EXPECT_EQ(buf.type.GetPointeeTy().GetSize(), 1);
   EXPECT_EQ(buf.offset, 24);
 
   EXPECT_TRUE(type->HasField("count"));
@@ -150,10 +150,10 @@ TEST_F(tracepoint_format_parser, array)
   EXPECT_TRUE(int_array.type.IsArrayTy());
   EXPECT_EQ(int_array.type.GetNumElements(), 2);
   EXPECT_EQ(int_array.offset, 16);
-  const auto *int_array_elem = int_array.type.GetElementTy();
-  EXPECT_TRUE(int_array_elem->IsIntTy());
-  EXPECT_EQ(int_array_elem->GetSize(), 4);
-  EXPECT_TRUE(int_array_elem->IsSigned());
+  const auto int_array_elem = int_array.type.GetElementTy();
+  EXPECT_TRUE(int_array_elem.IsIntTy());
+  EXPECT_EQ(int_array_elem.GetSize(), 4);
+  EXPECT_TRUE(int_array_elem.IsSigned());
 }
 
 TEST_F(tracepoint_format_parser, data_loc)
@@ -297,39 +297,39 @@ TEST_F(tracepoint_format_parser, pointer_types)
   EXPECT_TRUE(type->HasField("ptr"));
   auto ptr = type->GetField("ptr");
   EXPECT_TRUE(ptr.type.IsPtrTy());
-  EXPECT_TRUE(ptr.type.GetPointeeTy()->IsIntTy());
-  EXPECT_EQ(ptr.type.GetPointeeTy()->GetSize(), 4);
+  EXPECT_TRUE(ptr.type.GetPointeeTy().IsIntTy());
+  EXPECT_EQ(ptr.type.GetPointeeTy().GetSize(), 4);
   EXPECT_EQ(ptr.offset, 0);
 
   EXPECT_TRUE(type->HasField("const_ptr"));
   auto const_ptr = type->GetField("const_ptr");
   EXPECT_TRUE(const_ptr.type.IsPtrTy());
-  EXPECT_TRUE(const_ptr.type.GetPointeeTy()->IsIntTy());
-  EXPECT_EQ(const_ptr.type.GetPointeeTy()->GetSize(), 4);
+  EXPECT_TRUE(const_ptr.type.GetPointeeTy().IsIntTy());
+  EXPECT_EQ(const_ptr.type.GetPointeeTy().GetSize(), 4);
   EXPECT_EQ(const_ptr.offset, 8);
 
   EXPECT_TRUE(type->HasField("double_ptr"));
   auto double_ptr = type->GetField("double_ptr");
   EXPECT_TRUE(double_ptr.type.IsPtrTy());
-  EXPECT_TRUE(double_ptr.type.GetPointeeTy()->IsPtrTy());
-  EXPECT_TRUE(double_ptr.type.GetPointeeTy()->GetPointeeTy()->IsIntTy());
-  EXPECT_EQ(double_ptr.type.GetPointeeTy()->GetPointeeTy()->GetSize(), 4);
+  EXPECT_TRUE(double_ptr.type.GetPointeeTy().IsPtrTy());
+  EXPECT_TRUE(double_ptr.type.GetPointeeTy().GetPointeeTy().IsIntTy());
+  EXPECT_EQ(double_ptr.type.GetPointeeTy().GetPointeeTy().GetSize(), 4);
   EXPECT_EQ(double_ptr.offset, 16);
 
   EXPECT_TRUE(type->HasField("double_ptr_space"));
   auto double_ptr_space = type->GetField("double_ptr_space");
   EXPECT_TRUE(double_ptr_space.type.IsPtrTy());
-  EXPECT_TRUE(double_ptr_space.type.GetPointeeTy()->IsPtrTy());
-  EXPECT_TRUE(double_ptr_space.type.GetPointeeTy()->GetPointeeTy()->IsIntTy());
-  EXPECT_EQ(double_ptr_space.type.GetPointeeTy()->GetPointeeTy()->GetSize(), 4);
+  EXPECT_TRUE(double_ptr_space.type.GetPointeeTy().IsPtrTy());
+  EXPECT_TRUE(double_ptr_space.type.GetPointeeTy().GetPointeeTy().IsIntTy());
+  EXPECT_EQ(double_ptr_space.type.GetPointeeTy().GetPointeeTy().GetSize(), 4);
   EXPECT_EQ(double_ptr_space.offset, 24);
 
   EXPECT_TRUE(type->HasField("dbl_const_ptr"));
   auto dbl_const_ptr = type->GetField("dbl_const_ptr");
   EXPECT_TRUE(dbl_const_ptr.type.IsPtrTy());
-  EXPECT_TRUE(dbl_const_ptr.type.GetPointeeTy()->IsPtrTy());
-  EXPECT_TRUE(dbl_const_ptr.type.GetPointeeTy()->GetPointeeTy()->IsIntTy());
-  EXPECT_EQ(dbl_const_ptr.type.GetPointeeTy()->GetPointeeTy()->GetSize(), 4);
+  EXPECT_TRUE(dbl_const_ptr.type.GetPointeeTy().IsPtrTy());
+  EXPECT_TRUE(dbl_const_ptr.type.GetPointeeTy().GetPointeeTy().IsIntTy());
+  EXPECT_EQ(dbl_const_ptr.type.GetPointeeTy().GetPointeeTy().GetSize(), 4);
   EXPECT_EQ(dbl_const_ptr.offset, 32);
 }
 
@@ -357,14 +357,14 @@ TEST_F(tracepoint_format_parser, user_pointer)
   auto user_buf = type->GetField("user_buf");
   EXPECT_TRUE(user_buf.type.IsPtrTy());
   EXPECT_EQ(user_buf.type.GetAS(), AddrSpace::user);
-  EXPECT_TRUE(user_buf.type.GetPointeeTy()->IsIntTy());
+  EXPECT_TRUE(user_buf.type.GetPointeeTy().IsIntTy());
   EXPECT_EQ(user_buf.offset, 0);
 
   EXPECT_TRUE(type->HasField("kernel_buf"));
   auto kernel_buf = type->GetField("kernel_buf");
   EXPECT_TRUE(kernel_buf.type.IsPtrTy());
   EXPECT_EQ(kernel_buf.type.GetAS(), AddrSpace::kernel);
-  EXPECT_TRUE(kernel_buf.type.GetPointeeTy()->IsIntTy());
+  EXPECT_TRUE(kernel_buf.type.GetPointeeTy().IsIntTy());
   EXPECT_EQ(kernel_buf.offset, 8);
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4891
 * #4887
 * #4894
 * #4968
 * __->__#4967


--- --- ---

### types: make `SizedType` a concrete value for `GetPointeeTy` et al.


Currently, the `SizedType` object is heavyweight. This won't necessarily
remain the case. However, it will be the case that it carries the
address space of the underlying type. In order for this to work for
types that are using well-known BTF types, it will be necessary to use
full values for pointers and elements (since you can have the same BTF
type in different address spaces).

This change will result in a few more bytes being shuffled around during
analysis, but should otherwise be a non-functional change.

Signed-off-by: Adin Scannell <amscanne@meta.com>
