### PR TITLE
Disallow map assign in meta/introspection funcs

### DIFF
--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5872,6 +5872,16 @@ TEST_F(SemanticAnalyserTest, no_meta_used_warnings)
        NoWarning{ "Variable used" });
 }
 
+TEST_F(SemanticAnalyserTest, no_meta_map_assignments)
+{
+  test("begin { let $b : typeof({ @a = 1; 1 }); }", Error{});
+  test("begin { $b = typeinfo({ @a = 1; 1 }); }", Error{});
+  test("begin { print(sizeof({ @a = 1; 1 })); }", Error{});
+  test("struct Foo { int x; }  begin { let $a : struct Foo*; print(offsetof({ "
+       "@a =1; *$a}, x)); }",
+       Error{});
+}
+
 TEST_F(SemanticAnalyserTest, probe_return)
 {
   test("begin { return 1; }");


### PR DESCRIPTION
Stacked PRs:
 * __->__#4973


--- --- ---

### Disallow map assign in meta/introspection funcs


Currently these assignments don't affect runtime behavior so at best
they're confusing but they can also cause changes to map value types which
is just wrong. Disallowing mutations to map key types is something we want
to also prevent but that will be fixed in a later PR.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>