### PR TITLE
async: remove exceptions from async handlers

### DIFF
--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -1,6 +1,5 @@
-#include <memory>
-
 #include <fstream>
+#include <memory>
 #include <string>
 
 #include "ast/async_event_types.h"
@@ -33,14 +32,15 @@ static Result<std::vector<output::Primitive>> prepare_args(
   return res;
 }
 
-void AsyncHandlers::exit(const OpaqueValue &data)
+Result<> AsyncHandlers::exit(const OpaqueValue &data)
 {
   auto exit = data.bitcast<AsyncEvent::Exit>();
   bpftrace.exit_code = exit.exit_code;
   bpftrace.request_finalize();
+  return OK();
 }
 
-void AsyncHandlers::join(const OpaqueValue &data)
+Result<> AsyncHandlers::join(const OpaqueValue &data)
 {
   auto join = data.bitcast<AsyncEvent::Join>();
   uint64_t join_id = join.join_id;
@@ -58,9 +58,10 @@ void AsyncHandlers::join(const OpaqueValue &data)
     joined << current_str;
   }
   out->join(joined.str());
+  return OK();
 }
 
-void AsyncHandlers::time(const OpaqueValue &data)
+Result<> AsyncHandlers::time(const OpaqueValue &data)
 {
   // not respecting config_->get(ConfigKeyInt::max_strlen)
   char timestr[AsyncHandlers::MAX_TIME_STR_LEN];
@@ -68,28 +69,28 @@ void AsyncHandlers::time(const OpaqueValue &data)
   struct tm tmp;
   t = ::time(nullptr);
   if (!localtime_r(&t, &tmp)) {
-    LOG(WARNING) << "localtime_r: " << strerror(errno);
-    return;
+    return make_error<SystemError>("unable to get localtime");
   }
   auto time = data.bitcast<AsyncEvent::Time>();
   const auto *fmt = bpftrace.resources.time_args[time.time_id].c_str();
   if (strftime(timestr, sizeof(timestr), fmt, &tmp) == 0) {
-    LOG(WARNING) << "strftime returned 0";
-    return;
+    return make_error<SystemError>("strftime returned zero");
   }
   out->time(timestr);
+  return OK();
 }
 
-void AsyncHandlers::runtime_error(const OpaqueValue &data)
+Result<> AsyncHandlers::runtime_error(const OpaqueValue &data)
 {
   auto runtime_error = data.bitcast<AsyncEvent::RuntimeError>();
   auto error_id = runtime_error.error_id;
   const auto return_value = runtime_error.return_value;
   const auto &info = bpftrace.resources.runtime_error_info[error_id];
   out->runtime_error(return_value, info);
+  return OK();
 }
 
-void AsyncHandlers::print_non_map(const OpaqueValue &data)
+Result<> AsyncHandlers::print_non_map(const OpaqueValue &data)
 {
   auto print = data.bitcast<AsyncEvent::PrintNonMap>();
   const SizedType &ty = bpftrace.resources.non_map_print_args.at(
@@ -98,68 +99,61 @@ void AsyncHandlers::print_non_map(const OpaqueValue &data)
   auto v = format(
       bpftrace, c_definitions, ty, data.slice(sizeof(AsyncEvent::PrintNonMap)));
   if (!v) {
-    LOG(BUG) << "error printing non-map value: " << v.takeError();
+    return v.takeError();
   }
   out->value(*v);
+  return OK();
 }
 
-void AsyncHandlers::print_map(const OpaqueValue &data)
+Result<> AsyncHandlers::print_map(const OpaqueValue &data)
 {
   auto print = data.bitcast<AsyncEvent::Print>();
   const auto &map = bpftrace.bytecode_.getMap(print.mapid);
 
   auto res = format(bpftrace, c_definitions, map, print.top, print.div);
   if (!res) {
-    LOG(BUG) << "Could not print map with ident \"" << map.name()
-             << "\": " << res.takeError();
+    return res.takeError();
   }
 
   out->map(map.name(), *res);
+  return OK();
 }
 
-void AsyncHandlers::zero_map(const OpaqueValue &data)
+Result<> AsyncHandlers::zero_map(const OpaqueValue &data)
 {
   auto mapevent = data.bitcast<AsyncEvent::MapEvent>();
   const auto &map = bpftrace.bytecode_.getMap(mapevent.mapid);
   uint64_t nvalues = map.is_per_cpu_type() ? bpftrace.ncpus_ : 1;
-  auto ok = map.zero_out(nvalues);
-
-  if (!ok) {
-    LOG(BUG) << "Could not zero map with ident \"" << map.name()
-             << "\", err=" << ok.takeError();
-  }
+  return map.zero_out(nvalues);
 }
 
-void AsyncHandlers::clear_map(const OpaqueValue &data)
+Result<> AsyncHandlers::clear_map(const OpaqueValue &data)
 {
   auto mapevent = data.bitcast<AsyncEvent::MapEvent>();
   const auto &map = bpftrace.bytecode_.getMap(mapevent.mapid);
-  auto ok = map.clear();
-  if (!ok) {
-    LOG(BUG) << "Could not clear map with ident \"" << map.name()
-             << "\", err=" << ok.takeError();
-  }
+  return map.clear();
 }
 
-void AsyncHandlers::skboutput(const OpaqueValue &data)
+Result<> AsyncHandlers::skboutput(const OpaqueValue &data)
 {
   auto hdr = data.bitcast<AsyncEvent::SkbOutput>();
   int offset = std::get<1>(
       bpftrace.resources.skboutput_args_.at(hdr.skb_output_id));
   auto pkt = data.slice(sizeof(hdr));
   if (static_cast<size_t>(offset) >= pkt.size()) {
-    return; // Nothing to dump.
+    return OK(); // Nothing to dump.
   }
   bpftrace.write_pcaps(hdr.skb_output_id,
                        hdr.nsecs_since_boot,
                        pkt.slice(offset));
+  return OK();
 }
 
-void AsyncHandlers::syscall(const OpaqueValue &data)
+Result<> AsyncHandlers::syscall(const OpaqueValue &data)
 {
   if (bpftrace.safe_mode_) {
-    throw util::FatalUserException(
-        "syscall() not allowed in safe mode. Use '--unsafe'.");
+    return make_error<SystemError>(
+        "syscall() not allowed in safe mode. Use '--unsafe'.", EPERM);
   }
 
   auto id = data.bitcast<uint64_t>() -
@@ -169,7 +163,7 @@ void AsyncHandlers::syscall(const OpaqueValue &data)
   auto vals = prepare_args(
       bpftrace, c_definitions, args, data.slice(sizeof(uint64_t)));
   if (!vals) {
-    LOG(BUG) << "Error processing syscall arguments: " << vals.takeError();
+    return vals.takeError();
   }
 
   // Always execute via a shell, if available.
@@ -179,14 +173,14 @@ void AsyncHandlers::syscall(const OpaqueValue &data)
   system_args.emplace_back(fmt.format(*vals));
   auto result = util::exec_system(system_args);
   if (!result) {
-    LOG(ERROR) << "Error executing program: " << result.takeError();
-    return;
+    return result.takeError();
   }
 
   out->syscall(*result);
+  return OK();
 }
 
-void AsyncHandlers::cat(const OpaqueValue &data)
+Result<> AsyncHandlers::cat(const OpaqueValue &data)
 {
   auto id = data.bitcast<uint64_t>() - static_cast<uint64_t>(AsyncAction::cat);
   auto &fmt = std::get<0>(bpftrace.resources.cat_args[id]);
@@ -194,15 +188,13 @@ void AsyncHandlers::cat(const OpaqueValue &data)
   auto vals = prepare_args(
       bpftrace, c_definitions, args, data.slice(sizeof(uint64_t)));
   if (!vals) {
-    LOG(BUG) << "Error processing cat arguments: " << vals.takeError();
+    return vals.takeError();
   }
 
   auto filename = fmt.format(*vals);
   auto file = std::ifstream(filename, std::ios::binary);
   if (file.fail()) {
-    LOG(ERROR) << "failed to open file '" << filename
-               << "': " << strerror(errno);
-    return;
+    return make_error<SystemError>("failed to open file '" + filename + "'");
   }
 
   // Read up to the maximum bytes specified.
@@ -211,9 +203,10 @@ void AsyncHandlers::cat(const OpaqueValue &data)
   file.read(str.data(), bpftrace.config_->max_cat_bytes);
   str.resize(file.gcount());
   out->cat(str);
+  return OK();
 }
 
-void AsyncHandlers::printf(const OpaqueValue &data)
+Result<> AsyncHandlers::printf(const OpaqueValue &data)
 {
   auto id = data.bitcast<uint64_t>() -
             static_cast<uint64_t>(AsyncAction::printf);
@@ -224,14 +217,15 @@ void AsyncHandlers::printf(const OpaqueValue &data)
   auto vals = prepare_args(
       bpftrace, c_definitions, args, data.slice(sizeof(uint64_t)));
   if (!vals) {
-    LOG(BUG) << "Error processing printf arguments: " << vals.takeError();
+    return vals.takeError();
   }
 
   if (severity == PrintfSeverity::WARNING && bpftrace.warning_level_ == 0) {
-    return;
+    return OK();
   }
 
   out->printf(fmt.format(*vals), source_info, severity);
+  return OK();
 }
 
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -36,18 +36,18 @@ public:
                 output::Output &output)
       : bpftrace(bpftrace), c_definitions(c_definitions), out(&output) {};
 
-  void exit(const OpaqueValue &data);
-  void join(const OpaqueValue &data);
-  void time(const OpaqueValue &data);
-  void runtime_error(const OpaqueValue &data);
-  void print_non_map(const OpaqueValue &data);
-  void print_map(const OpaqueValue &data);
-  void zero_map(const OpaqueValue &data);
-  void clear_map(const OpaqueValue &data);
-  void skboutput(const OpaqueValue &data);
-  void syscall(const OpaqueValue &data);
-  void cat(const OpaqueValue &data);
-  void printf(const OpaqueValue &data);
+  Result<> exit(const OpaqueValue &data);
+  Result<> join(const OpaqueValue &data);
+  Result<> time(const OpaqueValue &data);
+  Result<> runtime_error(const OpaqueValue &data);
+  Result<> print_non_map(const OpaqueValue &data);
+  Result<> print_map(const OpaqueValue &data);
+  Result<> zero_map(const OpaqueValue &data);
+  Result<> clear_map(const OpaqueValue &data);
+  Result<> skboutput(const OpaqueValue &data);
+  Result<> syscall(const OpaqueValue &data);
+  Result<> cat(const OpaqueValue &data);
+  Result<> printf(const OpaqueValue &data);
 
   void change_output(output::Output &out)
   {

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -172,7 +172,7 @@ EXPECT hello
 
 NAME cat "no such file"
 PROG i:ms:1 { cat("/does/not/exist/file"); exit(); }
-EXPECT ERROR: failed to open file '/does/not/exist/file': No such file or directory
+EXPECT ERROR: failed to open file '/does/not/exist/file' (No such file or directory)
 
 NAME sizeof
 PROG struct Foo { int x; char c; } begin { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x));  }


### PR DESCRIPTION
Stacked PRs:
 * #4980
 * #4979
 * __->__#4978


--- --- ---

### async: remove exceptions from async handlers


Instead, use regular error propagation. The program can keep running
when a "FatalUserException" has occured, which may be for many reasons.
This also simplifies testing, which no longer requires stderr capture.

Signed-off-by: Adin Scannell <amscanne@meta.com>
