### PR TITLE
getopt: add description argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
 - `BPFTRACE_DEBUG_OUTPUT` is removed, and errors are now propagated via the runtime error path
   - [#4976](https://github.com/bpftrace/bpftrace/pull/4976)
 #### Added
+- `getopt()` add optional description argument
+  - [#4998](https://github.com/bpftrace/bpftrace/pull/4998)
 - Add `--probe-filter` CLI flag to selectively run probes matching a regex
   - [#5011](https://github.com/bpftrace/bpftrace/pull/5011)
 - Add `comm()` support for PID parameters.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -334,13 +334,13 @@ Name of the current function being traced (kprobes,uprobes,fentry)
 
 ### getopt
 - `bool getopt(string arg_name)`
-- `string getopt(string arg_name, string default_value)`
-- `int getopt(string arg_name, int default_value)`
-- `bool getopt(string arg_name, bool default_value)`
+- `bool getopt(string arg_name, bool default_value, [string description])`
+- `int getopt(string arg_name, int default_value, [string description])`
+- `string getopt(string arg_name, string default_value, [string description])`
 
 Get the named command line argument/option e.g.
 ```
-# bpftrace -e 'BEGIN { print(getopt("hello", 1)); }' -- --hello=5
+# bpftrace -e 'BEGIN { print(getopt("hello", 1, "Description of hello")); }' -- --hello=5
 
 ```
 
@@ -348,11 +348,12 @@ Get the named command line argument/option e.g.
 If no default type is provided, the option is treated like a boolean arg e.g. `getopt("hello")` would evaluate to `false` if `--hello` is not specified on the command line or `true` if `--hello` is passed or set to one of the following values: `true`, `1`.
 Additionally, boolean args accept the following false values: `0`, `false` e.g. `--hello=false`.
 If the arg is not set on the command line, the default value is used.
+`getopt` calls may optionally specify a string with the argument description (except for a boolean arg without a default value).
 
 You can use `--help` to see all named arguments/options.
 
 ```
-# bpftrace -e 'BEGIN { print((getopt("aa", 10), getopt("bb", "hello"), getopt("cc"), getopt("dd", false))); }' -- --cc --bb=bye
+# bpftrace -e 'BEGIN { print((getopt("aa", 10, "Description of aa"), getopt("bb", "hello"), getopt("cc"), getopt("dd", false))); }' -- --cc --bb=bye
 
 ```
 

--- a/src/ast/passes/named_param.h
+++ b/src/ast/passes/named_param.h
@@ -7,7 +7,7 @@ namespace bpftrace::ast {
 
 class NamedParamDefaults : public ast::State<"named_params_defaults"> {
 public:
-  std::unordered_map<std::string, globalvars::GlobalVarValue> defaults;
+  std::unordered_map<std::string, globalvars::GlobalVarInfo> defaults;
 };
 
 Pass CreateNamedParamsPass();

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -442,8 +442,10 @@ void ResourceAnalyser::visit(Map &map)
 
   auto it = named_param_defaults_.defaults.find(map.ident);
   if (it != named_param_defaults_.defaults.end()) {
-    resources_.global_vars.add_named_param(map.ident, it->second);
-    if (std::holds_alternative<std::string>(it->second)) {
+    resources_.global_vars.add_named_param(map.ident,
+                                           it->second.value,
+                                           it->second.description);
+    if (std::holds_alternative<std::string>(it->second.value)) {
       const auto max_strlen = bpftrace_.config_->max_strlen;
       if (exceeds_stack_limit(max_strlen))
         resources_.str_buffers++;

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -390,13 +390,13 @@ macro func()
 
 // :function getopt
 // :variant bool getopt(string arg_name)
-// :variant string getopt(string arg_name, string default_value)
-// :variant int getopt(string arg_name, int default_value)
-// :variant bool getopt(string arg_name, bool default_value)
+// :variant bool getopt(string arg_name, bool default_value, [string description])
+// :variant int getopt(string arg_name, int default_value, [string description])
+// :variant string getopt(string arg_name, string default_value, [string description])
 //
 // Get the named command line argument/option e.g.
 // ```
-// # bpftrace -e 'BEGIN { print(getopt("hello", 1)); }' -- --hello=5
+// # bpftrace -e 'BEGIN { print(getopt("hello", 1, "Description of hello")); }' -- --hello=5
 //
 // ```
 //
@@ -404,11 +404,12 @@ macro func()
 // If no default type is provided, the option is treated like a boolean arg e.g. `getopt("hello")` would evaluate to `false` if `--hello` is not specified on the command line or `true` if `--hello` is passed or set to one of the following values: `true`, `1`.
 // Additionally, boolean args accept the following false values: `0`, `false` e.g. `--hello=false`.
 // If the arg is not set on the command line, the default value is used.
+// `getopt` calls may optionally specify a string with the argument description (except for a boolean arg without a default value).
 //
 // You can use `--help` to see all named arguments/options.
 //
 // ```
-// # bpftrace -e 'BEGIN { print((getopt("aa", 10), getopt("bb", "hello"), getopt("cc"), getopt("dd", false))); }' -- --cc --bb=bye
+// # bpftrace -e 'BEGIN { print((getopt("aa", 10, "Description of aa"), getopt("bb", "hello"), getopt("cc"), getopt("dd", false))); }' -- --cc --bb=bye
 //
 // ```
 

--- a/tests/globalvars.cpp
+++ b/tests/globalvars.cpp
@@ -26,10 +26,10 @@ void test_named_param_error(globalvars::GlobalVars& global_vars,
 TEST(GlobalVars, get_named_param_vals)
 {
   auto global_vars = globalvars::GlobalVars();
-  global_vars.add_named_param("hello", "bye");
-  global_vars.add_named_param("is_true", true);
-  global_vars.add_named_param("will_be_true", false);
-  global_vars.add_named_param("number", 5);
+  global_vars.add_named_param("hello", "bye", "Bye");
+  global_vars.add_named_param("is_true", true, "Flag");
+  global_vars.add_named_param("will_be_true", false, "Will");
+  global_vars.add_named_param("number", 5, "Number of values");
 
   auto good_values1 = global_vars.get_named_param_vals(
       { "hello=low", "number=10", "will_be_true" });

--- a/tests/named_param.cpp
+++ b/tests/named_param.cpp
@@ -58,19 +58,19 @@ void test_error(const std::string& input, const std::string& error)
 
 TEST(named_param, basic_checks)
 {
-  test("begin { $a = getopt(\"hello\"); }",
+  test(R"(begin { $a = getopt("hello"); })",
        Program().WithProbe(ProbeMatcher().WithStatements({ AssignVarStatement(
            Variable("$a"), MapAccess(Map("hello"), Integer(0))) })));
 
-  test("begin { $a = getopt(\"hello\", 1); }",
+  test(R"(begin { $a = getopt("hello", 1); })",
        Program().WithProbe(ProbeMatcher().WithStatements({ AssignVarStatement(
            Variable("$a"), MapAccess(Map("hello"), Integer(0))) })));
 
-  test("begin { $a = getopt(\"hello\", true); }",
+  test(R"(begin { $a = getopt("hello", true); })",
        Program().WithProbe(ProbeMatcher().WithStatements({ AssignVarStatement(
            Variable("$a"), MapAccess(Map("hello"), Integer(0))) })));
 
-  test("begin { $a = getopt(\"hello\", false); }",
+  test(R"(begin { $a = getopt("hello", false); })",
        Program().WithProbe(ProbeMatcher().WithStatements({ AssignVarStatement(
            Variable("$a"), MapAccess(Map("hello"), Integer(0))) })));
 
@@ -78,18 +78,22 @@ TEST(named_param, basic_checks)
        Program().WithProbe(ProbeMatcher().WithStatements({ AssignVarStatement(
            Variable("$a"), MapAccess(Map("hello"), Integer(0))) })));
 
-  test_error("begin { $a = getopt(10); }",
+  test_error(R"(begin { $a = getopt(10); })",
              "First argument to 'getopt' must be a string literal");
-  test_error("begin { $a = getopt(\"hello\", $a); }",
+  test_error(R"(begin { $a = getopt("hello", $a); })",
              "Second argument to 'getopt' must be a string literal, integer "
              "literal, or a boolean literal.");
-  test_error("begin { $a = getopt(\"hello\", banana); }",
+  test_error(R"(begin { $a = getopt("hello", banana); })",
              "Second argument to 'getopt' must be a string literal, integer "
              "literal, or a boolean literal.");
   test_error(
       R"(begin { $a = getopt("hello", 1); $b = getopt("hello", "bye"); })",
       "Command line option 'hello' needs to have the same default value in all "
       "places it is used. Previous default value: 1");
+  test_error(
+      R"(begin { $a = getopt("hello", 1, "Hello1"); $b = getopt("hello", 1, "Hello2"); })",
+      "Command line option 'hello' must have the same description in all "
+      "places it's used. Hint: You can wrap it in a macro");
 }
 
 } // namespace bpftrace::test::named_param

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -378,6 +378,20 @@ RUN {{BPFTRACE}} -e 'begin { print(($1, getopt("aa", 10), getopt("bb", -1), $2, 
 EXPECT (pos1, 20, 5, pos2, bye, true)
 TIMEOUT 1
 
+NAME named params with description
+RUN {{BPFTRACE}} -e 'begin { print((getopt("aa", 10, "AA"), getopt("bb", 1))); }' -- --aa=22 --bb=2
+EXPECT (22, 2)
+TIMEOUT 1
+
+NAME named params with description help
+RUN {{BPFTRACE}} -e 'begin { print((getopt("aa", 10, "Description of aa"), getopt("bb", 1), getopt("cc"))); }' -- --help
+EXPECT HINT: expected program options:
+EXPECT --cc
+EXPECT --bb
+EXPECT --aa: Description of aa
+TIMEOUT 1
+WILL_FAIL
+
 # Can't run through the standard AOT path because we need to pass CLI args
 NAME named command line params aot
 RUN {{BPFTRACE}} -e 'begin { print((getopt("aa", 10), getopt("cc", true), getopt("dd"), getopt("ee", "hello")));  }' --aot /tmp/tmpprog.btaot && /tmp/tmpprog.btaot -- --dd --aa=20 --cc=False
@@ -401,7 +415,7 @@ EXPECT_NONE USAGE:
 WILL_FAIL
 
 NAME unexpected named command line params
-RUN {{BPFTRACE}} -e 'begin { print(getopt("aa", 10));  }' -- --bb
+RUN {{BPFTRACE}} -e 'begin { print(getopt("aa", 10)); }' -- --bb
 EXPECT ERROR: unexpected program command line options: --bb
 EXPECT HINT: expected program options: --aa
 EXPECT_NONE USAGE:

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -55,7 +55,7 @@ tracepoint:syscalls:sys_enter_openat2
 
 macro max_path_depth()
 {
-  getopt("depth", 35)
+  getopt("depth", 35, "Maximum depth of full path")
 }
 
 macro getcwd(@paths)

--- a/tools/syscount.bt
+++ b/tools/syscount.bt
@@ -82,7 +82,7 @@ BEGIN
 
 macro sysname()
 {
-  getopt("sysname")
+  getopt("sysname", false, "Show syscall name instead of syscall number")
 }
 
 tracepoint:raw_syscalls:sys_enter


### PR DESCRIPTION
The function getopt() needs to have  parameter descriptions  added because no  user wants to open the  BT script to read the code;  we should provide parameter  descriptions  for users.  Unfortunately, adding the description parameter will make getopt() incompatible with older versions, but I still think it is necessary.

For example: test.bt

```
  begin { getopt("a", 1, "des A"); getopt("b", 1, "des B"); }

  # bpftrace test.bt -- --help
  HINT: expected program options:
  --b: des B
  --a: des A
```