### PR TITLE
AOT: fix tuple and record based maps segfaulting on access

### DIFF
--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -252,6 +252,12 @@ public:
   // List of probes using userspace symbol resolution
   std::unordered_set<const ast::Probe *> probes_using_usym;
 
+  // Storage for Struct objects to keep weak_ptrs alive after AOT
+  // deserialization When cereal deserailizes weak_ptr<Struct>, it creates a
+  // temporary shared pointer that is destroyed after the load completes. We
+  // must keep those alive
+  std::vector<std::shared_ptr<Struct>> struct_storage_;
+
 private:
   friend class cereal::access;
   template <typename Archive>


### PR DESCRIPTION
Description:
When using tuple based keys in maps with Ahead-Of-Time compilation, we would segmentation fault when attempting to print the map. To fix, add a vector of shared pointers to RequiredResources, so that the RequiredResources instance during AOT run would own those inner_struct_ weak pointer's

Fixes #4983


##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
