### PR TITLE
builtins: make `cpid` similar to `ncpu` and AOT-friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to
   - [#4947](https://github.com/bpftrace/bpftrace/pull/4947)
 - Add `find` to get map value if it exists
   - [#4845](https://github.com/bpftrace/bpftrace/pull/4845)
+- Make `cpid` AOT friendly; using `cpid` while lacking a command is no longer a compile error and `has_cpid` has been added
+  - [#4984](https://github.com/bpftrace/bpftrace/pull/4984)
 #### Changed
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -168,7 +168,11 @@ This utilizes the BPF helper `get_current_comm`
 - `uint32 cpid()`
 - `uint32 cpid`
 
-Child process ID, if bpftrace is invoked with `-c`
+Child process ID, if bpftrace is invoked with `-c`.
+
+If there is no child process, a runtime warning will be issued and the
+return value will be zero.  This warning can be avoided by using `has_cpid`
+to check if `cpid` has a value, prior to referencing `cpid`.
 
 
 ### cpu
@@ -360,6 +364,13 @@ You can use `--help` to see all named arguments/options.
 Group ID of the current thread, as seen from the init namespace
 
 This utilizes the BPF helper `get_current_uid_gid`
+
+
+### has_cpid
+- `bool has_cpid()`
+- `bool has_cpid`
+
+Returns true iff cpid is available.
 
 
 ### has_key

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -247,10 +247,6 @@ std::optional<Expression> Builtins::visit(Builtin &builtin)
     if (arch::Host::Machine != arch::Machine::X86_64) {
       builtin.addError() << "'usermode' builtin is only supported on x86_64";
     }
-  } else if (builtin.ident == "__builtin_cpid") {
-    if (!has_child_) {
-      builtin.addError() << "cpid cannot be used without child command";
-    }
   } else if (builtin.ident == "args") {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -825,11 +825,10 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
     // ctx is undocumented builtin: for debugging.
     return ScopedExpr(ctx_);
   } else if (builtin.ident == "__builtin_cpid") {
-    pid_t cpid = bpftrace_.child_->pid();
-    if (cpid < 1) {
-      LOG(BUG) << "Invalid cpid: " << cpid;
-    }
-    return ScopedExpr(b_.getInt64(cpid));
+    return ScopedExpr(b_.CreateLoad(b_.getInt64Ty(),
+                                    module_->getGlobalVariable(std::string(
+                                        bpftrace::globalvars::CHILD_PID)),
+                                    "child_pid.cmp"));
   } else if (builtin.ident == "__builtin_jiffies") {
     return ScopedExpr(b_.CreateJiffies64(builtin.loc));
   } else {

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -161,6 +161,8 @@ void ResourceAnalyser::visit(Builtin &builtin)
 
   if (builtin.ident == "__builtin_ncpus") {
     resources_.global_vars.add_known(bpftrace::globalvars::NUM_CPUS);
+  } else if (builtin.ident == "__builtin_cpid") {
+    resources_.global_vars.add_known(bpftrace::globalvars::CHILD_PID);
   } else if (builtin.ident == "ustack" || builtin.ident == "kstack") {
     if (exceeds_stack_limit(builtin.builtin_type.GetSize())) {
       resources_.call_stack_buffers++;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -959,7 +959,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
   } else if (builtin.ident == "__builtin_usermode") {
     builtin.builtin_type = CreateUInt8();
   } else if (builtin.ident == "__builtin_cpid") {
-    builtin.builtin_type = CreateUInt32();
+    builtin.builtin_type = CreateUInt64();
   } else if (builtin.ident == "args") {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -105,7 +105,9 @@ void BpfBytecode::update_global_vars(BPFtrace &bpftrace,
       section_names_to_global_vars_map_,
       std::move(global_var_vals),
       bpftrace.ncpus_,
-      bpftrace.max_cpu_id_);
+      bpftrace.max_cpu_id_,
+      bpftrace.child_ ? std::make_optional<pid_t>(bpftrace.child_->pid())
+                      : std::nullopt);
 }
 
 uint64_t BpfBytecode::get_event_loss_counter(BPFtrace &bpftrace, int max_cpu_id)

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -529,10 +529,18 @@ void GlobalVars::update_global_vars(
         &section_name_to_global_vars_map,
     GlobalVarMap &&global_var_vals,
     uint64_t ncpus,
-    uint64_t max_cpu_id)
+    uint64_t max_cpu_id,
+    std::optional<pid_t> child_pid)
 {
   global_var_vals[std::string(globalvars::NUM_CPUS)] = ncpus;
   global_var_vals[std::string(globalvars::MAX_CPU_ID)] = max_cpu_id;
+  if (child_pid.has_value()) {
+    auto value = static_cast<uint64_t>(*child_pid);
+    global_var_vals[std::string(globalvars::CHILD_PID)] = value;
+  } else {
+    uint64_t empty_value = 0;
+    global_var_vals[std::string(globalvars::CHILD_PID)] = empty_value;
+  }
 
   verify_maps_found(section_name_to_global_vars_map);
   for (const auto &[section_name, global_vars_map] :

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -111,6 +111,7 @@ constexpr std::string_view VARIABLE_BUFFER = "__bt__var_buf";
 constexpr std::string_view MAP_KEY_BUFFER = "__bt__map_key_buf";
 constexpr std::string_view EVENT_LOSS_COUNTER = "__bt__event_loss_counter";
 constexpr std::string_view JOIN_BUFFER = "__bt__join_buf";
+constexpr std::string_view CHILD_PID = "__bt__child_pid";
 
 // Section names
 constexpr std::string_view RO_SECTION_NAME = ".rodata";
@@ -174,6 +175,8 @@ const std::unordered_map<std::string_view, GlobalVarConfig>
         { .section = std::string(MAP_KEY_BUFFER_SECTION_NAME) } },
       { JOIN_BUFFER,
         { .section = std::string(JOIN_BUFFER_SECTION_NAME) } },
+      { CHILD_PID,
+        { .section = std::string(RO_SECTION_NAME), .type = GlobalVarConfig::opt_unsigned } },
     };
 
 class GlobalVars {
@@ -207,7 +210,8 @@ public:
       const std::unordered_map<std::string, struct bpf_map *> &global_vars_map,
       GlobalVarMap &&global_var_vals,
       uint64_t ncpus,
-      uint64_t max_cpu_id);
+      uint64_t max_cpu_id,
+      std::optional<pid_t> child_pid);
 
   std::unordered_set<std::string> get_global_vars_for_section(
       std::string_view target_section);

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -174,11 +174,26 @@ macro comm(arg_pid)
   comm($pid)
 }
 
+// :variant bool has_cpid()
+// Returns true iff cpid is available.
+macro has_cpid()
+{
+  __builtin_cpid == 0
+}
+
 // :variant uint32 cpid()
-// Child process ID, if bpftrace is invoked with `-c`
+// Child process ID, if bpftrace is invoked with `-c`.
+//
+// If there is no child process, a runtime warning will be issued and the
+// return value will be zero.  This warning can be avoided by using `has_cpid`
+// to check if `cpid` has a value, prior to referencing `cpid`.
 macro cpid()
 {
-  __builtin_cpid
+  let $cpid = __builtin_cpid;
+  if (__builtin_cpid == 0) {
+    warnf("No child command (`-c`); cpid is zero");
+  }
+  $cpid
 }
 
 // :variant uint32 cpu()


### PR DESCRIPTION
Stacked PRs:
 * __->__#4984


--- --- ---

### builtins: make `cpid` similar to `ncpu` and AOT-friendly


Instead of being filled in at runtime, make this a static constant that
can be inlined by the verifier. This will work at runtime and all other
times, for programs that work even when there isn't a child. The cpid
will simply be zero in those cases.

Signed-off-by: Adin Scannell <amscanne@meta.com>
