### PR TITLE
README: drop Fedora 41 from distros overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Get started with bpftrace in just a few minutes! To build from source, see the [
   </tr>
   <tr>
     <td valign="middle">
-    <a href="https://packages.fedoraproject.org/pkgs/bpftrace/bpftrace/fedora-41-updates.html"><img src="https://repology.org/badge/version-for-repo/fedora_41/bpftrace.svg" alt="Fedora 41"/></a>
     <a href="https://packages.fedoraproject.org/pkgs/bpftrace/bpftrace/fedora-42-updates.html"><img src="https://repology.org/badge/version-for-repo/fedora_42/bpftrace.svg" alt="Fedora 42"/></a>
     <a href="https://packages.fedoraproject.org/pkgs/bpftrace/bpftrace/fedora-43.html"><img src="https://repology.org/badge/version-for-repo/fedora_43/bpftrace.svg" alt="Fedora 43"/></a>
     <a href="https://packages.fedoraproject.org/pkgs/bpftrace/bpftrace/fedora-rawhide.html"><img src="https://repology.org/badge/version-for-repo/fedora_rawhide/bpftrace.svg" alt="Fedora Rawhide"/></a>


### PR DESCRIPTION
Fedora 41 has reached EOL on Dec 15, 2025.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
