### PR TITLE
Fix wrong kprobe address check

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -488,9 +488,12 @@ Result<std::unique_ptr<AttachedKprobeProbe>> AttachedKprobeProbe::make(
     const BpfProgram &prog,
     BPFtrace &bpftrace)
 {
-  if ((!probe.attach_point.empty() || probe.address != 0) &&
-      !bpftrace.is_traceable_func(probe.attach_point))
+  if (!probe.attach_point.empty()) {
+    if (!bpftrace.is_traceable_func(probe.attach_point))
+      return make_error<AttachError>();
+  } else if (probe.address == 0) {
     return make_error<AttachError>();
+  }
 
   std::string funcname = probe.attach_point;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(bpftrace_test
   async_action.cpp
   ast.cpp
   ast_matchers.cpp
+  attached_probe.cpp
   attachpoint_passes.cpp
   bpfbytecode.cpp
   bpftrace.cpp

--- a/tests/attached_probe.cpp
+++ b/tests/attached_probe.cpp
@@ -1,0 +1,23 @@
+#include "attached_probe.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test {
+
+TEST(attached_probe, kprobe_empty_name_and_zero_address)
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+
+  BPFtrace &bpftrace = *mock_bpftrace;
+  BpfProgram prog(nullptr);
+
+  Probe probe;
+  probe.type = ProbeType::kprobe;
+  probe.attach_point = "";
+  probe.address = 0;
+
+  auto result = AttachedProbe::make(probe, prog, 0, bpftrace);
+  EXPECT_TRUE(!result);
+}
+
+} // namespace bpftrace::test


### PR DESCRIPTION
We should only check if function is traceable if there is name for it. Remove wrong '|| probe.address = 0' check and return early from AttachedKprobeProbe::make() if there is no name and no address.

