### PR TITLE
Fix IsCompatible for ptr types

### DIFF
--- a/src/ast/passes/type_checker.cpp
+++ b/src/ast/passes/type_checker.cpp
@@ -1541,6 +1541,12 @@ void TypeChecker::visit(Cast &cast)
     return;
   }
 
+  if (ty.IsPtrTy() && rhs.IsPtrTy()) {
+    if (!ty.IsCompatible(rhs)) {
+      logError();
+    }
+  }
+
   if (!ty.IsIntTy() && !ty.IsPtrTy() && !ty.IsBoolTy() &&
       (!ty.IsPtrTy() || ty.GetElementTy().IsIntTy() ||
        ty.GetElementTy().IsCStructTy()) &&

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -139,7 +139,7 @@ bool SizedType::IsCompatible(const SizedType &t) const
     return t.GetName() == GetName();
 
   if (IsPtrTy())
-    return GetPointeeTy().IsCompatible(t.GetPointeeTy());
+    return GetPointeeTy() == t.GetPointeeTy();
 
   if (IsIntegerTy()) {
     if (IsSigned() == t.IsSigned()) {

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2317,6 +2317,10 @@ TEST_F(TypeCheckerTest, variable_cast_types)
   test(structs +
            "kprobe:f { $x = (struct type1*)cpu; $x = (struct type2*)cpu; }",
        Error{});
+
+  test("begin { $x = (int16)5; $y = (int32)6; $p1 = &$x; $p2 = "
+       "(typeof(&$y))$p1; }",
+       Error{});
 }
 
 TEST_F(TypeCheckerTest, map_cast_types)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4997


--- --- ---

### Fix IsCompatible for ptr types


Pointer types need to be the exact same to be compatible.

Take this example which is currently allowed but should not be:
```
$val = (int16)5;
$val2 = (int32)6;
$p1 = &$val;
$p2 = (typeof(&$val2))$p1;
$val3 = *$p2; // oops we just read past 16 bytes
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>