### PR TITLE
Return Result from TraceableFunctionsReader::is_traceable_function

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1407,10 +1407,18 @@ std::unique_ptr<std::istream> BPFtrace::
   return std::make_unique<std::istringstream>(rts);
 }
 
+// TODO: Propagate errors up to ProbeMatcher (or other initial caller)
+// and print the error there
 bool BPFtrace::is_traceable_func(const std::string &func_name,
                                  const std::string &mod_name) const
 {
-  return traceable_funcs_reader_.is_traceable_function(func_name, mod_name);
+  auto ok = traceable_funcs_reader_.is_traceable_function(func_name, mod_name);
+  if (!ok) {
+    LOG(V1) << ok.takeError();
+    return false;
+  }
+
+  return *ok;
 }
 
 bool BPFtrace::is_module_loaded(const std::string &module) const

--- a/src/util/kernel.cpp
+++ b/src/util/kernel.cpp
@@ -541,26 +541,22 @@ Result<const FunctionSet &> TraceableFunctionsReader::get_module_funcs(
   return empty_set_;
 }
 
-// TODO: Propagate errors up to ProbeMatcher (or other initial caller)
-// and print the error there
-bool TraceableFunctionsReader::is_traceable_function(
+Result<bool> TraceableFunctionsReader::is_traceable_function(
     const std::string &func_name,
     const std::string &mod_name)
 {
   if (mod_name.empty() || has_wildcard(mod_name)) {
     auto found_mod = search_module_for_function(func_name);
-    if (!found_mod) {
-      LOG(V1) << found_mod.takeError();
-      return false;
-    }
-    return !(*found_mod).empty();
+    if (!found_mod)
+      return found_mod.takeError();
+
+    return !found_mod->empty();
   } else {
     auto found_fn_set = get_module_funcs(mod_name);
-    if (!found_fn_set) {
-      LOG(V1) << found_fn_set.takeError();
-      return false;
-    }
-    return (*found_fn_set).contains(func_name);
+    if (!found_fn_set)
+      return found_fn_set.takeError();
+
+    return found_fn_set->contains(func_name);
   }
 }
 

--- a/src/util/kernel.h
+++ b/src/util/kernel.h
@@ -48,8 +48,8 @@ public:
 
   Result<const FunctionSet &> get_module_funcs(const std::string &mod_name);
   ModuleSet get_func_modules(const std::string &func_name);
-  bool is_traceable_function(const std::string &func_name,
-                            const std::string &mod_name);
+  Result<bool> is_traceable_function(const std::string &func_name,
+                                     const std::string &mod_name);
   const ModulesFuncsMap &get_all_funcs();
 
 private:


### PR DESCRIPTION
Propagate error from opening available_filter_function a little bit upward.

NOTE: I planed to do further error propagation. As well move creation of probe list streams of the BPFtrace class to ProbeMatcher #4971.  But this conflicts with current big refactor from @amscanne #4968 , #4894 . So I'll wait until the refactor is done. 
