### PR TITLE
Fix interval probe attachment when CPU 0 is offline (#4966)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to
 - Drop support for LLVM 16
   - [#4534](https://github.com/bpftrace/bpftrace/pull/4534)
 #### Fixed
+- Fix interval probe attachment when CPU 0 is offline
+  - [#4987](https://github.com/bpftrace/bpftrace/pull/4987)
 - Respect `missing_probes` config for bad `args` if the probe will be pruned
   - [#4915](https://github.com/bpftrace/bpftrace/pull/4915)
 - Improved tuple binop comparison

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -993,6 +993,9 @@ Result<std::unique_ptr<AttachedIntervalProbe>> AttachedIntervalProbe::make(
 {
   int group_fd = -1;
   int cpu = 0;
+  std::vector<int> cpus = util::get_online_cpus();
+  if (!cpus.empty())
+    cpu = cpus[0];
 
   uint64_t period = 0, freq = 0;
   if (probe.path == "s") {


### PR DESCRIPTION
This PR addresses the issue where attaching `interval` probes fails when CPU 0 is offline (or hot-unplugged).

Previously, `AttachedIntervalProbe::make` hardcoded `cpu=0` when creating the perf event. This caused [open_perf_event](cci:1://file:///data/8797/nhlos/lagvm/LINUX/android/external/bpftrace/src/attached_probe.cpp:856:0-884:1) to fail if CPU 0 was not available.

This change updates it to utilize `util::get_online_cpus()` to dynamically select the first available online CPU, ensuring the probe can be attached successfully regardless of CPU 0's status. All other online CPUs are then looped over correctly as before.

Fixes #4966.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc` (N/A)
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests