### PR TITLE
Create VariablePreCheck pass

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(ast STATIC
   passes/type_system.cpp
   passes/unstable_feature.cpp
   passes/usdt_arguments.cpp
+  passes/variable_precheck.cpp
 )
 
 add_dependencies(ast parser)

--- a/src/ast/passes/variable_precheck.cpp
+++ b/src/ast/passes/variable_precheck.cpp
@@ -1,0 +1,262 @@
+#include "ast/passes/variable_precheck.h"
+
+#include <variant>
+
+#include "ast/ast.h"
+#include "ast/visitor.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+using VarOrigin = std::
+    variant<VarDeclStatement *, AssignVarStatement *, SubprogArg *, Variable *>;
+
+struct VarInfo {
+  VarOrigin origin;
+  bool was_assigned;
+};
+
+using Scope = Node *;
+
+void add_origin_context(Diagnostic &d, const VarOrigin &origin)
+{
+  std::visit(
+      [&d](auto &&arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, VarDeclStatement *>) {
+          d.addContext(arg->loc) << "This is the initial declaration.";
+        } else if constexpr (std::is_same_v<T, AssignVarStatement *>) {
+          d.addContext(arg->loc) << "This is the initial assignment.";
+        } else if constexpr (std::is_same_v<T, SubprogArg *>) {
+          d.addContext(arg->loc) << "This is the function parameter.";
+        } else if constexpr (std::is_same_v<T, Variable *>) {
+          d.addContext(arg->loc) << "This is the loop variable.";
+        }
+      },
+      origin);
+}
+
+class VariablePreCheck : public Visitor<VariablePreCheck> {
+public:
+  using Visitor<VariablePreCheck>::visit;
+
+  void visit(Variable &var);
+  void visit(VariableAddr &var_addr);
+  void visit(VarDeclStatement &decl);
+  void visit(AssignVarStatement &assignment);
+  void visit(SubprogArg &arg);
+  void visit(BlockExpr &block);
+  void visit(For &f);
+  void visit(Subprog &subprog);
+  void visit(Probe &probe);
+  void visit(Sizeof &szof);
+  void visit(Offsetof &offof);
+  void visit(Typeof &typeof_);
+  void visit(Typeinfo &typeinfo);
+
+private:
+  VarInfo *find_variable(const std::string &name);
+  void check_variable_decls();
+  std::vector<Scope> scope_stack_;
+  std::map<Scope, std::map<std::string, VarInfo>> variables_;
+  uint32_t meta_depth_ = 0; // sizeof, offsetof, typeof, typeinfo
+};
+
+VarInfo *VariablePreCheck::find_variable(const std::string &name)
+{
+  for (auto *scope : scope_stack_) {
+    if (auto scope_it = variables_.find(scope); scope_it != variables_.end()) {
+      if (auto var_it = scope_it->second.find(name);
+          var_it != scope_it->second.end()) {
+        return &var_it->second;
+      }
+    }
+  }
+  return nullptr;
+}
+
+void VariablePreCheck::check_variable_decls()
+{
+  for (const auto &[scope, var_map] : variables_) {
+    for (const auto &[ident, info] : var_map) {
+      if (info.was_assigned) {
+        continue;
+      }
+      if (const auto *decl = std::get_if<VarDeclStatement *>(&info.origin)) {
+        (*decl)->addWarning()
+            << "Variable " << ident << " was never assigned to.";
+      }
+    }
+  }
+}
+
+void VariablePreCheck::visit(Variable &var)
+{
+  if (auto *info = find_variable(var.ident)) {
+    if (!info->was_assigned && meta_depth_ == 0) {
+      var.addWarning() << "Variable used before it was assigned: " << var.ident;
+    }
+  } else {
+    var.addError() << "Undefined or undeclared variable: " << var.ident;
+  }
+}
+
+void VariablePreCheck::visit(VariableAddr &var_addr)
+{
+  if (auto *found = find_variable(var_addr.var->ident)) {
+    // We can't know if the pointer to a scratch variable was passed
+    // to an external function for assignment so just mark it as assigned.
+    found->was_assigned = true;
+  } else {
+    var_addr.var->addError()
+        << "Undefined or undeclared variable: " << var_addr.var->ident;
+  }
+}
+
+void VariablePreCheck::visit(VarDeclStatement &decl)
+{
+  // Only visit typeof, not the variable being declared
+  visit(decl.typeof);
+
+  const std::string &var_ident = decl.var->ident;
+
+  if (const auto *info = find_variable(var_ident)) {
+    auto &err = decl.addError();
+    err << "Variable " << var_ident
+        << " was already declared. Variable shadowing is not "
+           "allowed.";
+    add_origin_context(err, info->origin);
+    return;
+  }
+
+  // Declaration without assignment - was_assigned = false
+  if (!scope_stack_.empty()) {
+    variables_[scope_stack_.back()][var_ident] = VarInfo{
+      .origin = &decl, .was_assigned = false
+    };
+  }
+}
+
+void VariablePreCheck::visit(AssignVarStatement &assignment)
+{
+  visit(assignment.expr);
+
+  if (std::holds_alternative<VarDeclStatement *>(assignment.var_decl)) {
+    visit(assignment.var_decl);
+  }
+
+  const std::string &var_ident = assignment.var()->ident;
+  if (auto *info = find_variable(var_ident)) {
+    info->was_assigned = true;
+  } else if (!scope_stack_.empty()) {
+    variables_[scope_stack_.back()][var_ident] = VarInfo{
+      .origin = &assignment, .was_assigned = true
+    };
+  }
+}
+
+void VariablePreCheck::visit(SubprogArg &arg)
+{
+  // Only visit typeof, not the variable being defined as a parameter
+  visit(arg.typeof);
+}
+
+void VariablePreCheck::visit(BlockExpr &block)
+{
+  scope_stack_.push_back(&block);
+  Visitor<VariablePreCheck>::visit(block);
+  scope_stack_.pop_back();
+}
+
+void VariablePreCheck::visit(For &f)
+{
+  const auto &decl_name = f.decl->ident;
+  if (const auto *info = find_variable(decl_name)) {
+    auto &err = f.decl->addError();
+    err << "Loop declaration shadows existing variable: " + decl_name;
+    add_origin_context(err, info->origin);
+  }
+
+  visit(f.iterable);
+
+  scope_stack_.push_back(&f);
+  // Loop variable is always assigned
+  variables_[&f][decl_name] = VarInfo{ .origin = f.decl, .was_assigned = true };
+
+  visit(f.block);
+
+  scope_stack_.pop_back();
+}
+
+void VariablePreCheck::visit(Subprog &subprog)
+{
+  scope_stack_.push_back(&subprog);
+
+  // Function parameters are always assigned
+  for (auto *arg : subprog.args) {
+    variables_[&subprog][arg->var->ident] = VarInfo{ .origin = arg,
+                                                     .was_assigned = true };
+  }
+  visit(subprog.args);
+  visit(subprog.block);
+  visit(subprog.return_type);
+
+  check_variable_decls();
+  scope_stack_.pop_back();
+}
+
+void VariablePreCheck::visit(Probe &probe)
+{
+  scope_stack_.push_back(&probe);
+  Visitor<VariablePreCheck>::visit(probe);
+  check_variable_decls();
+  scope_stack_.pop_back();
+}
+
+void VariablePreCheck::visit(Sizeof &szof)
+{
+  meta_depth_++;
+  Visitor<VariablePreCheck>::visit(szof);
+  meta_depth_--;
+}
+
+void VariablePreCheck::visit(Offsetof &offof)
+{
+  meta_depth_++;
+  Visitor<VariablePreCheck>::visit(offof);
+  meta_depth_--;
+}
+
+void VariablePreCheck::visit(Typeof &typeof_)
+{
+  meta_depth_++;
+  Visitor<VariablePreCheck>::visit(typeof_);
+  meta_depth_--;
+}
+
+void VariablePreCheck::visit(Typeinfo &typeinfo)
+{
+  meta_depth_++;
+  Visitor<VariablePreCheck>::visit(typeinfo);
+  meta_depth_--;
+}
+
+} // namespace
+
+Pass CreateVariablePreCheckPass()
+{
+  auto fn = [](ASTContext &ast) {
+    // Variable state is effectively reset for each probe and subprog
+    for (auto &subprog : ast.root->functions) {
+      VariablePreCheck().visit(subprog);
+    }
+    for (auto &probe : ast.root->probes) {
+      VariablePreCheck().visit(probe);
+    }
+  };
+
+  return Pass::create("VariablePreCheck", fn);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/variable_precheck.h
+++ b/src/ast/passes/variable_precheck.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+// This pass issues errors and warnings about basic variable usage
+// - variable was never assigned to
+// - variable was used before assignment
+// - variable declaration shadows another variable
+// - variable is not defined
+Pass CreateVariablePreCheckPass();
+
+} // namespace bpftrace::ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "ast/passes/type_system.h"
+#include "ast/passes/variable_precheck.h"
 #include "benchmark.h"
 #include "bpffeature.h"
 #include "bpftrace.h"
@@ -344,6 +345,7 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
 {
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
+  add(ast::CreateVariablePreCheckPass());
   add(ast::CreateSemanticPass());
   add(ast::CreateResourcePass());
 }
@@ -353,6 +355,7 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreatePortabilityPass());
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
+  add(ast::CreateVariablePreCheckPass());
   add(ast::CreateSemanticPass());
   add(ast::CreateResourcePass());
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(bpftrace_test
   type_system.cpp
   unstable_feature.cpp
   utils.cpp
+  variable_precheck.cpp
 )
 add_test(NAME bpftrace_test COMMAND bpftrace_test)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/near_self_file "near_self_file")

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -563,110 +563,60 @@ kprobe:f { @x = 1; @x = hist(0); }
 
 TEST_F(SemanticAnalyserTest, compound_left)
 {
-  test("kprobe:f { $a <<= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a <<= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a <<= 1 }");
   test("kprobe:f { @a <<= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_right)
 {
-  test("kprobe:f { $a >>= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a >>= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a >>= 1 }");
   test("kprobe:f { @a >>= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_plus)
 {
-  test("kprobe:f { $a += 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a += 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a += 1 }");
   test("kprobe:f { @a += 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_minus)
 {
-  test("kprobe:f { $a -= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a -= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a -= 1 }");
   test("kprobe:f { @a -= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_mul)
 {
-  test("kprobe:f { $a *= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a *= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a *= 1 }");
   test("kprobe:f { @a *= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_div)
 {
-  test("kprobe:f { $a /= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a /= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a /= 1 }");
   test("kprobe:f { @a /= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_mod)
 {
-  test("kprobe:f { $a %= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a %= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a %= 1 }");
   test("kprobe:f { @a %= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_band)
 {
-  test("kprobe:f { $a &= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a &= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a &= 1 }");
   test("kprobe:f { @a &= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_bor)
 {
-  test("kprobe:f { $a |= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a |= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a |= 1 }");
   test("kprobe:f { @a |= 1 }");
 }
 
 TEST_F(SemanticAnalyserTest, compound_bxor)
 {
-  test("kprobe:f { $a ^= 0 }", Error{ R"(
-stdin:1:12-14: ERROR: Undefined or undeclared variable: $a
-kprobe:f { $a ^= 0 }
-           ~~
-)" });
   test("kprobe:f { $a = 0; $a ^= 1 }");
   test("kprobe:f { @a ^= 1 }");
 }
@@ -1801,7 +1751,7 @@ TEST_F(SemanticAnalyserTest, variable_reassignment)
 
   test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = 1; })",
        Error{ R"(
-stdin:1:23-30: ERROR: Type mismatch for $b: trying to assign value of type 'uint8' when variable already contains a value of type 'string[3]'
+stdin:1:23-30: ERROR: Type mismatch for $b: trying to assign value of type 'uint8' when variable already has a type 'string[3]'
 kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = 1; }
                       ~~~~~~~
 )" });
@@ -1811,11 +1761,6 @@ TEST_F(SemanticAnalyserTest, map_use_before_assign)
 {
   test("kprobe:f { @x = @y; @y = 2; }");
   test("kprobe:f { @y = 0; @y = @x; @x = 1; }");
-}
-
-TEST_F(SemanticAnalyserTest, variable_use_before_assign)
-{
-  test("kprobe:f { @x = $y; $y = 2; }", Error{});
 }
 
 TEST_F(SemanticAnalyserTest, maps_are_global)
@@ -3253,7 +3198,7 @@ TEST_F(SemanticAnalyserTest, mixed_int_var_assignments)
   test("begin { $a = -1; $a = 9223372036854775808; }", Error{});
   test("begin { $a = 9223372036854775807; $a = -2147483648 }", Error{});
   test("kprobe:f { $x = -1; $x = 10223372036854775807; }", Error{ R"(
-stdin:1:21-46: ERROR: Type mismatch for $x: trying to assign value of type 'uint64' when variable already contains a value of type 'int8'
+stdin:1:21-46: ERROR: Type mismatch for $x: trying to assign value of type 'uint64' when variable already has a type 'int8'
 kprobe:f { $x = -1; $x = 10223372036854775807; }
                     ~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -3948,7 +3893,7 @@ TEST_F(SemanticAnalyserTest, tuple)
 
   test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); })",
        Error{ R"(
-stdin:1:33-57: ERROR: Type mismatch for $t: trying to assign value of type '(uint8,(uint64,uint8))' when variable already contains a value of type '(uint8,(int8,uint8))'
+stdin:1:33-57: ERROR: Type mismatch for $t: trying to assign value of type '(uint8,(uint64,uint8))' when variable already has a type '(uint8,(int8,uint8))'
 begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); }
                                 ~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -4709,21 +4654,6 @@ begin { @map[0] = stats(10); for ($kv : @map) { } }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_shadowed_decl)
-{
-  test(R"(
-    begin {
-      $kv = 1;
-      @map[0] = 1;
-      for ($kv : @map) { }
-    })",
-       Error{ R"(
-stdin:4:12-15: ERROR: Loop declaration shadows existing variable: $kv
-      for ($kv : @map) { }
-           ~~~
-)" });
-}
-
 TEST_F(SemanticAnalyserTest, for_loop_variables_read_only)
 {
   test(
@@ -4856,37 +4786,6 @@ TEST_F(SemanticAnalyserTest, for_loop_variables_multiple)
             Jump(ast::JumpType::RETURN) })) });
 }
 
-TEST_F(SemanticAnalyserTest, for_loop_variables_created_in_loop_used_after)
-{
-  test(R"(
-    begin {
-      @map[0] = 1;
-      for ($kv : @map) {
-        $var = 2;
-      }
-      print($var);
-    })",
-       Error{ R"(
-stdin:6:13-17: ERROR: Undefined or undeclared variable: $var
-      print($var);
-            ~~~~
-)" });
-
-  test(R"(
-    begin {
-      @map[0] = 1;
-      for ($kv : @map) {
-        print($kv);
-      }
-      print($kv);
-    })",
-       Error{ R"(
-stdin:6:13-16: ERROR: Undefined or undeclared variable: $kv
-      print($kv);
-            ~~~
-)" });
-}
-
 TEST_F(SemanticAnalyserTest, for_loop_invalid_expr)
 {
   // Error location is incorrect: #3063
@@ -4904,22 +4803,6 @@ begin { for ($x : 1+2) { } }
 stdin:1:24-25: ERROR: syntax error, unexpected ), expecting [ or . or ->
 begin { for ($x : "abc") { } }
                        ~
-)" });
-}
-
-TEST_F(SemanticAnalyserTest, for_loop_multiple_errors)
-{
-  // Error location is incorrect: #3063
-  test(R"(
-    begin {
-      $kv = 1;
-      @map[0] = 1;
-      for ($kv : @map) { }
-    })",
-       Error{ R"(
-stdin:4:12-15: ERROR: Loop declaration shadows existing variable: $kv
-      for ($kv : @map) { }
-           ~~~
 )" });
 }
 
@@ -4963,15 +4846,6 @@ TEST_F(SemanticAnalyserTest, for_range_variable_use)
        "$i * 2; } }");
 }
 
-TEST_F(SemanticAnalyserTest, for_range_shadowing)
-{
-  test(R"(begin { $i = 10; for ($i : 0..5) { printf("%d", $i); } })", Error{ R"(
-stdin:1:23-25: ERROR: Loop declaration shadows existing variable: $i
-begin { $i = 10; for ($i : 0..5) { printf("%d", $i); } }
-                      ~~
-)" });
-}
-
 TEST_F(SemanticAnalyserTest, for_range_invalid_types)
 {
   test(R"(begin { for ($i : "str"..5) { printf("%d", $i); } })", Error{ R"(
@@ -5001,16 +4875,6 @@ TEST_F(SemanticAnalyserTest, for_range_control_flow)
   test("begin { for ($i : 0..5) { break; } }");
   test("begin { for ($i : 0..5) { continue; } }");
   test("begin { for ($i : 0..5) { return; } }");
-}
-
-TEST_F(SemanticAnalyserTest, for_range_out_of_scope)
-{
-  test(R"(begin { for ($i : 0..5) { printf("%d", $i); } printf("%d", $i); })",
-       Error{ R"(
-stdin:1:60-62: ERROR: Undefined or undeclared variable: $i
-begin { for ($i : 0..5) { printf("%d", $i); } printf("%d", $i); }
-                                                           ~~
-)" });
 }
 
 TEST_F(SemanticAnalyserTest, for_range_context_access)
@@ -5142,26 +5006,6 @@ TEST_F(SemanticAnalyserTest, variable_declarations)
   test("begin { if (pid) { let $x; } $x = 2; }");
   test("begin { if (pid) { let $x; } else { let $x; } let $x; }");
 
-  // https://github.com/bpftrace/bpftrace/pull/3668#issuecomment-2596432923
-  test("begin { let $a; print($a); $a = 1; }",
-       Warning{ "Variable used before it was assigned:" });
-
-  test("begin { let $a; if comptime (probetype == \"special\") { $a = 1; } "
-       "print($a); }",
-       NoWarning{ "Variable used before it was assigned:" });
-
-  test("begin { let $a; let $a; }",
-       Error{ R"(
-stdin:1:17-23: ERROR: Variable $a was already declared. Variable shadowing is not allowed.
-begin { let $a; let $a; }
-                ~~~~~~
-)" },
-       Warning{ R"(
-stdin:1:9-15: WARNING: This is the initial declaration.
-begin { let $a; let $a; }
-        ~~~~~~
-)" });
-
   test("begin { let $a: uint16; $a = -1; }", Error{ R"(
 stdin:1:25-32: ERROR: Type mismatch for $a: trying to assign value of type 'int32' when variable already has a type 'uint16'
 begin { let $a: uint16; $a = -1; }
@@ -5169,13 +5013,13 @@ begin { let $a: uint16; $a = -1; }
 )" });
 
   test("begin { let $a: uint8 = 1; $a = 10000; }", Error{ R"(
-stdin:1:28-38: ERROR: Type mismatch for $a: trying to assign value of type 'uint16' when variable already contains a value of type 'uint8'
+stdin:1:28-38: ERROR: Type mismatch for $a: trying to assign value of type 'uint16' when variable already has a type 'uint8'
 begin { let $a: uint8 = 1; $a = 10000; }
                            ~~~~~~~~~~
 )" });
 
   test("begin { let $a: int8 = 1; $a = -10000; }", Error{ R"(
-stdin:1:27-38: ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already contains a value of type 'int8'
+stdin:1:27-38: ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already has a type 'int8'
 begin { let $a: int8 = 1; $a = -10000; }
                           ~~~~~~~~~~~
 )" });
@@ -5227,12 +5071,6 @@ TEST_F(SemanticAnalyserTest, variable_address)
   auto *assignment = stmts.at(1).as<ast::AssignVarStatement>();
   ASSERT_TRUE(assignment->var()->var_type.IsPtrTy());
   ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy().IsIntTy());
-
-  test("begin { $a = 1; $b = &$c; }", Error{ R"(
-stdin:1:23-25: ERROR: Undefined or undeclared variable: $c
-begin { $a = 1; $b = &$c; }
-                      ~~
-)" });
 
   test("begin { let $a; $b = &$a; }", Error{ R"(
 stdin:1:22-25: ERROR: No type available for variable $a
@@ -5348,47 +5186,6 @@ TEST_F(SemanticAnalyserTest, block_scoping)
         }
       }
     })");
-
-  // if/else
-  test("begin { if (pid) { $a = 1; } print(($a)); }", Error{ R"(
-stdin:1:37-39: ERROR: Undefined or undeclared variable: $a
-begin { if (pid) { $a = 1; } print(($a)); }
-                                    ~~
-)" });
-  test("begin { if (pid) { $a = 1; } else { print(($a)); } }", Error{ R"(
-stdin:1:44-46: ERROR: Undefined or undeclared variable: $a
-begin { if (pid) { $a = 1; } else { print(($a)); } }
-                                           ~~
-)" });
-  test("begin { if (pid) { $b = 1; } else { $b = 2; } print(($b)); }",
-       Error{ R"(
-stdin:1:54-56: ERROR: Undefined or undeclared variable: $b
-begin { if (pid) { $b = 1; } else { $b = 2; } print(($b)); }
-                                                     ~~
-)" });
-
-  // for loops
-  test("kprobe:f { @map[0] = 1; for ($kv : @map) { $a = 1; } "
-       "print(($a)); }",
-       Error{ R"(
-stdin:1:61-63: ERROR: Undefined or undeclared variable: $a
-kprobe:f { @map[0] = 1; for ($kv : @map) { $a = 1; } print(($a)); }
-                                                            ~~
-)" });
-
-  // while loops
-  test("begin { while (1) { $a = 1; } print(($a)); }", Error{ R"(
-stdin:1:38-40: ERROR: Undefined or undeclared variable: $a
-begin { while (1) { $a = 1; } print(($a)); }
-                                     ~~
-)" });
-
-  // unroll
-  test("begin { unroll(1) { $a = 1; } print(($a)); }", Error{ R"(
-stdin:1:38-40: ERROR: Undefined or undeclared variable: $a
-begin { unroll(1) { $a = 1; } print(($a)); }
-                                     ~~
-)" });
 }
 
 TEST_F(SemanticAnalyserTest, invalid_assignment)
@@ -5452,13 +5249,6 @@ TEST_F(SemanticAnalyserTest, no_maximum_passes)
 
 TEST_F(SemanticAnalyserTest, block_expressions)
 {
-  // Illegal, check that variable is not available
-  test("begin { let $x = { let $y = $x; $y }; print($x) }", Error{ R"(
-stdin:1:29-31: ERROR: Undefined or undeclared variable: $x
-begin { let $x = { let $y = $x; $y }; print($x) }
-                            ~~
-)" });
-
   // Good, variable is not shadowed
   test("begin { let $x = { let $x = 1; $x }; print($x) }",
        ExpectedAST{ Program().WithProbe(Probe(
@@ -5536,7 +5326,7 @@ TEST_F(SemanticAnalyserTest, macros)
   test("macro set($x) { $x = 1; $x } begin { $a = \"string\"; set($a); }",
        Mock{ *bpftrace },
        Error{ R"(
-stdin:1:17-23: ERROR: Type mismatch for $a: trying to assign value of type 'uint8' when variable already contains a value of type 'string[7]'
+stdin:1:17-23: ERROR: Type mismatch for $a: trying to assign value of type 'uint8' when variable already has a type 'string[7]'
 macro set($x) { $x = 1; $x } begin { $a = "string"; set($a); }
                 ~~~~~~
 stdin:1:53-60: ERROR: expanded from
@@ -5591,29 +5381,6 @@ TEST_F(SemanticAnalyserTest, warning_for_discared_expression_statement_value)
   test("k:f { @a[1] = count(); }", NoWarning{ "Return value discarded" });
 }
 
-TEST_F(SemanticAnalyserTest, warning_for_never_assigned_to)
-{
-  test("k:f { $a = { let $x = 1; $x + 1 }; }",
-       NoWarning{ "Variable $x was never assigned to" });
-  test("begin { print(1); } k:f { $a = { let $x = 1; $x + 1 }; }",
-       NoWarning{ "Variable $x was never assigned to" });
-  test("fn foo($a : int64) : int8 { return 0; } begin { let $x; $x = 1; }",
-       NoWarning{ "Variable $x was never assigned to" });
-  test("fn foo($a : int64) : int8 { return 0; } fn bar($a : int64) : int8 { "
-       "let $x; $x = 2; return 0; }",
-       NoWarning{ "Variable $x was never assigned to" });
-
-  test("k:f { let $x; }", Warning{ "Variable $x was never assigned to" });
-  test("k:f { let $x; if comptime (false) { $x = 1; } }",
-       Warning{ "Variable $x was never assigned to" });
-  test("fn foo($a : int64) : int8 { let $x; return 0; } begin { let $x; $x = "
-       "1; }",
-       Warning{ "Variable $x was never assigned to" });
-  test("fn foo($a : int64) : int8 { let $y; return 0; } begin { let $x; $x = "
-       "1; }",
-       Warning{ "Variable $y was never assigned to" });
-}
-
 TEST_F(SemanticAnalyserTest, external_function)
 {
   ast::TypeMetadata types;
@@ -5660,7 +5427,7 @@ kprobe:f { foo((int64)1, (int64)2); }
   test("kprobe:f { $x = (int32*)0; $x = foo((int32)1, (int64)2); }",
        Types{ types },
        Error{ R"(
-stdin:1:28-56: ERROR: Type mismatch for $x: trying to assign value of type 'int32' when variable already contains a value of type 'int32 *'
+stdin:1:28-56: ERROR: Type mismatch for $x: trying to assign value of type 'int32' when variable already has a type 'int32 *'
 kprobe:f { $x = (int32*)0; $x = foo((int32)1, (int64)2); }
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -5755,21 +5522,6 @@ TEST_F(SemanticAnalyserTest, typeof_subprog)
   test("fn foo($x : typeof($y), $y : int64) : typeof($x) { return (int64)0; }");
   test("fn foo($x : typeof($y), $y : int64) : typeof($y) { return (int64)0; }");
   test("fn foo($x : typeof($y), $y : int64) : typeof($x) { return 0; }");
-
-  test("fn foo($x : typeof($y), $y : int64) : int64 { return (uint64)0; }",
-       Error{});
-
-  // But we can't define using non-existent variables.
-  test("fn foo($x : int64, $y : typeof($z)) : int64 { return 0; }", Error{ R"(
-stdin:1:32-34: ERROR: Undefined or undeclared variable: $z
-fn foo($x : int64, $y : typeof($z)) : int64 { return 0; }
-                               ~~
-)" });
-  test("fn foo($x : int64, $y : int64) : typeof($z) { return 0; }", Error{ R"(
-stdin:1:41-43: ERROR: Undefined or undeclared variable: $z
-fn foo($x : int64, $y : int64) : typeof($z) { return 0; }
-                                        ~~
-)" });
 }
 
 TEST_F(SemanticAnalyserTest, typeof_casts)
@@ -5962,7 +5714,7 @@ TEST_F(SemanticAnalyserTest, record)
   test(
       R"(begin { $t = (a=1, b=(x=2, y=3)); $t = (a=4, b=(x=(int64)5, y="hi")); })",
       Error{ R"(
-stdin:1:35-69: ERROR: Type mismatch for $t: trying to assign value of type 'record { .a = uint8, .b = record { .x = int64, .y = string[3] } }' when variable already contains a value of type 'record { .a = uint8, .b = record { .x = uint8, .y = uint8 } }'
+stdin:1:35-69: ERROR: Type mismatch for $t: trying to assign value of type 'record { .a = uint8, .b = record { .x = int64, .y = string[3] } }' when variable already has a type 'record { .a = uint8, .b = record { .x = uint8, .y = uint8 } }'
 begin { $t = (a=1, b=(x=2, y=3)); $t = (a=4, b=(x=(int64)5, y="hi")); }
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });

--- a/tests/variable_precheck.cpp
+++ b/tests/variable_precheck.cpp
@@ -1,0 +1,211 @@
+#include "ast/passes/variable_precheck.h"
+#include "driver.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::variable_precheck {
+
+using ::testing::HasSubstr;
+
+std::string_view clean_prefix(std::string_view view)
+{
+  while (!view.empty() && view[0] == '\n')
+    view.remove_prefix(1); // Remove initial '\n'
+  return view;
+}
+
+void test(const std::string &input,
+          const std::string &expected_error = "",
+          const std::string &expected_warning = "")
+{
+  auto bpftrace = get_mock_bpftrace();
+  ast::ASTContext ast("stdin", input);
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(*bpftrace)
+                .add(CreateParsePass())
+                .add(ast::CreateVariablePreCheckPass())
+                .run();
+  ASSERT_TRUE(bool(ok));
+
+  std::stringstream err_out;
+  ast.diagnostics().emit(err_out, ast::Diagnostics::Severity::Error);
+  std::stringstream warn_out;
+  ast.diagnostics().emit(warn_out, ast::Diagnostics::Severity::Warning);
+
+  if (expected_error.empty()) {
+    EXPECT_EQ(err_out.str(), "") << "Unexpected error: " << err_out.str();
+  } else {
+    EXPECT_THAT(err_out.str(), HasSubstr(clean_prefix(expected_error)));
+  }
+
+  if (expected_warning.empty()) {
+    EXPECT_EQ(warn_out.str(), "") << "Unexpected warning: " << warn_out.str();
+  } else {
+    EXPECT_THAT(warn_out.str(), HasSubstr(clean_prefix(expected_warning)));
+  }
+}
+
+TEST(VariablePreCheck, shadowing)
+{
+  test("begin { let $x = 1 } end { let $x = 2 }");
+  test("begin { let $x = 1; { let $y = 2; } }");
+  test("begin { if (1) { let $x = 1 } else { let $x = 2 } }");
+  test("begin { $x = 5; for ($i : 1..10) { print($i) } }");
+  test("fn foo($x: int64): void { let $y = 1 }");
+  test("fn foo($x: int64): void { let $y = 1 } fn bar($y: int64): void { let "
+       "$x = 1 }");
+
+  // Errors
+  static const std::string error_str =
+      "Variable $x was already declared. Variable shadowing is not allowed.";
+  test("begin { let $x = 1; { let $x = 2 } }", error_str);
+  test("begin { $x = 1; { let $x = 2 } }", error_str);
+  test("begin { let $x = 1; let $x = 2 }", error_str);
+  test("begin { let $x = 1; if (1) { let $x = 2 } }", error_str);
+  test("begin { $i = 5; for ($i : 1..10) { print($i) } }",
+       "Loop declaration shadows existing variable: $i");
+  test("begin { let $i = 5; for ($i : 1..10) { print($i) } }",
+       "Loop declaration shadows existing variable: $i");
+  test("begin { for ($x : 1..10) { let $x = 1; } }", error_str);
+  test("fn foo($x: int64): void { for ($x : 1..10) { print($x) } }",
+       "Loop declaration shadows existing variable: $x");
+  test("fn foo($x: int64): void { let $x = 1 }", error_str);
+  // N.B. these are separate tests of error context so we don't have to include
+  // the line/col in the error output
+  test("begin { let $x = 1; { let $x = 2 } }",
+       "This is the initial declaration.");
+  test("begin { $x = 1; { let $x = 2 } }", "This is the initial assignment.");
+  test("fn foo($x: int64): void { for ($x : 1..10) { print($x) } }",
+       "This is the function parameter.");
+  test("begin { for ($i : 1..10) { let $i = 1; } }",
+       "This is the loop variable.");
+
+  // Errors with source location
+  test("begin { let $x = 1; { let $x = 2 } }",
+       R"(
+ERROR: Variable $x was already declared. Variable shadowing is not allowed.
+begin { let $x = 1; { let $x = 2 } }
+                      ~~~~~~
+)");
+  test("begin { $i = 5; for ($i : 1..10) { print($i) } }",
+       R"(
+ERROR: Loop declaration shadows existing variable: $i
+begin { $i = 5; for ($i : 1..10) { print($i) } }
+                     ~~
+)");
+  test("fn foo($x: int64): void { let $x = 1 }",
+       R"(
+ERROR: Variable $x was already declared. Variable shadowing is not allowed.
+fn foo($x: int64): void { let $x = 1 }
+                          ~~~~~~
+)");
+
+  // One test to show the full error context
+  test("begin { let $x = 1; { let $x = 2 } }",
+       R"(
+stdin:1:23-29: ERROR: Variable $x was already declared. Variable shadowing is not allowed.
+begin { let $x = 1; { let $x = 2 } }
+                      ~~~~~~
+stdin:1:9-15: ERROR: This is the initial declaration.
+begin { let $x = 1; { let $x = 2 } }
+        ~~~~~~
+)");
+}
+
+TEST(VariablePreCheck, undefined)
+{
+  test("begin { $x = 1; print($x) }");
+  test("begin { let $x = 1; print($x) }");
+  test("begin { $x = 1; $y = $x + 1 }");
+  test("fn foo($x: int64): void { print($x) }");
+  test("begin { for ($i : 1..10) { print($i) } }");
+  test("fn foo($z : typeof($x), $x : int64) : int64 { return 0; }");
+
+  // Errors
+  static const std::string error_str = "Undefined or undeclared variable: $x";
+  test("begin { print($x) }", error_str);
+  test("begin { $y = $x }", error_str);
+  test("begin { $x = $x + 1 }", error_str);
+  test("fn foo($x: int64): void { print($y) }",
+       "Undefined or undeclared variable: $y");
+  test("begin { $x += 0 }", error_str);
+  test("begin { $x >>= 0 }", error_str);
+  test(R"(
+    begin {
+      @map[0] = 1;
+      for ($kv : @map) {
+        $x = 2;
+      }
+      print($x);
+    })",
+       error_str);
+  test("begin { for ($x : 0..5) { print($x); } print($x); }", error_str);
+  test("begin { $a = 1; $b = &$x; }", error_str);
+  test("begin { let $x = { let $y = $x; $y }; print($x) }", error_str);
+  test("fn foo($z : int64, $y : typeof($x)) : int64 { return 0; }", error_str);
+  test("fn foo($z : int64, $y : int64) : typeof($x) { return 0; }", error_str);
+
+  // Errors with source location
+  test("begin { $y = $x }", R"(
+ERROR: Undefined or undeclared variable: $x
+begin { $y = $x }
+             ~~
+)");
+}
+
+TEST(VariablePreCheck, used_before_assigned)
+{
+  test("begin { let $x = 1; print($x) }");
+  test("begin { let $x; $x = 1; print($x) }");
+  // We don't consider comptime for this warning
+  test("begin { let $a; if comptime (false) { $a = 1; } print($a); }");
+  // No warning inside meta functions
+  test("fn foo($z : typeof($x), $x : int64) : int64 { return 0; }");
+  test("begin { let $x; let $y : typeof($x) = 1; $x = 1; }");
+  test("begin { let $x; let $y : typeof({ print(1); $x }) = 1; $x = 1; }");
+  test("begin { let $x; some_func(&$x); print($x); $x = 1; }");
+
+  // Warnings
+  test("begin { let $x; print($x); $x = 1; }",
+       "",
+       "Variable used before it was assigned: $x");
+  test("begin { let $x; $y = $x; $x = 1; }",
+       "",
+       "Variable used before it was assigned: $x");
+
+  // Warnings with source location
+  test("begin { let $x; print($x); $x = 1; }",
+       "",
+       R"(
+WARNING: Variable used before it was assigned: $x
+begin { let $x; print($x); $x = 1; }
+                      ~~
+)");
+}
+
+TEST(VariablePreCheck, never_assigned)
+{
+  test("begin { let $x = 1; print($x) }");
+  test("begin { let $x = 1; print($x) } end { print(1); }");
+  test("begin { let $x; $x = 1; print($x) }");
+  test("begin { let $x; some_func(&$x); print($x) }");
+  test("k:f { $a = { let $x = 1; $x + 1 }; }");
+  test("begin { print(1); } k:f { $a = { let $x = 1; $x + 1 }; }");
+  test("fn foo($a : int64) : int8 { return 0; } begin { let $x; $x = 1; }");
+  test("fn foo($a : int64) : int8 { return 0; } fn bar($a : int64) : int8 { "
+       "let $x; $x = 2; return 0; }");
+
+  // Warnings
+  test("begin { let $x; }", "", "Variable $x was never assigned to.");
+  test("fn foo(): void { let $x; }", "", "Variable $x was never assigned to.");
+
+  // Warnings with source location
+  test("begin { let $x; }", "", R"(
+WARNING: Variable $x was never assigned to.
+begin { let $x; }
+        ~~~~~~
+)");
+}
+
+} // namespace bpftrace::test::variable_precheck


### PR DESCRIPTION
Stacked PRs:
 * #4963
 * __->__#4986


--- --- ---

### Create VariablePreCheck pass


This moves variable usage checks from semantic_analyser to this new pass
further reducing the size and complexity of semantic_analyser. The behavior
is almost identical except that comptime branches are not special cased in
VariablePreCheck pass meaning that we might not get a warning from a
variable assignment that was in a branch that ends up getting pruned. This
feels like a good trade-off to reduce internal complexity.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>