### PR TITLE
Fix build for 32-bit targets

### DIFF
--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -527,7 +527,7 @@ void JsonOutput::benchmark_result(const std::vector<std::string> &all_benches,
 {
   Primitive::Record result;
   result.fields.emplace_back("average", average.count());
-  result.fields.emplace_back("iters", iters);
+  result.fields.emplace_back("iters", static_cast<uint64_t>(iters));
   emit_data(out_, "benchmark_result", all_benches[index], result);
 }
 


### PR DESCRIPTION
Trivial fix to unbreak the 32-bit ARM build. The `Primitive` type only supports 64-bit integer types, so it may not be constructible from a `size_t`.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
