### PR TITLE
Fix cases of missing Result<T> error handling

### DIFF
--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -805,6 +805,7 @@ static void query_clang_include_dirs(std::vector<std::string> &result)
   auto check = util::exec_system(args);
   if (!check) {
     // Exec failed, ignore and move on.
+    consumeError(std::move(check));
     return;
   }
   std::istringstream lines(*check);

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -63,6 +63,7 @@ MacroRegistry MacroRegistry::create(ASTContext &ast)
       err.addContext((*exists)->loc) << "This is the original definition.";
       continue; // Skip this macro.
     }
+    consumeError(std::move(exists));
     if (!validate(macro)) {
       continue;
     }

--- a/src/ast/passes/type_checker.cpp
+++ b/src/ast/passes/type_checker.cpp
@@ -1066,6 +1066,7 @@ void TypeChecker::visit(Call &call)
     // check that they are exactly equal.
     auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
     if (!maybe_func) {
+      consumeError(std::move(maybe_func));
       if (call.return_type.IsNoneTy()) {
         LOG(BUG) << "Unknown builtin function " << call.func;
       }
@@ -1075,6 +1076,7 @@ void TypeChecker::visit(Call &call)
     const auto &func = *maybe_func;
     auto proto = func.type();
     if (!proto) {
+      consumeError(std::move(proto));
       return;
     }
 

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -131,6 +131,14 @@ Result<> handleErrors(Result<T>&& ok, Ts&&... args)
   return llvmErr;
 }
 
+// Silently swallow an error. This method should be used only when an error can
+// be considered a reasonable and expected return value.
+template <typename T>
+void consumeError(Result<T> result)
+{
+  llvm::consumeError(result.takeError());
+}
+
 }; // namespace bpftrace
 
 namespace llvm {


### PR DESCRIPTION
`Result<T>`, which is a wrapper around `llvm::Expected<T>`, requires all errors to be handled explicitly -- not doing so triggers an abort[1] if LLVM is built with assertions enabled.

This patch introduces a new helper `consumeError()` that swallows an error. It's intended to be used in rare cases where error results are expected, such as failed lookup in `MacroRegistry::create()`.

Also fixes a few known instances where errors weren't handled (these issues were discovered while using bpftrace linked against debug LLVM).

[1] https://github.com/llvm/llvm-project/blob/2078da43e2/llvm/include/llvm/Support/Error.h#L713

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
