### PR TITLE
codegen: move `debug_output` to the more well-trodden runtime error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   - [Migration guide](docs/migration_guide.md##args-in-tracepoints-now-requires-btf)
 - Experimental `watchpoint:func+arg` and `asyncwatchpoint:func+arg` attach points are not supported anymore (for now, at least)
   - [#4890](https://github.com/bpftrace/bpftrace/pull/4890)
+- `BPFTRACE_DEBUG_OUTPUT` is removed, and errors are now propagated via the runtime error path
+  - [#4976](https://github.com/bpftrace/bpftrace/pull/4976)
 #### Added
 - Add `comm()` support for PID parameters.
   - [#4799](https://github.com/bpftrace/bpftrace/pull/4799)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -240,13 +240,6 @@ Default: None
 The path to a BTF file. By default, bpftrace searches several locations to find a BTF file.
 See src/btf.cpp for the details.
 
-==== BPFTRACE_DEBUG_OUTPUT
-
-Default: 0
-
-Outputs bpftrace's runtime debug messages to the trace_pipe. This feature can be turned on by setting
-the value of this environment variable to `1`.
-
 ==== BPFTRACE_KERNEL_BUILD
 
 Default: `/lib/modules/$(uname -r)`

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -165,9 +165,6 @@ public:
                               Value *key,
                               Value *val,
                               const Location &loc);
-  void CreateDebugOutput(std::string fmt_str,
-                         const std::vector<Value *> &values,
-                         const Location &loc);
   void CreateTracePrintk(Value *fmt,
                          Value *fmt_size,
                          const std::vector<Value *> &values,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -595,10 +595,9 @@ ScopedExpr CodegenLLVM::kstack(const SizedType &stype, const Location &loc)
   b_.CreateCondBr(condition, get_stack_success, get_stack_fail);
 
   b_.SetInsertPoint(get_stack_fail);
-  b_.CreateDebugOutput("Failed to get kstack. Error: %d",
-                       std::vector<Value *>{ stack_size },
-                       loc);
+  b_.CreateRuntimeError(RuntimeErrorId::KSTACK, loc);
   b_.CreateBr(merge_block);
+
   b_.SetInsertPoint(get_stack_success);
 
   Value *num_frames = b_.CreateUDiv(stack_size,
@@ -647,10 +646,9 @@ ScopedExpr CodegenLLVM::ustack(const SizedType &stype, const Location &loc)
   b_.CreateCondBr(condition, get_stack_success, get_stack_fail);
 
   b_.SetInsertPoint(get_stack_fail);
-  b_.CreateDebugOutput("Failed to get ustack. Error: %d",
-                       std::vector<Value *>{ stack_size },
-                       loc);
+  b_.CreateRuntimeError(RuntimeErrorId::USTACK, loc);
   b_.CreateBr(merge_block);
+
   b_.SetInsertPoint(get_stack_success);
 
   Value *num_frames = b_.CreateUDiv(stack_size,
@@ -2648,9 +2646,11 @@ ScopedExpr CodegenLLVM::visit(ArrayAccess &arr)
         "oob_cond");
 
     b_.CreateCondBr(cond, is_oob, merge);
+
     b_.SetInsertPoint(is_oob);
     b_.CreateRuntimeError(RuntimeErrorId::ARRAY_ACCESS_OOB, arr.loc);
     b_.CreateBr(merge);
+
     b_.SetInsertPoint(merge);
   }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -207,7 +207,6 @@ public:
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
   int warning_level_ = 1;
-  bool debug_output_ = false;
   std::optional<struct timespec> boottime_;
   std::optional<struct timespec> delta_taitime_;
   bool need_recursion_check_ = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -345,7 +345,10 @@ const std::map<std::string, std::string> DEPRECATED = {
 // These are configuration names that are consumed elsewhere. We use this only
 // to check if we should produce a more helpful error for the user.
 const std::unordered_set<std::string> ENV_ONLY = {
-  "btf", "debug_output", "kernel_build", "kernel_source", "vmlinux",
+  "btf",
+  "kernel_build",
+  "kernel_source",
+  "vmlinux",
 };
 
 // This is applied for all environment variables, and will also be accepted

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,7 +160,6 @@ void usage(std::ostream& out)
   out << "    BPFTRACE_CACHE_USER_SYMBOLS       [default: auto] enable user symbol cache" << std::endl;
   out << "    BPFTRACE_COLOR                    [default: auto] enable log output colorization" << std::endl;
   out << "    BPFTRACE_CPP_DEMANGLE             [default: 1] enable C++ symbol demangling" << std::endl;
-  out << "    BPFTRACE_DEBUG_OUTPUT             [default: 0] enable bpftrace's internal debugging outputs" << std::endl;
   out << "    BPFTRACE_KERNEL_BUILD             [default: /lib/modules/$(uname -r)] kernel build directory" << std::endl;
   out << "    BPFTRACE_KERNEL_SOURCE            [default: /lib/modules/$(uname -r)] kernel headers directory" << std::endl;
   out << "    BPFTRACE_LAZY_SYMBOLICATION       [default: 0] symbolicate lazily/on-demand" << std::endl;
@@ -795,12 +794,6 @@ int main(int argc, char* argv[])
   }
   util::UserFunctionInfoImpl user_func_info;
   ast::FunctionInfo func_info_state(*kernel_func_info, user_func_info);
-
-  // Most configuration can be applied during the configuration pass, however
-  // we need to extract a few bits of configuration up front, because they may
-  // affect the actual compilation process.
-  util::get_bool_env_var("BPFTRACE_DEBUG_OUTPUT",
-                         [&](bool x) { bpftrace.debug_output_ = x; });
 
   bpftrace.usdt_file_activation_ = args.usdt_file_activation;
   bpftrace.safe_mode_ = args.safe_mode;

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -38,7 +38,7 @@ std::ostream &operator<<(std::ostream &os, const RuntimeErrorInfo &info)
 {
   switch (info.error_id) {
     case RuntimeErrorId::HELPER_ERROR: {
-      // Helper errors are handled separately in output
+      // Helper errors are handled separately in output.
       os << "";
       break;
     }
@@ -48,6 +48,18 @@ std::ostream &operator<<(std::ostream &os, const RuntimeErrorInfo &info)
     }
     case RuntimeErrorId::ARRAY_ACCESS_OOB: {
       os << ARRAY_ACCESS_OOB_MSG;
+      break;
+    }
+    case RuntimeErrorId::CPU_COUNT_MISMATCH: {
+      os << CPU_COUNT_MISMATCH_MSG;
+      break;
+    }
+    case RuntimeErrorId::KSTACK: {
+      os << KSTACK_MSG;
+      break;
+    }
+    case RuntimeErrorId::USTACK: {
+      os << USTACK_MSG;
       break;
     }
   }

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -31,10 +31,20 @@ static const auto ARRAY_ACCESS_OOB_MSG =
     "Array access out of bounds. This can lead to unexpected "
     "results.";
 
+static const auto CPU_COUNT_MISMATCH_MSG =
+    "CPU count mismatch; unable to find per-cpu data.";
+
+static const auto KSTACK_MSG = "Error reading kstack.";
+
+static const auto USTACK_MSG = "Error reading ustack.";
+
 enum class RuntimeErrorId {
   DIVIDE_BY_ZERO,
   HELPER_ERROR,
   ARRAY_ACCESS_OOB,
+  CPU_COUNT_MISMATCH,
+  KSTACK,
+  USTACK,
 };
 
 enum class PrintfSeverity {

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -19,11 +19,6 @@ RUN {{BPFTRACE}} -e 'config = { bad_config=raw } begin {}'
 EXPECT stdin:1:12-26: ERROR: bad_config: not a known configuration option
 WILL_FAIL
 
-NAME env only config
-RUN {{BPFTRACE}} -e 'config = { debug_output=1 } begin {}'
-EXPECT stdin:1:12-26: ERROR: debug_output: can only be set as an environment variable
-WILL_FAIL
-
 NAME maps are printed by default
 PROG begin { @["test"] = count();  }
 EXPECT @[test]: 1


### PR DESCRIPTION
Stacked PRs:
 * __->__#4976


--- --- ---

### codegen: move `debug_output` to the more well-trodden runtime error path


Amazingly, there is a separate debug output path that is completely
unrelated to the existing debug output paths. It is accessibly only via
the environment variable `BPFTRACE_DEBUG_OUTPUT` and applies *only* to
certain errors (per_cpu aggregation, kstack, and ustack).

This change removes all the special plumbing associated with this
feature, likely unknown to nearly all users, and replaces it with the
standardized runtime error path. Technically this is a breaking change,
but given that the feature was "env only", it can only be resposible for
serving up errors that were previously being suppressed.

Signed-off-by: Adin Scannell <amscanne@meta.com>
