### PR TITLE
passes: remove `listing` mode from passes, use `ProbeMatcher` directly

### DIFF
--- a/src/ast/passes/attachpoint_passes.h
+++ b/src/ast/passes/attachpoint_passes.h
@@ -33,8 +33,7 @@ class AttachPointParser {
 public:
   AttachPointParser(ASTContext &ctx,
                     BPFtrace &bpftrace,
-                    FunctionInfo &func_info_state,
-                    bool listing);
+                    FunctionInfo &func_info_state);
   ~AttachPointParser() = default;
   void parse();
 
@@ -86,12 +85,11 @@ private:
   std::stringstream errs_;
   std::vector<std::string> parts_;
   AttachPointList new_attach_points;
-  bool listing_;
   bool has_iter_ap_ = false;
 };
 
 // The attachpoints are expanded in their own separate pass.
-Pass CreateParseAttachpointsPass(bool listing = false);
-Pass CreateCheckAttachpointsPass(bool listing = false);
+Pass CreateParseAttachpointsPass();
+Pass CreateCheckAttachpointsPass();
 
 } // namespace bpftrace::ast

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -72,10 +72,16 @@ public:
   std::set<std::string> expand_probetype_kernel(const std::string &probe_type);
   std::set<std::string> expand_probetype_userspace(
       const std::string &probe_type);
-  // Match all probes in prog and print them to stdout.
-  void list_probes(ast::Program *prog);
-  // Print definitions of structures matching search.
-  void list_structs(const std::string &search);
+  // Match all probes in prog and return them as formatted strings.
+  std::vector<std::string> get_probes_for_listing(ast::Program *prog);
+  // Get probes matching a raw pattern string (e.g., "kprobe:*", "*:*foo*").
+  // If pid is provided, userspace probes will be included even with wildcard
+  // probe types; otherwise userspace probes require explicit probe type.
+  std::vector<std::string> get_probes_for_listing(
+      const std::string &pattern,
+      std::optional<pid_t> pid = std::nullopt);
+  // Get definitions of structures matching search.
+  std::vector<std::string> get_structs_for_listing(const std::string &search);
 
   const BPFtrace *bpftrace_;
   util::KernelFunctionInfo &kernel_func_info_;
@@ -113,5 +119,12 @@ private:
 
   FuncParamLists get_iters_params(const std::set<std::string> &iters);
   FuncParamLists get_uprobe_params(const std::set<std::string> &uprobes);
+  FuncParamLists get_params_for_matches(ProbeType probe_type,
+                                        const std::set<std::string> &matches);
+  void format_matches_for_listing(ProbeType probe_type,
+                                  const std::set<std::string> &matches,
+                                  const FuncParamLists &param_lists,
+                                  std::vector<std::string> &results,
+                                  const std::string &lang = "");
 };
 } // namespace bpftrace

--- a/src/util/kernel.h
+++ b/src/util/kernel.h
@@ -29,7 +29,7 @@ public:
   virtual ~KernelFunctionInfo() = default;
 
   // Returns the set of available modules.
-  virtual const ModuleSet &get_modules() const = 0;
+  virtual ModuleSet get_modules(const std::optional<std::string> &mod_name = std::nullopt) const = 0;
 
   // Returns all traceable functions.
   virtual ModulesFuncsMap get_traceable_funcs(const std::optional<std::string> &mod_name = std::nullopt) const = 0;
@@ -95,7 +95,7 @@ public:
 
   bool is_module_loaded(const std::string &mod_name) const override {
     const auto *impl = static_cast<const T *>(this);
-    return impl->get_modules().contains(mod_name);
+    return !impl->get_modules(mod_name).empty();
   }
 };
 
@@ -109,7 +109,7 @@ public:
   KernelFunctionInfoImpl &operator=(KernelFunctionInfoImpl &&other) = default;
   ~KernelFunctionInfoImpl() override = default;
 
-  const ModuleSet &get_modules() const override;
+  ModuleSet get_modules(const std::optional<std::string> &mod_name = std::nullopt) const override;
   ModulesFuncsMap get_traceable_funcs(const std::optional<std::string> &mod_name = std::nullopt) const override;
   ModulesFuncsMap get_raw_tracepoints(const std::optional<std::string> &mod_name = std::nullopt) const override;
   ModulesFuncsMap get_tracepoints(const std::optional<std::string> &category_name = std::nullopt) const override;

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -11,9 +11,7 @@ namespace attachpoint_parser {
 
 using ::testing::HasSubstr;
 
-void test(const std::string& input,
-          bool listing = false,
-          const std::string& error = "")
+void test(const std::string& input, const std::string& error = "")
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
@@ -29,7 +27,7 @@ void test(const std::string& input,
                 .put(bpftrace)
                 .put(get_mock_function_info())
                 .add(CreateParsePass())
-                .add(ast::CreateParseAttachpointsPass(listing))
+                .add(ast::CreateParseAttachpointsPass())
                 .run();
 
   std::ostringstream out;
@@ -52,7 +50,7 @@ void test(const std::string& input,
 
 void test_error(const std::string& input, const std::string& error)
 {
-  test(input, false, error);
+  test(input, error);
 }
 
 void test_uprobe_lang(const std::string& input, const std::string& lang = "")
@@ -69,7 +67,7 @@ void test_uprobe_lang(const std::string& input, const std::string& lang = "")
                 .put(bpftrace)
                 .put(get_mock_function_info())
                 .add(CreateParsePass())
-                .add(ast::CreateParseAttachpointsPass(false))
+                .add(ast::CreateParseAttachpointsPass())
                 .run();
 
   ASSERT_TRUE(ok && ast.diagnostics().ok());
@@ -94,10 +92,6 @@ TEST(attachpoint_parser, iter)
              R"(iter probe type does not support wildcards)");
   test_error("iter:task, iter:task_file { 1 }",
              R"(iter probe only supports one attach point)");
-  // Listing is ok
-  test("iter:task* { 1 }", true);
-  test("iter:task:* { 1 }", true);
-  test("iter:task, iter:task_file { 1 }", true);
 }
 
 TEST(attachpoint_parser, uprobe_lang)
@@ -114,7 +108,6 @@ using ::testing::HasSubstr;
 
 void test(BPFtrace& bpftrace,
           const std::string& input,
-          bool listing = false,
           const std::string& error = "")
 {
   // The input provided here is embedded into an expression.
@@ -128,8 +121,8 @@ void test(BPFtrace& bpftrace,
                 .put(bpftrace)
                 .put(get_mock_function_info())
                 .add(CreateParsePass())
-                .add(ast::CreateParseAttachpointsPass(listing))
-                .add(ast::CreateCheckAttachpointsPass(listing))
+                .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateCheckAttachpointsPass())
                 .run();
 
   std::ostringstream out;
@@ -149,25 +142,25 @@ void test(BPFtrace& bpftrace,
   }
 }
 
-void test(const std::string& input, bool listing = false)
+void test(const std::string& input)
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
-  test(bpftrace, input, listing);
+  test(bpftrace, input);
 }
 
 void test_error(const std::string& input, std::string&& error = "ERROR")
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
-  test(bpftrace, input, false, error);
+  test(bpftrace, input, error);
 }
 
 void test_error(BPFtrace& bpftrace,
                 const std::string& input,
                 std::string&& error = "ERROR")
 {
-  test(bpftrace, input, false, error);
+  test(bpftrace, input, error);
 }
 
 TEST(attachpoint_checker, uprobe)
@@ -331,7 +324,6 @@ TEST(attachpoint_checker, hardware)
 
   // Wildcard
   test_error("hardware:*:100000000 { 1 }");
-  test("hardware:*:100000000 { 1 }", true /*listing*/);
 }
 
 TEST(attachpoint_checker, software)
@@ -341,7 +333,6 @@ TEST(attachpoint_checker, software)
 
   // Wildcard
   test_error("software:*:100000000 { 1 }");
-  test("software:*:100000000 { 1 }", true /*listing*/);
 }
 
 } // namespace attachpoint_checker

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -430,8 +430,7 @@ TEST(bpftrace, empty_attachpoint)
   // ... ah, but it doesn't really. What fails is the attachpoint parser. The
   // above is a valid program, it is just not a valid attachpoint.
   StrictMock<MockBPFtrace> bpftrace;
-  ast::AttachPointParser ap_parser(
-      ast, bpftrace, get_mock_function_info(), false);
+  ast::AttachPointParser ap_parser(ast, bpftrace, get_mock_function_info());
   ap_parser.parse();
   EXPECT_FALSE(ast.diagnostics().ok());
 }

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -10,7 +10,8 @@ using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::StrictMock;
 
-const util::ModuleSet &MockKernelFunctionInfo::get_modules() const
+util::ModuleSet MockKernelFunctionInfo::get_modules(
+    [[maybe_unused]] const std::optional<std::string> &mod_name) const
 {
   static const util::ModuleSet modules = {
     "vmlinux", "mock_vmlinux", "kernel_mod_1", "kernel_mod_2"

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -8,7 +8,6 @@
 #include "child.h"
 #include "probe_matcher.h"
 #include "procmon.h"
-#include "util/elf_parser.h"
 #include "util/kernel.h"
 #include "util/result.h"
 #include "util/strings.h"
@@ -19,7 +18,7 @@ namespace bpftrace::test {
 
 class MockKernelFunctionInfo : public util::KernelFunctionInfoBase<MockKernelFunctionInfo> {
 public:
-  const util::ModuleSet &get_modules() const override;
+  util::ModuleSet get_modules(const std::optional<std::string> &mod_name = std::nullopt) const override;
   util::ModulesFuncsMap get_traceable_funcs(const std::optional<std::string> &mod_name = std::nullopt) const override;
   util::ModulesFuncsMap get_raw_tracepoints(const std::optional<std::string> &mod_name = std::nullopt) const override;
   util::ModulesFuncsMap get_tracepoints(const std::optional<std::string> &category_name = std::nullopt) const override;

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -204,7 +204,6 @@ NAME warning on non existent file
 RUN {{BPFTRACE}} -l non_existent_file.bt
 EXPECT WARNING: It appears that 'non_existent_file.bt' is a filename but the file does not exist. Treating 'non_existent_file.bt' as a search pattern.
 TIMEOUT 1
-WILL_FAIL
 
 NAME pid fails validation with leading non-number
 RUN {{BPFTRACE}} -p a1111 file.bt

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -133,7 +133,6 @@ AFTER ./testprogs/syscall read
 
 NAME kprobe_module_missing
 PROG kprobe:nonsense:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT_REGEX .* ERROR: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
 EXPECT_REGEX .* ERROR: No matches for kprobe nonsense:vfs_read.
 WILL_FAIL
 

--- a/tests/tools-parsing-test.sh
+++ b/tests/tools-parsing-test.sh
@@ -30,7 +30,13 @@ function set_tooldir() {
 
 function do_test() {
   local file="$1"
-  if $BPFTRACE_EXECUTABLE --unsafe -v --dry-run "$file" 2>/dev/null >/dev/null; then
+  local probes="$($BPFTRACE_EXECUTABLE -l "$file")"
+  if [[ $? -ne 0 ]]; then
+    echo "$file    failed, unable to list probes";
+  fi
+  if [[ -z "$probes" ]]; then
+    echo "$file    skipped";
+  elif $BPFTRACE_EXECUTABLE --unsafe -v --dry-run "$file" 2>/dev/null >/dev/null; then
     echo "$file    passed"
   else
     echo "$file    failed";


### PR DESCRIPTION
Stacked PRs:
 * __->__#4974


--- --- ---

### passes: remove `listing` mode from passes, use `ProbeMatcher` directly


The `listing` mode adds confusing complexity into the stack, and
requires that we construct a synthetic program simply to list available
probes. Since the `ProbeMatcher` is relatively well-defined and now
available in main, we can just use this directly to support the listing
modes. This requires some additional logic to be implemented, but makes
it much more direct and simple to understand. Further refactoring of the
probe matcher can follow with the providers work, turning providers into
a proper interface that can be implemented.

This change also updates the tools parsing test to skip any tests that
result in all probes being removed. It is not possible to compile these
adequetely to check types.

Signed-off-by: Adin Scannell <amscanne@meta.com>
