### PR TITLE
Create probes list stream in ProbeMatcher

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1347,66 +1347,6 @@ std::string BPFtrace::resolve_probe(uint64_t probe_id) const
   return resources.probe_ids[probe_id];
 }
 
-std::unique_ptr<std::istream> BPFtrace::get_traceable_funcs(
-    bool with_modules) const
-{
-  auto mod_funcs_map = traceable_funcs_reader_.get_all_funcs();
-  std::string funcs;
-
-  for (const auto &mod_funcs : mod_funcs_map) {
-    auto mod = mod_funcs.first;
-    for (const auto &fn : mod_funcs.second) {
-      if (with_modules)
-        funcs += mod + ":" + fn + "\n";
-      else
-        funcs += fn + "\n";
-    }
-  }
-
-  return std::make_unique<std::istringstream>(funcs);
-}
-
-std::unique_ptr<std::istream> BPFtrace::get_module_traceable_funcs(
-    const std::string &mod) const
-{
-  std::string funcs;
-
-  auto fn_set = traceable_funcs_reader_.get_module_funcs(mod);
-  if (!fn_set) {
-    LOG(WARNING) << fn_set.takeError();
-  } else {
-    for (const auto &fn : *fn_set)
-      funcs += mod + ":" + fn + "\n";
-  }
-
-  return std::make_unique<std::istringstream>(funcs);
-}
-// Using "available_filter_functions" here because they have the correct
-// module for the prefixed raw tracepoints e.g. in "available_events"
-// there is "kvmmmu:check_mmio_spte" but the module is actually "kvm"
-// and shows up as "__probestub_check_mmio_spte [kvm]" in
-// "available_filter_functions"
-std::unique_ptr<std::istream> BPFtrace::
-    get_raw_tracepoints_from_traceable_funcs() const
-{
-  auto mod_funcs_map = traceable_funcs_reader_.get_all_funcs();
-  std::string rts;
-
-  for (const auto &mod_funcs : mod_funcs_map) {
-    auto mod = mod_funcs.first;
-    for (const auto &fn : mod_funcs.second) {
-      for (const auto &prefix : RT_BTF_PREFIXES) {
-        if (fn.starts_with(prefix)) {
-          rts += mod + ":" + fn.substr(prefix.length()) + "\n";
-          break;
-        }
-      }
-    }
-  }
-
-  return std::make_unique<std::istringstream>(rts);
-}
-
 bool BPFtrace::is_traceable_func(const std::string &func_name,
                                  const std::string &mod_name) const
 {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -198,11 +198,6 @@ public:
   FunctionRegistry functions;
   // For each helper, list of all generated call sites.
   std::map<bpf_func_id, std::vector<RuntimeErrorInfo>> helper_use_loc_;
-  std::unique_ptr<std::istream> get_traceable_funcs(bool with_modules) const;
-  std::unique_ptr<std::istream> get_module_traceable_funcs(
-      const std::string &module_name) const;
-  std::unique_ptr<std::istream> get_raw_tracepoints_from_traceable_funcs()
-      const;
   util::KConfig kconfig;
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::vector<int> sigusr1_prog_fds_;
@@ -222,6 +217,7 @@ public:
   bool need_recursion_check_ = false;
 
   std::unique_ptr<ProbeMatcher> probe_matcher_;
+  mutable util::TraceableFunctionsReader traceable_funcs_reader_;
 
   std::unordered_set<std::string> btf_set_;
   std::unique_ptr<ChildProcBase> child_;
@@ -275,7 +271,6 @@ private:
   struct perf_buffer *skb_perfbuf_ = nullptr;
   uint64_t event_loss_count_ = 0;
 
-  mutable util::TraceableFunctionsReader traceable_funcs_reader_;
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
 };
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -557,8 +557,7 @@ Result<std::shared_ptr<Struct>> BTF::resolve_args(std::string_view func,
 
   if (check_traceable) {
     if (bpftrace_ && !bpftrace_->is_traceable_func(std::string(func))) {
-      // TODO: do not create stream just for not-empty check
-      if (bpftrace_->get_traceable_funcs(false)->eof()) {
+      if (bpftrace_->traceable_funcs_reader_.get_all_funcs().empty()) {
         return make_error<ast::ArgParseError>(
             func,
             "could not read traceable functions from " +

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -103,6 +103,8 @@ private:
       const std::string &mod) const;
   virtual std::unique_ptr<std::istream> get_running_bpf_programs() const;
   virtual std::unique_ptr<std::istream> get_raw_tracepoint_symbols() const;
+  virtual std::unique_ptr<std::istream> get_raw_tracepoints_from_traceable_funcs()
+      const;
 
   std::unique_ptr<std::istream> get_iter_symbols() const;
 


### PR DESCRIPTION
The only user of probes list stream is ProbeMatcher, so move code creating the stream, out of Bpftrace class to ProbeMatcher class.

