### PR TITLE
Fix typeof for map desugaring

### DIFF
--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5777,7 +5777,6 @@ fn foo($x : int64, $y : int64) : typeof($z) { return 0; }
 
 TEST_F(SemanticAnalyserTest, typeof_casts)
 {
-  // Legal casts are still legal.
   test(R"(kprobe:f { $x = (uint8)1; $y = (typeof($x))10; })");
   test(R"(kprobe:f { $x = (void*)0; $y = (typeof($x))1; })");
 
@@ -5785,7 +5784,17 @@ TEST_F(SemanticAnalyserTest, typeof_casts)
   test(R"(kprobe:f { $x = (uint8)1; $y = (typeof($x))256; })");
   test(R"(kprobe:f { $x = (uint8)1; $y = (typeof($x))-1; })");
 
-  // Illegal casts are still illegal.
+  // Map keys and values
+  test(
+      R"(kprobe:f { let $a: int8; $a = (typeof(@x))2; @x[(int8)2] = (uint32)10; })");
+  test(R"(kprobe:f { let $a: int8; $a = (typeof(@x))2; @x = (int8)10; })");
+  test(
+      R"(kprobe:f { let $a: int8; $a = (typeof(@x[1]))2; @x[(int32)2] = (int8)10; })");
+  // This is read as a scalar map access which doesn't match the map type
+  test(
+      R"(kprobe:f { let $a: int8; $a = (typeof({ @x }))2; @x[(int8)2] = (uint32)10; })",
+      Error{});
+
   test(
       R"(struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; })",
       Error{ R"(


### PR DESCRIPTION
Stacked PRs:
 * #4973
 * __->__#4972


--- --- ---

### Fix typeof for map desugaring


We need to wait to evaluate typeof in the MapDefaultKey pass in case a map
is assigned to after the typeof in the AST. Not doing so causes this to be
an error: `$a = (typeof(@x))1; @x[(int16)1] = 1;` because the first
appearance of `@x` looks like a scalar usage but it's not. The typeof wants
the type of the map key.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>