### PR TITLE
Support global variable

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1363,10 +1363,14 @@ public:
   explicit VarDeclStatement(ASTContext &ctx,
                             Location &&loc,
                             Variable *var,
-                            Typeof *typeof)
-      : Node(ctx, std::move(loc)), var(var), typeof(typeof) {};
-  explicit VarDeclStatement(ASTContext &ctx, Location &&loc, Variable *var)
-      : Node(ctx, std::move(loc)), var(var) {};
+                            Typeof *typeof,
+                            bool global)
+      : Node(ctx, std::move(loc)), var(var), typeof(typeof), global(global) {};
+  explicit VarDeclStatement(ASTContext &ctx,
+                            Location &&loc,
+                            Variable *var,
+                            bool global)
+      : Node(ctx, std::move(loc)), var(var), global(global) {};
   explicit VarDeclStatement(ASTContext &ctx,
                             const Location &loc,
                             const VarDeclStatement &other)
@@ -1387,6 +1391,7 @@ public:
 
   Variable *var = nullptr;
   Typeof *typeof = nullptr;
+  bool global = false;
 };
 
 // Scalar map assignment is purely syntactic sugar that is removed by the pass

--- a/src/ast/passes/loop_return.cpp
+++ b/src/ast/passes/loop_return.cpp
@@ -196,7 +196,7 @@ void LoopReturn::inject(T &node)
     // need to supercede all the other statements in the block.
     if (loop_return_.value()) {
       auto *ret_var_decl = ast_.make_node<VarDeclStatement>(
-          node.loc, get_return_var(node));
+          node.loc, get_return_var(node), false);
       node.block->stmts.insert(node.block->stmts.begin(),
                                Statement(ret_var_decl));
     }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -275,6 +275,7 @@ oct_esc  [0-7]{1,3}
   "typeof"                { return Parser::make_TYPEOF(yytext, driver.loc); }
   "typeinfo"              { return Parser::make_TYPEINFO(yytext, driver.loc); }
   "let"                   { return Parser::make_LET(yytext, driver.loc); }
+  "global"                { return Parser::make_GLOBAL(yytext, driver.loc); }
   "import"                { return Parser::make_IMPORT(yytext, driver.loc); }
   "comptime"              { return Parser::make_COMPTIME(yytext, driver.loc); }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -139,6 +139,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> TYPEINFO "typeinfo"
 %token <std::string> COMPTIME "comptime"
 %token <std::string> LET "let"
+%token <std::string> GLOBAL "global"
 %token <std::string> IMPORT "import"
 %token <std::string> HEADER "header"
 %token <bool> BOOL "bool"
@@ -621,8 +622,10 @@ map_decl_stmt:
         ;
 
 var_decl_stmt:
-                 LET var                {  $$ = driver.ctx.make_node<ast::VarDeclStatement>(@$, $2); }
-        |        LET var COLON any_type {  $$ = driver.ctx.make_node<ast::VarDeclStatement>(@$, $2, $4); }
+                 GLOBAL var                {  $$ = driver.ctx.make_node<ast::VarDeclStatement>(@$, $2, true); }
+        |        GLOBAL var COLON any_type {  $$ = driver.ctx.make_node<ast::VarDeclStatement>(@$, $2, $4, true); }
+        |        LET var                   {  $$ = driver.ctx.make_node<ast::VarDeclStatement>(@$, $2, false); }
+        |        LET var COLON any_type    {  $$ = driver.ctx.make_node<ast::VarDeclStatement>(@$, $2, $4, false); }
         ;
 
 tuple_expr:
@@ -889,6 +892,7 @@ keyword:
         |       CONTINUE      { $$ = $1; }
         |       ELSE          { $$ = $1; }
         |       FOR           { $$ = $1; }
+        |       GLOBAL        { $$ = $1; }
         |       IF            { $$ = $1; }
         |       LET           { $$ = $1; }
         |       OFFSETOF      { $$ = $1; }

--- a/tools/syscount.bt
+++ b/tools/syscount.bt
@@ -78,12 +78,11 @@
 BEGIN
 {
   printf("Counting syscalls... Hit Ctrl-C to end.\n"); // ausyscall --dump | awk 'NR > 1 { printf("\t@sysname[%d] = \"%s\";\n", $1, $2); }'
+  global $sysname = getopt("sysname");
 }
 
 tracepoint:raw_syscalls:sys_enter
 {
-  $sysname = getopt("sysname");
-
   if $sysname {
     @syscallname[syscall_name(args.id)] = count();
   } else {
@@ -101,8 +100,6 @@ macro display_map(description, @map)
 
 END
 {
-  $sysname = getopt("sysname");
-
   if $sysname {
     display_map("\nTop 10 syscalls NAMEs:\n", @syscallname);
   } else {


### PR DESCRIPTION
In a bpftrace script, a variable might be used multiple times across probes, such as the getopt() variable. Adding support for global variables can solve this problem.

For examples:

    profile:s:1 {
      if getopt("onoff", 0) {
      } else {
      }
    }
    END {
      if getopt("onoff", 0) {
      } else {
      }
    }

Improved script:

    BEGIN {
      global $g_switch = getopt("onoff", 0);
    }
    profile:s:1 {
      if $g_switch {
      } else {
      }
    }
    END {
      if $g_switch {
      } else {
      }
    }

In fact, we can do much more with global variables as long as you need.

There are still testing issues. Let's first see if this feature is meaningful and worth continuing to develop. Thank you ;)