### PR TITLE
stdlib: add `glob_match()` function (#1097)

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -366,6 +366,21 @@ Group ID of the current thread, as seen from the init namespace
 This utilizes the BPF helper `get_current_uid_gid`
 
 
+### globmatch
+- `bool globmatch(string str, string pat)`
+
+Returns whether the string `str` matches the glob pattern `pat`.
+`pat` may consist of literal characters, `?` to match any single character,
+`*` to match any sequence of zero or more characters, and character classes
+listing individual characters (`[abc]`) or ranges (`[a-z]`), with support
+for negation (`[!abc]`).
+
+Note that, unlike POSIX/shell globbing, this function matches the pattern
+against the entire string, with no special handling of path components or the
+`/` character.
+
+
+
 ### has_cpid
 - `bool has_cpid()`
 - `bool has_cpid`

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -169,3 +169,42 @@ macro syscall_name(n)
   __syscall_name((int32)n, &$v);
   $v
 }
+
+// Returns whether the string `str` matches the glob pattern `pat`.
+// `pat` may consist of literal characters, `?` to match any single character,
+// `*` to match any sequence of zero or more characters, and character classes
+// listing individual characters (`[abc]`) or ranges (`[a-z]`), with support
+// for negation (`[!abc]`).
+//
+// Note that, unlike POSIX/shell globbing, this function matches the pattern
+// against the entire string, with no special handling of path components or the
+// `/` character.
+//
+// :variant bool globmatch(string str, string pat)
+macro globmatch($str, $pat)
+{
+  import "stdlib/strings/strings.bpf.c";
+
+  assert_str($str);
+  assert_str($pat);
+
+  let $str_size = strcap($str);
+  let $pat_size = strcap($pat);
+
+  __bpf_glob_match((int8*)&$str, $str_size, (int8*)&$pat, $pat_size)
+}
+macro globmatch($str, pat)
+{
+  let $pat = pat;
+  globmatch($str, $pat)
+}
+macro globmatch(str, $pat)
+{
+  let $str = str;
+  globmatch($str, $pat)
+}
+macro globmatch(str, pat)
+{
+  let $str = str;
+  globmatch($str, pat)
+}

--- a/src/stdlib/strings/strings.bpf.c
+++ b/src/stdlib/strings/strings.bpf.c
@@ -3,6 +3,7 @@
 #include <asm/posix_types.h>
 #include <linux/errno.h>
 #include <linux/types.h>
+#include <stdbool.h>
 #include <stddef.h>
 
 #include <bpf/bpf_helpers.h>
@@ -64,6 +65,103 @@ int __bpf_strnstr(const char *haystack,
     }
   }
   return -1;
+}
+
+bool __bpf_glob_match(const char *str, size_t str_size, const char *pat, size_t pat_size)
+{
+  /*
+   * Backtrack to previous * on mismatch and retry starting one
+   * character later in the string.  Because * matches all characters
+   * (no exception for /), it can be easily proved that there's
+   * never a need to backtrack multiple levels.
+   */
+  ptrdiff_t back_pat = -1;
+  size_t back_str = 0;
+
+  size_t s = 0; /* Index into str */
+  size_t p = 0; /* Index into pat */
+
+  /*
+   * Loop over each token (character or class) in pat, matching
+   * it against the remaining unmatched tail of str.  Return false
+   * on mismatch, or true after matching the trailing nul bytes.
+   */
+  for (;;) {
+    /*
+     * Strings may run to the full size without a final NUL, or they may be
+     * terminated early by a NUL. Handle this by wrapping all string accesses
+     * with checks that produce '\0' when reading past the end.
+     */
+    unsigned char c = s < str_size ? str[s++] : '\0';
+    unsigned char d = p < pat_size ? pat[p++] : '\0';
+
+    switch (d) {
+    case '?':  /* Wildcard: anything but nul */
+      if (c == '\0')
+        return false;
+      break;
+    case '*': {  /* Any-length wildcard */
+      char pat_next = p < pat_size ? pat[p] : '\0';
+      if (pat_next == '\0')  /* Optimize trailing * case */
+        return true;
+      back_pat = p;
+      back_str = s > 0 ? --s : 0;  /* Allow zero-length match */
+      }
+      break;
+    case '[': {  /* Character class */
+      unsigned char pat_next = p < pat_size ? pat[p] : '\0';
+      bool match = false, inverted = (pat_next == '!');
+      size_t class = p + inverted;
+      unsigned char a = class < pat_size ? pat[class++] : '\0';
+
+      /*
+       * Iterate over each span in the character class.
+       * A span is either a single character a, or a
+       * range a-b.  The first span may begin with ']'.
+       */
+      do {
+        unsigned char b = a;
+
+        if (a == '\0')  /* Malformed */
+          goto literal;
+
+        if (class + 2 < pat_size && pat[class] == '-' && pat[class + 1] != ']') {
+          b = pat[class + 1];
+
+          if (b == '\0')
+            goto literal;
+
+          class += 2;
+        }
+        match |= (a <= c && c <= b);
+        a = class < pat_size ? pat[class++] : '\0';
+      } while (a != ']');
+
+      if (match == inverted)
+        goto backtrack;
+      p = class;
+      }
+      break;
+    case '\\':
+      d = p < pat_size ? pat[p++] : '\0';
+      fallthrough;
+    default:  /* Literal character */
+literal:
+      if (c == d) {
+        if (d == '\0')
+          return true;
+        break;
+      }
+backtrack:
+      if (c == '\0' || back_pat < 0)
+        return false;  /* No point continuing */
+      /* Try again from last *, one character later in str. */
+      p = back_pat;
+      s = ++back_str;
+      break;
+    }
+  }
+  return false;
 }
 
 int __strerror(int errno, err_str *out) {

--- a/tests/self/globmatch.bt
+++ b/tests/self/globmatch.bt
@@ -1,0 +1,75 @@
+test:literals_match {
+  if !globmatch("a", "a") { return 1; }
+}
+
+test:literals_no_match {
+  if globmatch("a", "b") { return 1; }
+}
+
+test:single_char_wildcard_match {
+  if !globmatch("abc", "a?c") { return 1; }
+}
+
+test:single_char_wildcard_no_match_wrong_char {
+  if globmatch("abx", "a?c") { return 1; }
+}
+
+test:single_char_wildcard_no_match_short {
+  if globmatch("ab", "a?c") { return 1; }
+}
+
+test:pattern_prefix_no_match {
+  if globmatch("abc", "a") { return 1; }
+}
+
+test:pattern_prefix_wildcard_match {
+  if !globmatch("abc", "a*") { return 1; }
+}
+
+test:pattern_suffix_wildcard_match {
+  if !globmatch("abc", "*bc") { return 1; }
+}
+
+test:pattern_prefix_and_suffix_wildcard match {
+  if !globmatch("abc", "a*c") { return 1; }
+}
+
+test:wildcard_zero_length_match {
+  if !globmatch("abc", "a*bc") { return 1; }
+}
+
+test:wildcard_backtracking_match {
+  if !globmatch("ababc", "a*abc") { return 1; }
+}
+
+test:class_match {
+  if !globmatch("abc", "a[xyzabc]c") { return 1; }
+}
+
+test:class_no_match {
+  if globmatch("abc", "a[xyz]c") { return 1; }
+}
+
+test:class_range_match {
+  if !globmatch("abc", "a[a-z]c") { return 1; }
+}
+
+test:class_range_no_match {
+  if globmatch("abc", "a[0-9]c") { return 1; }
+}
+
+test:class_inverted_match {
+  if !globmatch("abc", "a[!xyz]c") { return 1; }
+}
+
+test:class_inverted_no_match {
+  if globmatch("abc", "a[!abc]c") { return 1; }
+}
+
+test:class_range_containing_bracket {
+  if !globmatch("a_c", "a[]-a]c") { return 1; }
+}
+
+test:class_range_containing_bracket_inverted {
+  if globmatch("a_c", "a[!]-a]c") { return 1; }
+}


### PR DESCRIPTION
This adds a function to match a string against a shell-style wildcard pattern (?, *, []) to the stdlib. The glob function itself is adapted from selftests/bpf but rewritten to account for bpftrace string-like types which may or may not have a NUL terminator.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
