### PR TITLE
SizedType: fix stack type equality check

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -246,6 +246,11 @@ std::strong_ordering SizedType::operator<=>(const SizedType &t) const
     return std::strong_ordering::equal;
   }
 
+  if (IsStack()) {
+    if (auto cmp = stack_type <=> t.stack_type; cmp != 0)
+      return cmp;
+  }
+
   if (auto cmp = GetSize() <=> t.GetSize(); cmp != 0)
     return cmp;
 

--- a/src/types.h
+++ b/src/types.h
@@ -125,7 +125,18 @@ struct StackType {
 
   bool operator==(const StackType &obj) const
   {
-    return limit == obj.limit && mode == obj.mode && kernel == obj.kernel;
+    return (*this <=> obj) == 0;
+  }
+
+  std::strong_ordering operator<=>(const StackType &obj) const
+  {
+    if (auto cmp = limit <=> obj.limit; cmp != 0)
+      return cmp;
+
+    if (auto cmp = mode <=> obj.mode; cmp != 0)
+      return cmp;
+
+    return kernel <=> obj.kernel;
   }
 
   std::string name() const


### PR DESCRIPTION
Stacked PRs:
 * __->__#4999


--- --- ---

### SizedType: fix stack type equality check


This should be comparing the internal "stack_type" structure to determine
type equality.

Signed-off-by: Jordan Rome <linux@jordanrome.com>