### PR TITLE
Runtime tests: Drop usage of nft_trans_alloc_gfp

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -204,15 +204,15 @@ REQUIRES nft --help
 CLEANUP nft delete table bpftrace
 
 NAME kprobe_offset_module_error
-RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
+RUN {{BPFTRACE}} -e 'kprobe:nf_tables_newtable+0x1 { printf("hit\n"); exit(); }'
 EXPECT ERROR: Possible attachment attempt in the middle of an instruction, try a different offset.
 ARCH x86_64
 REQUIRES lsmod | grep '^nf_tables'
 WILL_FAIL
 
 NAME kprobe_offset_module_error
-RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
-EXPECT ERROR: Unable to attach probe: kprobe:nft_trans_alloc_gfp+0x1. If this is expected, set the 'missing_probes' config variable to 'warn'.
+RUN {{BPFTRACE}} -e 'kprobe:nf_tables_newtable+0x1 { printf("hit\n"); exit(); }'
+EXPECT ERROR: Unable to attach probe: kprobe:nf_tables_newtable+0x1. If this is expected, set the 'missing_probes' config variable to 'warn'.
 ARCH aarch64|ppc64le|ppc64
 REQUIRES lsmod | grep '^nf_tables'
 WILL_FAIL


### PR DESCRIPTION
The `nft_trans_alloc_gfp` function has been recently removed by kernel commit [3d95a2e016ab](https://github.com/torvalds/linux/commit/3d95a2e016ab) ("netfilter: nf_tables: all transaction allocations can now sleep"). Replace it by `nf_tables_newtable` in the relevant tests.

This is in line with 79460f34 ("tests: runtime: Use nf_tables_newtable for module tests") which did the same change for the rest of the tests.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
