### PR TITLE
Create PreTypeCheck pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#4890](https://github.com/bpftrace/bpftrace/pull/4890)
 - `BPFTRACE_DEBUG_OUTPUT` is removed, and errors are now propagated via the runtime error path
   - [#4976](https://github.com/bpftrace/bpftrace/pull/4976)
+- Unary increment/decrement on maps (`++@a`) requires the map to have an initial type
+  - [#X](https://github.com/bpftrace/bpftrace/pull/X)
 #### Added
 - Add `comm()` support for PID parameters.
   - [#4799](https://github.com/bpftrace/bpftrace/pull/4799)

--- a/docs/type_resolution.md
+++ b/docs/type_resolution.md
@@ -1,0 +1,109 @@
+# Type Resolution
+
+This explains how bpftrace handles type inference and resolution resulting in static types at runtime. The complicated pass that does this is called the TypeGraphPass (type_graph.cpp) and inside this pass is the the TypeGraph visitor, which builds up a graph of types as it walks the AST and then resolves them with a breath first search approach.
+
+## The Basics
+The main TypeGraph visitor creates a type graph, which is a map of Sources to Consumers (a one to many relationship). When the Source's type resolves or changes then each Consumer "subscribing" to this Source will have their callback invoked (with this type as the argument), which returns another type or std::nullopt. The Source is a `GraphNode`, which is a variant (`Node *`, `Typeof *`, `ScopedVariable`, `std::string`). The `std::string` represents either a map key or a map value as these are often resolved separately by different statements/expressions (e.g. `@a = 1; $b = @b["str"]`).
+
+In addition to a callback function, the Consumer struct consists of another `GraphNode` (the Consuming node) and after the callback returns we use this Consumer `GraphNode` as the next Source to lookup the next set of Consumers to call with the returned type in the graph/map.
+
+### Example Iteration
+```
+$a = 1; $b = $a;
+```
+
+**visit**
+1. the ScopedVariable `$a` subscribes to the Node on the right side of the assignment (integer literal `1`)
+1. variable `Node` `$a` on the left side of the assignment subscribes to ScopedVariable `$a`
+1. the integer literal `1` gets added to a queue of already resolved types (we already know it's a `uint8`)
+1. the ScopedVariable `$b` subscribes to the Node on the right side of the assignment (Variable `$a`)
+1. `$a` (on the right side of `$b`) subscribes to the ScopedVariable `$a`
+
+Notice the distinction between the variable `Node` and a `ScopedVariable`. The latter is not an AST object but something specific to the TypeGraph. `ScopedVariable` is responsible for tracking the type of a variable and then updating the associated variable `Node`s.
+
+**resolve**
+1. start type propagation
+1. pop from the queue of resolved types
+1. finding `1` with a type of `uint8`, we see if this Node has any consumers in the graph
+1. we find the ScopedVariable `$a` and in this case the Consumer callback does some checking to see if this ScopedVariable already has a type that is compatible with `uint8`
+1. the callback sees that it has a `None` type (by looking it up in the `resolved_types_` map). It can safely forward/return `uint8`
+1. the `propagate_resolved_types` logic gets the `uint8` from the returned Consumer callback and sets this as the value of the Consumer `GraphNode` in `resolved_types_`. In this case ScopedVariable `$a`.
+1. it then looks to see if the graph has any Consumers for the ScopedVariable `$a` and finds two variable `Node`s for `$a`
+1. the callbacks for Variable Node `$a` both return this new type
+1. `propagate_resolved_types` sets the value for both variable `Node`s `$a` to `uint8` in the `resolved_types_` map
+1. finally since ScopedVariable `$b` is subscribed to Variable `Node` `$a` it's type also gets set to `uint8` in the `resolved_types_` map
+
+The reason we store all the types in a separate map as opposed to on the AST nodes themselves is because the TypeGraph visitor may need to run multiple times to resolve things like comptime branches (more on this later). We need a clean state every time we run or else weird/bad things happen that are hard to debug. When the TypeGraph visitor is done running (possibly multiple times). This `resolved_types` map is then passed to the TypeApplicator visitor which uses it to set the types on the AST nodes.
+
+## Preventing Infinite Loops
+There is a really easy example that demonstrates how we might end up with an infinite loop when propagating types through the graph. Consider this example:
+```
+$a = 1; $a = $a + 1;
+```
+The second statement demonstrates that `$a` is subscribed to the result of the binop on the right side. The binop is subscribed to both `$a` and `1`. So when `$a` is resolved from the first statement and `1` is resolved, we enter the infinite loop of resolving `$a` then resolving the binop then resolving `$a` again and so forth. The TypeGraph does something very simple in that if it sees that the type returned by the Consumer callback is the same as the type already previously set by that callback then it simply stops propagating. In this case the binop resolves to a `uint64` so when `$a` becomes a `uint64` and re-triggers the binop, it already has this type and therefore stops.
+
+## Breath First Search
+`propagate_resolved_types` utilizes a BFS to propagate types instead of a DFS to prevent an issue with stale updates.
+For example:
+```
+let $a; $a = $a + 1; $a = 1;
+```
+There are 4 `$a` variable `Node`s that need types. They should all resolve to the same type with their Source being the ScopedVariable `$a` in the graph. In a depth first search when we resolve the first integer literal `1` and set the type of the ScopedVariable `$a` to `uint8`, we have 4 callbacks to fire. When we fire the third one (the left statement in the binop) the binop resolves to a `uint64` setting this as the type of the ScopedVariable `$a`. We then fire all 4 callbacks again setting the 4 `$a` variable nodes to type `uint64`. All is OK **BUT** we have one last callback left over from the first update to ScopedVariable `$a` which sets the last `$a` node (`$a = 1`) to a `uint8` - here is the stale update. Walk this example yourself to see why a BFS approach fixes this problem.
+
+## Comptime branches
+A large source of complication in the TypeGraph visitor is the existance of `comptime` branches, e.g. `if comptime (...) { } else { }`. There are some `comptime` expressions that get resolved before we ever reach the TypeGraph visitor (e.g. `if comptime (1 == 1)`) but some `comptime` expressions rely on knowing the types of things, e.g. `if comptime (typeinfo($a).full_ty == "uint64"))`. For these we need to wait to fully resolve the type of `$a` before we can evaluate this `comptime` expression. Additionally `comptime` branches may further expose parts of the type graph that we couldn't visit before. For example:
+```
+$a = 1;
+if comptime (typeinfo($a).full_ty == "uint64") {
+  @map = 1;
+} else {
+  @map = "str";
+}
+$a = (uint64)2;
+```
+In this case the value type of map `@map` changes depending on which branch we take.
+
+So in order to resolve the type of `$a` we need a full resolution of the TypeGraph visitor (minus the `comptime` branches). We then call upon the `AstTransformer` to transform `typeinfo($a)` into a literal record (e.g. `(btf_id=0, base_ty="int", full_ty="uint64")`). We can then evaluate the comptime expression and, if it's part of a conditional in an `if` statement (like above), decide what branch to keep.
+
+We then need to re-run the TypeGraph visitor because there are new branches to visit. We basically have to keep doing this until we either have no more `comptime` expressions (as they can be nested) OR we reach a point where we simply can't resolve them (and return an error).
+
+## Locked GraphNodes
+
+Let's look at a slight variation to the `comptime` example above:
+```
+$a = 1;
+if comptime (typeinfo($a).full_ty == "uint32") {
+  $a = (uint64)3;
+}
+$a = (uint32)2;
+```
+Hopefully you spot the issue right away. We resolve the type of `$a` to be a `uint32`, the `comptime` expression evaluates to `true` and we take a branch that then sets the type of ScopedVariable `$a` to `uint64`. How can `$a` be both a `uint32` and a `uint64`? **It can't**. This is where `locked_nodes` comes in. It's a simple map that gets passed to subsequent TypeGraph visits from former ones, indicating which `GraphNode`s have "locked" types - meaning they can't be changed. In this case because `$a` was evaluated inside of a introspection function (`typeinfo`) it is locked and trying to change it's type results in an error.
+
+However, `GraphNodes` that are not used inside of introspection functions (`typeinfo`, `typeof`, `sizeof`, `offsetof`) CAN be changed inside of `comptime` branches.
+
+## Variable Declarations
+One neat thing we can do with the TypeGraph's design is around the handling of variables with explicit type declarations.
+Example:
+```
+$b = 1;
+let $a: typeof($b) = "str";
+```
+This is clearly an error as the type of `$a` is a `uint8` and we're trying to assign a string literal to it. However, the error itself doesn't manifest in the TypeGraph visitor. This is because we completely ignore the right side of the assignment to determine the type of `$a` because it has a type declaration. Then in a later pass, we simply issue an error if the right side type is not compatible with the left side. This reduces some complication and added state required to track what variables have explicit type declarations. Except types with no size - in these cases we need the RHS to know how big the type is, e.g. `let $a: string = "hello"`.
+
+## Casting
+Inserted casts are reserved for a separate visitor, but still in the TypeGraphPass.
+Example:
+```
+$a = 1;
+$b = 1;
+$a = $b;
+$a = (uint32)2;
+```
+In this example both `$a` and `$b` start off as `uint8` but the last assignment transforms `$a` into a `uint32` (propagating to all the `$a` variable Nodes). So the statement `$a = $b` is valid because `uint8` fits into `uint32` but the type of `$b` shouldn't change, we just need to add a cast so both sides are of the same type. This is done in the CastCreator visitor. Again, for the purposes of not overcomplicating the TypeGraph visitor and separating the concern of cast injection, which doesn't change the types of the GraphNodes but just inserts an expression that doesn't require type evaluation (namely the cast to a specific type).
+
+## Pointer Sources
+TODO
+
+## Small Regressions/Changes
+
+$x = (int8)1; $x = 5; - This now becomes $x = (int16)(int8)1; $x = 5; because $x got promoted to int16 - we can fix this but it makes the logic more complicated.

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(ast STATIC
   passes/clang_parser.cpp
   passes/clang_build.cpp
   passes/named_param.cpp
+  passes/cast_creator.cpp
   passes/config_analyser.cpp
   passes/control_flow_analyser.cpp
   passes/deprecated.cpp
@@ -42,6 +43,7 @@ add_library(ast STATIC
   passes/probe_prune.cpp
   passes/resource_analyser.cpp
   passes/type_checker.cpp
+  passes/type_graph.cpp
   passes/codegen_llvm.cpp
   passes/resolve_imports.cpp
   passes/recursion_check.cpp

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -959,7 +959,9 @@ public:
   explicit MapAddr(ASTContext &ctx, Location &&loc, Map *map)
       : Node(ctx, std::move(loc)), map(map) {};
   explicit MapAddr(ASTContext &ctx, const Location &loc, const MapAddr &other)
-      : Node(ctx, loc + other.loc), map(clone(ctx, loc, other.map)) {};
+      : Node(ctx, loc + other.loc),
+        map(clone(ctx, loc, other.map)),
+        map_addr_type(other.map_addr_type) {};
 
   const SizedType &type() const
   {
@@ -1031,7 +1033,8 @@ public:
   explicit Unop(ASTContext &ctx, const Location &loc, const Unop &other)
       : Node(ctx, loc + other.loc),
         expr(clone(ctx, loc, other.expr)),
-        op(other.op) {};
+        op(other.op),
+        result_type(other.result_type) {};
 
   const SizedType &type() const
   {
@@ -1112,7 +1115,8 @@ public:
                        const ArrayAccess &other)
       : Node(ctx, loc + other.loc),
         expr(clone(ctx, loc, other.expr)),
-        indexpr(clone(ctx, loc, other.indexpr)) {};
+        indexpr(clone(ctx, loc, other.indexpr)),
+        element_type(other.element_type) {};
 
   const SizedType &type() const
   {
@@ -1245,7 +1249,9 @@ public:
   explicit Tuple(ASTContext &ctx, Location &&loc, ExpressionList &&elems)
       : Node(ctx, std::move(loc)), elems(std::move(elems)) {};
   explicit Tuple(ASTContext &ctx, const Location &loc, const Tuple &other)
-      : Node(ctx, loc + other.loc), elems(clone(ctx, loc, other.elems)) {};
+      : Node(ctx, loc + other.loc),
+        elems(clone(ctx, loc, other.elems)),
+        tuple_type(other.tuple_type) {};
 
   const SizedType &type() const
   {
@@ -1304,7 +1310,8 @@ public:
       : Node(ctx, std::move(loc)), elems(std::move(named_args)) {};
   explicit Record(ASTContext &ctx, const Location &loc, const Record &other)
       : Node(ctx, loc + other.loc),
-        elems(clone(ctx, loc, other.elems)) {};
+        elems(clone(ctx, loc, other.elems)),
+        record_type(other.record_type) {};
 
   const SizedType &type() const
   {
@@ -1790,7 +1797,8 @@ public:
       : Node(ctx, loc + other.loc),
         decl(clone(ctx, loc, other.decl)),
         iterable(clone(ctx, loc, other.iterable)),
-        block(clone(ctx, loc, other.block)) {};
+        block(clone(ctx, loc, other.block)),
+        ctx_type(other.ctx_type) {};
 
   bool operator==(const For &other) const
   {

--- a/src/ast/passes/cast_creator.cpp
+++ b/src/ast/passes/cast_creator.cpp
@@ -1,0 +1,407 @@
+#include "ast/passes/cast_creator.h"
+#include "ast/ast.h"
+#include "bpftrace.h"
+#include "log.h"
+#include "types.h"
+
+#include <functional>
+
+namespace bpftrace::ast {
+
+bool try_element_cast(ASTContext &ctx,
+                      Expression &elem,
+                      const SizedType &expr_type,
+                      const SizedType &target_type);
+
+bool try_tuple_cast(ASTContext &ctx,
+                    Expression &exp,
+                    const SizedType &expr_type,
+                    const SizedType &target_type)
+{
+  if (auto *block_expr = exp.as<BlockExpr>()) {
+    return try_tuple_cast(ctx, block_expr->expr, expr_type, target_type);
+  }
+
+  if (!exp.is<Variable>() && !exp.is<TupleAccess>() && !exp.is<MapAccess>() &&
+      !exp.is<Tuple>() && !exp.is<FieldAccess>() && !exp.is<Unop>()) {
+    LOG(BUG) << "Unexpected expression kind: try_tuple_cast";
+  }
+
+  ExpressionList expr_list = {};
+
+  for (size_t i = 0; i < target_type.GetFields().size(); ++i) {
+    auto &expr_field_ty = expr_type.GetField(i).type;
+    auto &target_field_ty = target_type.GetField(i).type;
+    Expression elem;
+    if (auto *tuple_literal = exp.as<Tuple>()) {
+      elem = clone(ctx,
+                   tuple_literal->elems.at(i).loc(),
+                   tuple_literal->elems.at(i));
+    } else {
+      elem = ctx.make_node<TupleAccess>(Location(exp.loc()),
+                                        clone(ctx, exp.loc(), exp),
+                                        i);
+      elem.as<TupleAccess>()->element_type = expr_field_ty;
+    }
+    if (!try_element_cast(ctx, elem, expr_field_ty, target_field_ty)) {
+      return false;
+    }
+    expr_list.emplace_back(std::move(elem));
+  }
+
+  exp = ctx.make_node<Tuple>(Location(exp.loc()), std::move(expr_list));
+  exp.as<Tuple>()->tuple_type = target_type;
+
+  return true;
+}
+
+bool try_record_cast(ASTContext &ctx,
+                     Expression &exp,
+                     const SizedType &expr_type,
+                     const SizedType &target_type)
+{
+  if (auto *block_expr = exp.as<BlockExpr>()) {
+    return try_record_cast(ctx, block_expr->expr, expr_type, target_type);
+  }
+
+  if (!exp.is<Variable>() && !exp.is<FieldAccess>() && !exp.is<MapAccess>() &&
+      !exp.is<Record>() && !exp.is<TupleAccess>() && !exp.is<Unop>()) {
+    LOG(BUG) << "Unexpected expression kind: try_record_cast";
+  }
+
+  std::unordered_map<size_t, NamedArgument *> named_arg_map;
+
+  for (size_t i = 0; i < expr_type.GetFields().size(); ++i) {
+    const auto &target_field = target_type.GetField(i);
+    const auto &expr_field_ty = expr_type.GetField(target_field.name).type;
+    const auto &target_field_ty = target_field.type;
+    Expression elem;
+    if (auto *record_literal = exp.as<Record>()) {
+      auto field_idx = expr_type.GetFieldIdx(target_field.name);
+      elem = clone(ctx,
+                   record_literal->elems.at(field_idx)->expr.loc(),
+                   record_literal->elems.at(field_idx)->expr);
+    } else {
+      elem = ctx.make_node<FieldAccess>(Location(exp.loc()),
+                                        clone(ctx, exp.loc(), exp),
+                                        target_field.name);
+      elem.as<FieldAccess>()->field_type = expr_field_ty;
+    }
+    if (!try_element_cast(ctx, elem, expr_field_ty, target_field_ty)) {
+      return false;
+    }
+    auto *named_arg = ctx.make_node<NamedArgument>(Location(exp.loc()),
+                                                   target_field.name,
+                                                   std::move(elem));
+    named_arg_map[expr_type.GetFieldIdx(target_field.name)] = named_arg;
+  }
+
+  // Maintain the ordering for the current type
+  NamedArgumentList named_args = {};
+  for (size_t i = 0; i < expr_type.GetFields().size(); ++i) {
+    named_args.emplace_back(named_arg_map[i]);
+  }
+
+  exp = ctx.make_node<Record>(Location(exp.loc()), std::move(named_args));
+  exp.as<Record>()->record_type = target_type;
+
+  return true;
+}
+
+bool try_int_cast(ASTContext &ctx,
+                  Expression &exp,
+                  const SizedType &expr_type,
+                  const SizedType &target_type)
+{
+  // We don't need a cast if it's a literal
+  if (auto *integer = exp.as<Integer>()) {
+    if (target_type.IsSigned()) {
+      auto signed_ty = ast::get_signed_integer_type(integer->value);
+      if (!signed_ty || !signed_ty->FitsInto(target_type)) {
+        // The integer is too large
+        return false;
+      }
+    } else {
+      auto unsigned_ty = ast::get_integer_type(integer->value);
+      if (!unsigned_ty.FitsInto(target_type)) {
+        // The integer is too large
+        return false;
+      }
+    }
+    exp = ctx.make_node<Integer>(
+        Location(exp.loc()), integer->value, target_type, integer->original);
+    return true;
+  } else if (auto *negative_integer = exp.as<NegativeInteger>()) {
+    if (!target_type.IsSigned()) {
+      return false;
+    }
+
+    auto signed_ty = ast::get_signed_integer_type(negative_integer->value);
+    if (!signed_ty.FitsInto(target_type)) {
+      // The integer is too large
+      return false;
+    }
+
+    exp = ctx.make_node<NegativeInteger>(Location(exp.loc()),
+                                         negative_integer->value,
+                                         target_type);
+    return true;
+  }
+
+  if (!expr_type.FitsInto(target_type) && !expr_type.IsCastableMapTy()) {
+    return false;
+  }
+
+  auto *typeof_r = ctx.make_node<Typeof>(Location(exp.loc()), target_type);
+  exp = ctx.make_node<Cast>(Location(exp.loc()),
+                            typeof_r,
+                            clone(ctx, exp.loc(), exp));
+
+  return true;
+}
+
+bool try_string_cast(ASTContext &ctx,
+                     Expression &exp,
+                     const SizedType &expr_type,
+                     const SizedType &target_type)
+{
+  if (exp.type().GetSize() == target_type.GetSize()) {
+    return true;
+  }
+
+  if (!expr_type.FitsInto(target_type)) {
+    return false;
+  }
+
+  auto *typeof_r = ctx.make_node<Typeof>(Location(exp.loc()), target_type);
+  exp = ctx.make_node<Cast>(Location(exp.loc()),
+                            typeof_r,
+                            clone(ctx, exp.loc(), exp));
+  return true;
+}
+
+bool try_element_cast(ASTContext &ctx,
+                      Expression &elem,
+                      const SizedType &expr_type,
+                      const SizedType &target_type)
+{
+  if (expr_type == target_type) {
+    return true;
+  }
+
+  // No when both are castable map types
+  if (expr_type.GetTy() == target_type.GetTy() && expr_type.IsCastableMapTy()) {
+    return true;
+  }
+
+  if ((expr_type.IsIntegerTy() || expr_type.IsCastableMapTy()) &&
+      (target_type.IsIntegerTy() || target_type.IsCastableMapTy())) {
+    return try_int_cast(ctx, elem, expr_type, target_type);
+  }
+
+  if (expr_type.GetTy() != target_type.GetTy()) {
+    return false;
+  }
+
+  if (target_type.IsStringTy()) {
+    return try_string_cast(ctx, elem, expr_type, target_type);
+  } else if (target_type.IsTupleTy()) {
+    return try_tuple_cast(ctx, elem, expr_type, target_type);
+  } else if (target_type.IsRecordTy()) {
+    return try_record_cast(ctx, elem, expr_type, target_type);
+  }
+
+  return false;
+}
+
+CastCreator::CastCreator(ASTContext &ast, BPFtrace &bpftrace)
+    : ctx_(ast), bpftrace_(bpftrace)
+{
+}
+
+void CastCreator::visit(AssignMapStatement &assignment)
+{
+  visit(assignment.map_access);
+  visit(assignment.expr);
+
+  const auto &expr_type = assignment.expr.type();
+  const auto &value_type = assignment.map_access->map->value_type;
+
+  if (value_type == expr_type) {
+    return;
+  }
+
+  if (!try_element_cast(ctx_, assignment.expr, expr_type, value_type)) {
+    assignment.addError() << "Type mismatch for "
+                          << assignment.map_access->map->ident << ": "
+                          << "trying to assign value of type '" << expr_type
+                          << "' when map already has a value type '"
+                          << value_type << "'";
+  }
+}
+
+void CastCreator::visit(AssignVarStatement &assignment)
+{
+  visit(assignment.expr);
+  visit(assignment.var_decl);
+
+  const auto &expr_type = assignment.expr.type();
+  const auto &var_type = assignment.var()->type();
+
+  if (var_type == expr_type) {
+    return;
+  }
+
+  if (!try_element_cast(ctx_, assignment.expr, expr_type, var_type)) {
+    assignment.addError() << "Type mismatch for " << assignment.var()->ident
+                          << ": "
+                          << "trying to assign value of type '" << expr_type
+                          << "' when variable already has a type '" << var_type
+                          << "'";
+  }
+}
+
+void CastCreator::visit(Binop &op)
+{
+  visit(op.left);
+  visit(op.right);
+
+  const auto &left_type = op.left.type();
+  const auto &right_type = op.right.type();
+  if (left_type == right_type) {
+    return;
+  }
+
+  auto promoted = get_promoted_type(left_type, right_type);
+  if (promoted) {
+    try_element_cast(ctx_, op.left, left_type, *promoted);
+    try_element_cast(ctx_, op.right, right_type, *promoted);
+  }
+}
+
+void CastCreator::visit(BlockExpr &block)
+{
+  visit(block.stmts);
+  visit(block.expr);
+}
+
+void CastCreator::visit(Cast &cast)
+{
+  visit(cast.expr);
+  visit(cast.typeof);
+}
+
+void CastCreator::visit(IfExpr &if_expr)
+{
+  visit(if_expr.cond);
+  visit(if_expr.left);
+  visit(if_expr.right);
+
+  const auto &result_type = if_expr.result_type;
+  const auto &left_type = if_expr.left.type();
+  const auto &right_type = if_expr.right.type();
+
+  if (result_type != left_type) {
+    if (!try_element_cast(ctx_, if_expr.left, left_type, result_type)) {
+      if_expr.addError()
+          << "Branches must return the same type or compatible types: "
+          << "have '" << left_type << "' and '" << right_type << "'";
+    }
+  }
+
+  if (result_type != right_type) {
+    if (!try_element_cast(ctx_, if_expr.right, right_type, result_type)) {
+      if_expr.addError()
+          << "Branches must return the same type or compatible types: "
+          << "have '" << left_type << "' and '" << right_type << "'";
+    }
+  }
+}
+
+void CastCreator::visit(Jump &jump)
+{
+  if (jump.ident == JumpType::RETURN) {
+    visit(jump.return_value);
+    if (dynamic_cast<Probe *>(top_level_node_)) {
+      if (jump.return_value.has_value()) {
+        const auto &ty = jump.return_value->type();
+        if (ty.IsIntegerTy() && ty.GetSize() != 8) {
+          // Probes always return 64 bit ints
+          try_element_cast(ctx_, *jump.return_value, ty, CreateInt64());
+        }
+      }
+    } else if (auto *subprog = dynamic_cast<Subprog *>(top_level_node_)) {
+      if (!jump.return_value.has_value()) {
+        if (!subprog->return_type->type().IsVoidTy()) {
+          jump.addError() << "Function " << subprog->name << " is of type "
+                          << subprog->return_type->type() << ", cannot return "
+                          << CreateVoid();
+          return;
+        }
+        return;
+      }
+      if (!try_element_cast(ctx_,
+                            *jump.return_value,
+                            jump.return_value->type(),
+                            subprog->return_type->type())) {
+        jump.addError() << "Function " << subprog->name << " is of type "
+                        << subprog->return_type->type() << ", cannot return "
+                        << jump.return_value->type();
+        return;
+      }
+    }
+  }
+}
+
+void CastCreator::visit(Map &map)
+{
+  if (map.value_type.IsNoneTy()) {
+    map.addError() << "Undefined map: " + map.ident;
+  }
+}
+
+void CastCreator::visit(MapAccess &acc)
+{
+  visit(acc.key);
+  visit(acc.map);
+  const auto &expr_type = acc.key.type();
+  const auto &key_type = acc.map->key_type;
+
+  if (key_type.IsNoneTy() || expr_type.IsNoneTy()) {
+    return;
+  }
+
+  if (!try_element_cast(ctx_, acc.key, expr_type, key_type)) {
+    acc.addError() << "Type mismatch for " << acc.map->ident << ": "
+                   << "trying to assign key of type '" << expr_type
+                   << "' when map already has a key type '" << key_type << "'";
+  }
+}
+
+void CastCreator::visit(Probe &probe)
+{
+  top_level_node_ = &probe;
+  visit(probe.attach_points);
+  visit(probe.block);
+}
+
+void CastCreator::visit(Subprog &subprog)
+{
+  top_level_node_ = &subprog;
+
+  for (SubprogArg *arg : subprog.args) {
+    visit(arg->var);
+  }
+
+  visit(subprog.block);
+  visit(subprog.return_type);
+}
+
+void CastCreator::visit(Variable &var)
+{
+  if (var.var_type.IsNoneTy()) {
+    var.addError() << "Could not resolve the type of this variable";
+  }
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/cast_creator.h
+++ b/src/ast/passes/cast_creator.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+#include "ast/visitor.h"
+
+namespace bpftrace {
+class BPFtrace;
+} // namespace bpftrace
+
+namespace bpftrace::ast {
+
+bool try_tuple_cast(ASTContext &ctx,
+                    Expression &exp,
+                    const SizedType &expr_type,
+                    const SizedType &target_type);
+
+bool try_record_cast(ASTContext &ctx,
+                     Expression &exp,
+                     const SizedType &expr_type,
+                     const SizedType &target_type);
+
+class CastCreator : public Visitor<CastCreator> {
+public:
+  explicit CastCreator(ASTContext &ast, BPFtrace &bpftrace);
+
+  using Visitor<CastCreator>::visit;
+  void visit(AssignMapStatement &assignment);
+  void visit(AssignVarStatement &assignment);
+  void visit(Binop &binop);
+  void visit(BlockExpr &block);
+  void visit(Cast &cast);
+  void visit(IfExpr &if_expr);
+  void visit(Jump &jump);
+  void visit(Map &map);
+  void visit(MapAccess &acc);
+  void visit(Probe &probe);
+  void visit(Subprog &subprog);
+  void visit(Variable &var);
+
+private:
+  ASTContext &ctx_;
+  BPFtrace &bpftrace_;
+  Node *top_level_node_ = nullptr;
+
+  void create_int_cast(Expression &exp, const SizedType &target_type);
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -946,6 +946,12 @@ void fold(ASTContext &ast, Expression &expr)
   folder.visit(expr);
 }
 
+void fold(ASTContext &ast)
+{
+  LiteralFolder folder(ast);
+  folder.visit(ast.root);
+}
+
 Pass CreateFoldLiteralsPass()
 {
   auto fn = [](ASTContext &ast, BPFtrace &b) {

--- a/src/ast/passes/fold_literals.h
+++ b/src/ast/passes/fold_literals.h
@@ -11,6 +11,8 @@ namespace bpftrace::ast {
 // literals. Note however, that it is up to the pass to ensure that the full
 // expression is recursively folded.
 void fold(ASTContext &ast, Expression &expr);
+// Re-visit the whole ast and re-fold
+void fold(ASTContext &ast);
 
 // Fold all nodes.
 Pass CreateFoldLiteralsPass();

--- a/src/ast/passes/type_graph.cpp
+++ b/src/ast/passes/type_graph.cpp
@@ -1,0 +1,2972 @@
+#include "ast/passes/type_graph.h"
+#include "ast/ast.h"
+#include "ast/async_event_types.h"
+#include "ast/passes/cast_creator.h"
+#include "ast/passes/clang_parser.h"
+#include "ast/passes/fold_literals.h"
+#include "ast/passes/macro_expansion.h"
+#include "ast/passes/map_sugar.h"
+#include "ast/passes/type_system.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+#include "btf/compat.h"
+#include "collect_nodes.h"
+#include "config.h"
+#include "config_parser.h"
+#include "log.h"
+#include "probe_types.h"
+#include "struct.h"
+#include "types.h"
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <functional>
+#include <queue>
+
+// Notes:
+// begin { $a = 0; $a = (uint64)1; }
+// 0 is resolved
+// assignment assigns uint8 to the scoped var
+// two $a Variable nodes are subscribed to this scoped var
+// they both update their nodes to uint8
+// uint64 is resolved
+// 2nd assignment assigns uint64 to the scoped var
+// both subscribed $a nodes update to uint64
+
+namespace bpftrace::ast {
+
+namespace {
+
+std::unordered_set<std::string> VOID_RETURNING_FUNCS = {
+  "join", "printf", "errorf", "warnf", "system", "cat",     "debugf",
+  "exit", "print",  "clear",  "zero",  "time",   "unwatch", "fail"
+};
+
+std::unordered_map<std::string, SizedType (*)()> SIMPLE_BUILTIN_TYPES = {
+  { "pid", CreateUInt32 },
+  { "tid", CreateUInt32 },
+  { "nsecs", CreateUInt64 },
+  { "__builtin_elapsed", CreateUInt64 },
+  { "__builtin_cgroup", CreateUInt64 },
+  { "__builtin_uid", CreateUInt64 },
+  { "__builtin_gid", CreateUInt64 },
+  { "__builtin_cpu", CreateUInt64 },
+  { "__builtin_rand", CreateUInt64 },
+  { "__builtin_jiffies", CreateUInt64 },
+  { "__builtin_ncpus", CreateUInt64 },
+  { "__builtin_username", CreateUsername },
+  { "__builtin_usermode", CreateUInt8 },
+  { "__builtin_cpid", CreateUInt64 },
+};
+
+std::unordered_map<std::string, SizedType (*)()> SIMPLE_CALL_TYPES = {
+  { "ksym", CreateKSym },          { "usym", CreateUSym },
+  { "cgroupid", CreateUInt64 },    { "cgroup_path", CreateCgroupPath },
+  { "stack_len", CreateInt64 },    { "strftime", CreateTimestamp },
+  { "macaddr", CreateMacAddress }, { "skboutput", CreateUInt32 },
+  { "strncmp", CreateUInt64 },     { "socket_cookie", CreateUInt64 },
+};
+
+const std::unordered_map<Type, std::string_view> AGGREGATE_HINTS{
+  { Type::count_t, "count()" },
+  { Type::sum_t, "sum(retval)" },
+  { Type::min_t, "min(retval)" },
+  { Type::max_t, "max(retval)" },
+  { Type::avg_t, "avg(retval)" },
+  { Type::hist_t, "hist(retval)" },
+  { Type::lhist_t, "lhist(rand %10, 0, 10, 1)" },
+  { Type::tseries_t, "tseries(rand %10, 10s, 1)" },
+  { Type::stats_t, "stats(arg2)" },
+};
+
+AddrSpace find_addrspace(ProbeType pt)
+{
+  switch (pt) {
+    case ProbeType::kprobe:
+    case ProbeType::kretprobe:
+    case ProbeType::fentry:
+    case ProbeType::fexit:
+    case ProbeType::tracepoint:
+    case ProbeType::iter:
+    case ProbeType::rawtracepoint:
+      return AddrSpace::kernel;
+    case ProbeType::uprobe:
+    case ProbeType::uretprobe:
+    case ProbeType::usdt:
+      return AddrSpace::user;
+    case ProbeType::invalid:
+    case ProbeType::special:
+    case ProbeType::test:
+    case ProbeType::benchmark:
+    case ProbeType::profile:
+    case ProbeType::interval:
+    case ProbeType::software:
+    case ProbeType::hardware:
+    case ProbeType::watchpoint:
+      return AddrSpace::none;
+  }
+  return {}; // unreached
+}
+
+template <class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+
+using ScopedVariable = std::pair<Node *, std::string>;
+using GraphNode = std::variant<Node *, Typeof *, ScopedVariable, std::string>;
+
+struct MapType {
+  SizedType key_type;
+  SizedType value_type;
+};
+
+struct Consumer {
+  GraphNode node;
+  std::function<SizedType(SizedType)> callback;
+  std::optional<SizedType> last_propagated;
+
+  Consumer(GraphNode node, std::function<SizedType(SizedType)> callback)
+      : node(std::move(node)), callback(std::move(callback))
+  {
+  }
+};
+
+struct ScopedVariableHash {
+  std::size_t operator()(const ScopedVariable &sv) const
+  {
+    auto h1 = std::hash<Node *>{}(sv.first);
+    auto h2 = std::hash<std::string>{}(sv.second);
+    return h1 ^ (h2 << 1);
+  }
+};
+
+struct GraphNodeHash {
+  std::size_t operator()(const GraphNode &gn) const
+  {
+    return std::visit(
+        [](const auto &val) -> std::size_t {
+          using T = std::decay_t<decltype(val)>;
+          if constexpr (std::is_same_v<T, Node *>) {
+            return std::hash<Node *>{}(val);
+          } else if constexpr (std::is_same_v<T, Typeof *>) {
+            return std::hash<Typeof *>{}(val);
+          } else if constexpr (std::is_same_v<T, std::string>) {
+            return std::hash<std::string>{}(val);
+          } else {
+            return ScopedVariableHash{}(val);
+          }
+        },
+        gn);
+  }
+};
+
+using LockedNodes = std::unordered_map<GraphNode, SizedType, GraphNodeHash>;
+
+std::string get_map_value_name(const std::string &ident)
+{
+  return ident + "__val";
+}
+
+std::string get_map_key_name(const std::string &ident)
+{
+  return ident + "__key";
+}
+
+class TypeGraph : public Visitor<TypeGraph> {
+public:
+  explicit TypeGraph(ASTContext &ast,
+                     BPFtrace &bpftrace,
+                     MapMetadata &map_metadata,
+                     CDefinitions &c_definitions,
+                     TypeMetadata &type_metadata,
+                     const MacroRegistry &macro_registry,
+                     LockedNodes locked_nodes = {})
+      : ast_(ast),
+        bpftrace_(bpftrace),
+        map_metadata_(map_metadata),
+        c_definitions_(c_definitions),
+        type_metadata_(type_metadata),
+        macro_registry_(macro_registry),
+        locked_nodes_(std::move(locked_nodes))
+  {
+  }
+
+  using Visitor<TypeGraph>::visit;
+  void visit(ArrayAccess &arr);
+  void visit(AssignMapStatement &assignment);
+  void visit(AssignVarStatement &assignment);
+  void visit(Binop &binop);
+  void visit(BlockExpr &block);
+  void visit(Boolean &boolean);
+  void visit(Builtin &builtin);
+  void visit(Call &call);
+  void visit(Cast &cast);
+  void visit(Comptime &comptime);
+  void visit(ExprStatement &expr);
+  void visit(FieldAccess &acc);
+  void visit(For &f);
+  void visit(Identifier &identifier);
+  void visit(IfExpr &if_expr);
+  void visit(Integer &integer);
+  void visit(Jump &jump);
+  void visit(Map &map);
+  void visit(MapAccess &acc);
+  void visit(MapAddr &map_addr);
+  void visit(NegativeInteger &integer);
+  void visit(Offsetof &offof);
+  void visit(Probe &probe);
+  void visit(Record &record);
+  void visit(Sizeof &szof);
+  void visit(String &str);
+  void visit(Subprog &subprog);
+  void visit(Tuple &tuple);
+  void visit(TupleAccess &acc);
+  void visit(Typeof &typeof);
+  void visit(Typeinfo &typeinfo);
+  void visit(Unop &unop);
+  void visit(VarDeclStatement &decl);
+  void visit(Variable &var);
+  void visit(VariableAddr &var_addr);
+
+  bool resolve();
+  LockedNodes get_locked_nodes();
+
+  const auto &get_resolved_types() const
+  {
+    return resolved_types_;
+  }
+
+  const std::vector<Comptime *> &get_unresolved_comptimes() const
+  {
+    return unresolved_comptimes_;
+  }
+
+  bool needs_rerun() const
+  {
+    return needs_rerun_;
+  }
+
+private:
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+  MapMetadata &map_metadata_;
+  CDefinitions &c_definitions_;
+  TypeMetadata &type_metadata_;
+  const MacroRegistry &macro_registry_;
+  const LockedNodes locked_nodes_;
+  bool needs_rerun_ = false;
+  std::queue<std::pair<GraphNode, SizedType>> queue_;
+  std::unordered_map<GraphNode, std::vector<Consumer>, GraphNodeHash> graph_;
+  std::unordered_map<Node *, std::unordered_map<std::string, SizedType>>
+      variables_;
+  std::map<Node *, CollectNodes<Variable>> for_vars_referenced_;
+  // These are variables that have a declaration with a type with a SIZE
+  // let $a: uint16; // type with a size
+  // let $a; // no type no size
+  // let $a: string // type but no size
+  std::unordered_set<ScopedVariable, ScopedVariableHash> decl_variables_;
+  std::vector<Node *> scope_stack_;
+  Node *top_level_node_ = nullptr;
+  std::string func_; // tracks Call context for Identifier resolution
+  int introspection_level_ = 0;
+  std::unordered_set<GraphNode, GraphNodeHash> introspected_nodes_;
+
+  std::vector<Comptime *> unresolved_comptimes_;
+  // Tracks the "source" of pointer types (the variable/map being addressed).
+  // Key: the ScopedVariable or map value/key holding the pointer Value (the
+  // variable/map being addressed - the source).
+  std::unordered_map<GraphNode, GraphNode, GraphNodeHash> pointer_sources_;
+
+  std::unordered_map<GraphNode, SizedType, GraphNodeHash> resolved_types_;
+  // This is for tracking type compatibilty for the arguments passed to map
+  // aggregate functions, e.g. `sum`, `avg`, etc.
+  std::unordered_map<std::string, SizedType> agg_map_args_;
+
+  bool resolve_struct_type(SizedType &type, Node &node);
+  bool check_offsetof_type(Offsetof &offof, SizedType cstruct);
+
+  SizedType get_resolved_type(const GraphNode &node) const
+  {
+    auto it = resolved_types_.find(node);
+    return it != resolved_types_.end() ? it->second : CreateNone();
+  }
+  SizedType get_variable_type(
+      const ScopedVariable &scoped_var,
+      const SizedType &type,
+      Node &error_node,
+      std::optional<GraphNode> ptr_source = std::nullopt);
+  SizedType get_map_value(std::string map_name,
+                          const SizedType &type,
+                          Node &error_node,
+                          std::optional<GraphNode> ptr_source = std::nullopt);
+  SizedType get_agg_map_value(std::string map_name,
+                              const SizedType &type,
+                              Call &call);
+  SizedType get_map_key(std::string map_name,
+                        const SizedType &type,
+                        Node &error_node,
+                        std::optional<GraphNode> ptr_source = std::nullopt);
+  void propagate_resolved_types();
+  void add_resolved_type(const GraphNode &node, const SizedType &type);
+  Node *find_variable_scope(const std::string &var_ident, bool safe = true);
+  void add_consumer(const GraphNode &source, const GraphNode &consumer);
+  SizedType get_locked_node(const GraphNode &node,
+                            const SizedType &type,
+                            Node &error_node,
+                            const std::string &name);
+  GraphNode get_pointer_source(Expression &expr);
+  bool is_same_pointer_source(const GraphNode &node_key,
+                              const GraphNode &ptr_source,
+                              const SizedType &incoming_type,
+                              const SizedType &current_type);
+  Probe *get_probe();
+  Probe *get_probe(Node &node, std::string name = "");
+  void check_stack_call(Call &call, bool kernel);
+};
+
+using ResolvedTypes = std::unordered_map<GraphNode, SizedType, GraphNodeHash>;
+
+class AstTransformer
+    : public Visitor<AstTransformer, std::optional<Expression>> {
+public:
+  AstTransformer(ASTContext &ast,
+                 const MacroRegistry &macro_registry,
+                 const ResolvedTypes &resolved_types)
+      : ast_(ast),
+        macro_registry_(macro_registry),
+        resolved_types_(resolved_types) {};
+
+  using Visitor<AstTransformer, std::optional<Expression>>::visit;
+
+  std::optional<Expression> visit(Expression &expr);
+  std::optional<Expression> visit(Binop &binop);
+  std::optional<Expression> visit(Offsetof &offof);
+  std::optional<Expression> visit(Sizeof &szof);
+  std::optional<Expression> visit(Typeinfo &typeinfo);
+  std::optional<Expression> visit(FieldAccess &acc);
+
+  bool had_transforms() const
+  {
+    return had_transforms_;
+  }
+
+private:
+  ASTContext &ast_;
+  const MacroRegistry &macro_registry_;
+  const ResolvedTypes &resolved_types_;
+  bool had_transforms_ = false;
+
+  const SizedType &get_type(const GraphNode &node) const
+  {
+    auto it = resolved_types_.find(node);
+    if (it != resolved_types_.end()) {
+      return it->second;
+    }
+    static SizedType none = CreateNone();
+    return none;
+  }
+};
+
+class TypeApplicator : public Visitor<TypeApplicator> {
+public:
+  explicit TypeApplicator(const ResolvedTypes &resolved_types)
+      : resolved_types_(resolved_types) {};
+
+  using Visitor<TypeApplicator>::visit;
+
+  void visit(ArrayAccess &arr);
+  void visit(Binop &binop);
+  void visit(Builtin &builtin);
+  void visit(Call &call);
+  void visit(Cast &cast);
+  void visit(FieldAccess &acc);
+  void visit(Identifier &identifier);
+  void visit(IfExpr &if_expr);
+  void visit(Map &map);
+  void visit(MapAddr &map_addr);
+  void visit(Record &record);
+  void visit(Tuple &tuple);
+  void visit(TupleAccess &acc);
+  void visit(Unop &unop);
+  void visit(Variable &var);
+  void visit(VariableAddr &var_addr);
+
+private:
+  const ResolvedTypes &resolved_types_;
+
+  void apply(Node &node, SizedType &target)
+  {
+    auto it = resolved_types_.find(&node);
+    if (it != resolved_types_.end()) {
+      target = it->second;
+    }
+  }
+};
+
+SizedType binop_ptr(Binop &binop, const SizedType &lht, const SizedType &rht)
+{
+  bool left_is_ptr = lht.IsPtrTy();
+  const auto &ptr = left_is_ptr ? lht : rht;
+  const auto &other = left_is_ptr ? rht : lht;
+
+  bool compare = is_comparison_op(binop.op);
+  bool logical = binop.op == Operator::LAND || binop.op == Operator::LOR;
+
+  auto invalid_op = [&binop, &lht, &rht]() -> SizedType {
+    binop.addError() << "The " << opstr(binop)
+                     << " operator can not be used on expressions of types "
+                     << lht << ", " << rht;
+    return CreateNone();
+  };
+
+  // Binop on two pointers
+  if (other.IsPtrTy()) {
+    if (compare) {
+      const auto le = lht.GetPointeeTy();
+      const auto re = rht.GetPointeeTy();
+      if (le != re) {
+        auto &warn = binop.addWarning();
+        warn << "comparison of distinct pointer types: " << le << ", " << re;
+        warn.addContext(binop.left.loc()) << "left (" << le << ")";
+        warn.addContext(binop.right.loc()) << "right (" << re << ")";
+      }
+      return CreateBool();
+    } else if (!logical) {
+      return invalid_op();
+    } else {
+      return CreateBool();
+    }
+  }
+  // Binop on a pointer and (int or bool)
+  else if (other.IsIntTy() || other.IsBoolTy()) {
+    // sum is associative but minus only works with pointer on the left hand
+    // side
+    if (binop.op == Operator::MINUS && !left_is_ptr)
+      return invalid_op();
+    else if (binop.op == Operator::PLUS || binop.op == Operator::MINUS)
+      return CreatePointer(ptr.GetPointeeTy(), ptr.GetAS());
+    else if (!compare && !logical)
+      return invalid_op();
+
+    if (compare) {
+      return CreateBool();
+    } else {
+      return invalid_op();
+    }
+  }
+  // Binop on a pointer and something else
+  else {
+    return invalid_op();
+  }
+}
+
+SizedType binop_int(Binop &binop, const SizedType &lht, const SizedType &rht)
+{
+  auto is_comparison = is_comparison_op(binop.op);
+  if (lht == rht) {
+    if (is_comparison) {
+      return CreateBool();
+    } else {
+      if (lht.IsSigned()) {
+        return CreateInt64();
+      }
+      return CreateUInt64();
+    }
+  }
+
+  bool show_warning = false;
+  bool mismatched_sign = rht.IsSigned() != lht.IsSigned();
+  // N.B. all castable map values are 64 bits
+  if (lht.IsCastableMapTy()) {
+    if (rht.IsCastableMapTy()) {
+      show_warning = mismatched_sign;
+    } else {
+      if (!get_promoted_type(rht, CreateInteger(64, lht.IsSigned()))) {
+        show_warning = true;
+      }
+    }
+  } else if (rht.IsCastableMapTy()) {
+    if (!get_promoted_type(lht, CreateInteger(64, rht.IsSigned()))) {
+      show_warning = true;
+    }
+  } else if (!get_promoted_type(lht, rht)) {
+    show_warning = true;
+  }
+
+  if (show_warning) {
+    switch (binop.op) {
+      case Operator::EQ:
+      case Operator::NE:
+      case Operator::LE:
+      case Operator::GE:
+      case Operator::LT:
+      case Operator::GT:
+        binop.addWarning() << "comparison of integers of different signs: '"
+                           << lht << "' and '" << rht << "'"
+                           << " can lead to undefined behavior";
+        break;
+      case Operator::PLUS:
+      case Operator::MINUS:
+      case Operator::MUL:
+      case Operator::DIV:
+      case Operator::MOD:
+        binop.addWarning() << "arithmetic on integers of different signs: '"
+                           << lht << "' and '" << rht << "'"
+                           << " can lead to undefined behavior";
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (is_comparison) {
+    return CreateBool();
+  }
+
+  // Next, warn on any operations that require signed division.
+  //
+  // SDIV is not implemented for bpf. See Documentation/bpf/bpf_design_QA
+  // in kernel sources
+  if (binop.op == Operator::DIV || binop.op == Operator::MOD) {
+    // If they're still signed, we have to warn
+    if (lht.IsSigned() || rht.IsSigned()) {
+      binop.addWarning() << "signed operands for '" << opstr(binop)
+                         << "' can lead to undefined behavior "
+                         << "(cast to unsigned to silence warning)";
+    }
+  }
+  if (lht.IsSigned() || rht.IsSigned()) {
+    return CreateInt64();
+  }
+
+  return CreateUInt64();
+}
+
+SizedType get_binop_type(Binop &binop,
+                         const SizedType &lht,
+                         const SizedType &rht)
+{
+  bool is_comparison = is_comparison_op(binop.op);
+
+  if (lht.IsNoneTy() || rht.IsNoneTy()) {
+    return CreateNone();
+  }
+
+  if (lht.IsBoolTy() && rht.IsBoolTy()) {
+    return CreateBool();
+  }
+
+  bool lsign = lht.IsSigned();
+  bool rsign = rht.IsSigned();
+  bool is_int_binop = (lht.IsCastableMapTy() || lht.IsIntTy() ||
+                       lht.IsBoolTy()) &&
+                      (rht.IsCastableMapTy() || rht.IsIntTy() ||
+                       rht.IsBoolTy());
+
+  bool is_signed = lsign || rsign;
+  switch (binop.op) {
+    case Operator::LEFT:
+    case Operator::RIGHT:
+      is_signed = lsign;
+      break;
+    default:
+      break;
+  }
+
+  if (lht.IsPtrTy() || rht.IsPtrTy()) {
+    return binop_ptr(binop, lht, rht);
+  }
+
+  auto result_type = is_comparison ? CreateBool()
+                                   : CreateInteger(64, is_signed);
+  auto addr_lhs = lht.GetAS();
+  auto addr_rhs = rht.GetAS();
+
+  // if lhs or rhs has different addrspace (not none), then set the
+  // addrspace to none. This preserves the behaviour for x86.
+  if (addr_lhs != addr_rhs && addr_lhs != AddrSpace::none &&
+      addr_rhs != AddrSpace::none) {
+    binop.addWarning() << "Addrspace mismatch";
+    result_type.SetAS(AddrSpace::none);
+  }
+  // Associativity from left to right for binary operator
+  else if (addr_lhs != AddrSpace::none) {
+    result_type.SetAS(addr_lhs);
+  } else {
+    // In case rhs is none, then this triggers warning in
+    // selectProbeReadHelper.
+    result_type.SetAS(addr_rhs);
+  }
+
+  if (is_int_binop) {
+    return binop_int(binop, lht, rht);
+  }
+
+  return result_type;
+}
+
+bool TypeGraph::check_offsetof_type(Offsetof &offof, SizedType cstruct)
+{
+  // Check if all sub-fields are present.
+  for (const auto &field : offof.field) {
+    if (!cstruct.IsCStructTy()) {
+      offof.addError() << "'" << cstruct << "' " << "is not a c_struct type.";
+      return false;
+    } else if (!bpftrace_.structs.Has(cstruct.GetName())) {
+      offof.addError() << "'" << cstruct.GetName() << "' does not exist.";
+      return false;
+    } else if (!cstruct.HasField(field)) {
+      offof.addError() << "'" << cstruct.GetName() << "' "
+                       << "has no field named " << "'" << field << "'";
+      return false;
+    } else {
+      // Get next sub-field
+      const auto &f = cstruct.GetField(field);
+      cstruct = f.type;
+    }
+  }
+  return true;
+}
+
+// These are special map aggregation types that cannot be assigned
+// to scratch variables and map values/keys:
+// @a = count();                  // OK
+// @a = 1; @b = count(); @a = @b; // OK
+// @a = 1; @b = hist(); @a = @b;  // NOK
+// @b = count(); @a = @b;         // NOK
+// @a = 1; @a = count();          // NOK
+// @a = count(); @a = 1;          // NOK
+// @a = count(); @a = sum(5);     // NOK
+bool is_valid_assignment(const SizedType &type,
+                         const SizedType &current_type,
+                         bool is_map_assignment = false)
+{
+  if (type.IsNoneTy() || type.IsVoidTy()) {
+    return false;
+  } else if (type.NeedsPercpuMap() && !type.IsCastableMapTy()) {
+    return false;
+  } else if (!current_type.IsIntegerTy() && type.IsCastableMapTy()) {
+    // Assigning to maps with no value type yet is not allowed (mostly to
+    // prevent user confusion)
+    // @b = count(); @a = @b;
+    // But assigning to scratch variables or map keys is OK
+    if (is_map_assignment) {
+      return false;
+    } else if (!current_type.IsNoneTy()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+void TypeGraph::visit(ArrayAccess &arr)
+{
+  visit(arr.expr);
+  visit(arr.indexpr);
+
+  graph_[&arr.expr.node()].emplace_back(
+      &arr, [&arr](SizedType type) -> SizedType {
+        SizedType elem;
+        if (type.IsArrayTy()) {
+          elem = type.GetElementTy();
+        } else if (type.IsPtrTy()) {
+          elem = type.GetPointeeTy();
+        } else if (type.IsStringTy()) {
+          elem = CreateInt8();
+        } else {
+          arr.addError() << "The array index operator [] can only be "
+                            "used on arrays and pointers, found "
+                         << type << ".";
+        }
+
+        elem.SetAS(type.GetAS());
+
+        // BPF verifier cannot track BTF information for double pointers so we
+        // cannot propagate is_internal for arrays of pointers and we need to
+        // reset it on the array type as well. Indexing a pointer as an array
+        // also can't be verified, so the same applies there.
+        if (elem.IsPtrTy() || type.IsPtrTy()) {
+          elem.is_internal = false;
+        } else {
+          elem.is_internal = type.is_internal;
+        }
+
+        return elem;
+      });
+}
+
+void TypeGraph::visit(AssignMapStatement &assignment)
+{
+  visit(assignment.map_access);
+  visit(assignment.expr);
+
+  auto map_name = assignment.map_access->map->ident;
+  auto value_name = get_map_value_name(map_name);
+  auto ptr_source = get_pointer_source(assignment.expr);
+
+  graph_[&assignment.expr.node()].emplace_back(
+      value_name,
+      [this, &assignment, map_name, ptr_source](SizedType type) -> SizedType {
+        auto value_name = get_map_value_name(map_name);
+        auto current_type = get_resolved_type(value_name);
+
+        if (!is_valid_assignment(type, current_type, true)) {
+          auto &err = assignment.addError();
+          auto hint = AGGREGATE_HINTS.find(type.GetTy());
+          if (hint != AGGREGATE_HINTS.end()) {
+            err << "Map value '" << type
+                << "' cannot be assigned from one map to another. "
+                   "The function that returns this type must be called "
+                   "directly "
+                   "e.g. "
+                   "`"
+                << assignment.map_access->map->ident << " = " << hint->second
+                << ";`.";
+            if (const auto *acc = assignment.expr.as<MapAccess>()) {
+              if (type.IsCastableMapTy()) {
+                err.addHint()
+                    << "Add a cast to integer if you want the value of the "
+                       "aggregate, "
+                    << "e.g. `" << assignment.map_access->map->ident
+                    << " = (int64)" << acc->map->ident << ";`.";
+              }
+            }
+          } else {
+            err << "Value '" << type << "' cannot be assigned to a map.";
+          }
+
+          return CreateNone();
+        }
+
+        return get_map_value(map_name, type, assignment, ptr_source);
+      });
+}
+
+void TypeGraph::visit(AssignVarStatement &assignment)
+{
+  visit(assignment.expr);
+  visit(assignment.var_decl);
+
+  Node *var_scope = find_variable_scope(assignment.var()->ident);
+  ScopedVariable scoped_var = std::make_pair(var_scope,
+                                             assignment.var()->ident);
+
+  if (decl_variables_.contains(scoped_var)) {
+    return;
+  }
+
+  auto ptr_source = get_pointer_source(assignment.expr);
+
+  graph_[&assignment.expr.node()].emplace_back(
+      scoped_var,
+      [this, &assignment, scoped_var, ptr_source](SizedType type) -> SizedType {
+        if (!is_valid_assignment(type, get_resolved_type(scoped_var))) {
+          assignment.addError()
+              << "Value '" << type
+              << "' cannot be assigned to a scratch variable.";
+          return CreateNone();
+        }
+
+        return get_variable_type(scoped_var, type, assignment, ptr_source);
+      });
+}
+
+void TypeGraph::visit(Builtin &builtin)
+{
+  SizedType builtin_type = CreateNone();
+  auto simple_it = SIMPLE_BUILTIN_TYPES.find(builtin.ident);
+  if (simple_it != SIMPLE_BUILTIN_TYPES.end()) {
+    builtin_type = simple_it->second();
+  } else if (builtin.ident == "ctx") {
+    auto *probe = get_probe(builtin, builtin.ident);
+    if (probe == nullptr)
+      return;
+    ProbeType pt = probetype(probe->attach_points[0]->provider);
+    bpf_prog_type bt = progtype(pt);
+    std::string func = probe->attach_points[0]->func;
+    builtin_type = CreatePointer(CreateNone());
+    switch (bt) {
+      case BPF_PROG_TYPE_KPROBE: {
+        auto record = bpftrace_.structs.Lookup("struct pt_regs");
+        if (!record.expired()) {
+          builtin_type = CreatePointer(CreateCStruct("struct pt_regs", record),
+                                       AddrSpace::kernel);
+          builtin_type.MarkCtxAccess();
+        }
+        break;
+      }
+      case BPF_PROG_TYPE_PERF_EVENT:
+        builtin_type = CreatePointer(
+            CreateCStruct("struct bpf_perf_event_data",
+                          bpftrace_.structs.Lookup(
+                              "struct bpf_perf_event_data")),
+            AddrSpace::kernel);
+        builtin_type.MarkCtxAccess();
+        break;
+      case BPF_PROG_TYPE_TRACING:
+        if (pt == ProbeType::iter) {
+          std::string type = "struct bpf_iter__" + func;
+          builtin_type = CreatePointer(
+              CreateCStruct(type, bpftrace_.structs.Lookup(type)),
+              AddrSpace::kernel);
+          builtin_type.MarkCtxAccess();
+        }
+        break;
+      default:
+        break;
+    }
+  } else if (builtin.ident == "__builtin_curtask") {
+    builtin_type = CreatePointer(CreateCStruct("struct task_struct",
+                                               bpftrace_.structs.Lookup(
+                                                   "struct task_struct")),
+                                 AddrSpace::kernel);
+  } else if (builtin.ident == "__builtin_retval") {
+    auto *probe = get_probe(builtin, builtin.ident);
+    if (probe == nullptr)
+      return;
+    ProbeType type = probe->get_probetype();
+    if (type == ProbeType::fentry || type == ProbeType::fexit) {
+      const auto *arg = bpftrace_.structs.GetProbeArg(*probe,
+                                                      RETVAL_FIELD_NAME);
+      if (arg) {
+        builtin_type = arg->type;
+      } else
+        builtin.addError() << "Can't find a field " << RETVAL_FIELD_NAME;
+    } else {
+      builtin_type = CreateUInt64();
+    }
+    builtin_type.SetAS(find_addrspace(type));
+  } else if (builtin.ident == "kstack") {
+    if (bpftrace_.config_->stack_mode == StackMode::build_id) {
+      builtin.addWarning() << "'build_id' stack mode can only be used for "
+                              "ustack. Falling back to 'raw' mode.";
+      builtin_type = CreateStack(true, StackType{ .mode = StackMode::raw });
+    } else {
+      builtin_type = CreateStack(
+          true, StackType{ .mode = bpftrace_.config_->stack_mode });
+    }
+  } else if (builtin.ident == "ustack") {
+    builtin_type = CreateStack(
+        false, StackType{ .mode = bpftrace_.config_->stack_mode });
+  } else if (builtin.ident == "__builtin_comm") {
+    constexpr int COMM_SIZE = 16;
+    builtin_type = CreateString(COMM_SIZE);
+    builtin_type.SetAS(AddrSpace::kernel);
+  } else if (builtin.ident == "__builtin_func") {
+    auto *probe = get_probe(builtin, builtin.ident);
+    if (probe == nullptr)
+      return;
+    ProbeType type = probe->get_probetype();
+    if (type == ProbeType::uprobe || type == ProbeType::uretprobe) {
+      builtin_type = CreateUSym();
+    } else {
+      builtin_type = CreateKSym();
+    }
+  } else if (builtin.is_argx()) {
+    auto *probe = get_probe(builtin, builtin.ident);
+    if (probe == nullptr)
+      return;
+    builtin_type = CreateUInt64();
+    builtin_type.SetAS(
+        find_addrspace(probetype(probe->attach_points[0]->provider)));
+  } else if (builtin.ident == "args") {
+    auto *probe = get_probe(builtin, builtin.ident);
+    if (probe == nullptr)
+      return;
+
+    ProbeType type = probe->get_probetype();
+    auto type_name = probe->args_typename();
+    if (!type_name) {
+      builtin.addError() << "Unable to resolve unique type name.";
+      return;
+    }
+
+    if (type == ProbeType::fentry || type == ProbeType::fexit ||
+        type == ProbeType::uprobe || type == ProbeType::rawtracepoint) {
+      builtin_type = CreateCStruct(*type_name,
+                                   bpftrace_.structs.Lookup(*type_name));
+      if (builtin_type.GetFieldCount() == 0)
+        builtin.addError() << "Cannot read function parameters";
+
+      builtin_type.MarkCtxAccess();
+      builtin_type.is_funcarg = true;
+      builtin_type.SetAS(type == ProbeType::uprobe ? AddrSpace::user
+                                                   : AddrSpace::kernel);
+      if (type == ProbeType::uprobe)
+        builtin_type.is_internal = true;
+    } else if (type == ProbeType::tracepoint) {
+      builtin_type = CreateCStruct(*type_name,
+                                   bpftrace_.structs.Lookup(*type_name));
+      builtin_type.SetAS(probe->attach_points.front()->target == "syscalls"
+                             ? AddrSpace::user
+                             : AddrSpace::kernel);
+      builtin_type.MarkCtxAccess();
+    }
+  } else {
+    LOG(BUG) << "Unknown builtin variable: '" << builtin.ident << "'";
+  }
+  add_resolved_type(&builtin, builtin_type);
+}
+
+void TypeGraph::visit(Call &call)
+{
+  // RAII setter for func_ context (used by Identifier resolution)
+  struct func_setter {
+    func_setter(TypeGraph &pass, const std::string &s)
+        : pass_(pass), old_func_(pass_.func_)
+    {
+      pass_.func_ = s;
+    }
+
+    ~func_setter()
+    {
+      pass_.func_ = old_func_;
+    }
+
+  private:
+    TypeGraph &pass_;
+    std::string old_func_;
+  };
+
+  func_setter scope_bound_func_setter{ *this, call.func };
+
+  // Visit children to wire up graph edges for arguments
+  for (auto &varg : call.vargs) {
+    visit(varg);
+  }
+
+  // These map aggregate functions are the only ones that can set the map value
+  // types to the corresponding aggregate types. For example `@a = count();`
+  // gets desuggared to `count(@a, 0)` However some of these aggregation types
+  // are castable to ints so this is ok:
+  // `@a = count(); @b = 1; @b = @a;` but the value type of `@b` remains an
+  // integer not `count_t`.
+  if (getAssignRewriteFuncs().contains(call.func)) {
+    if (auto *map = call.vargs.at(0).as<Map>()) {
+      auto map_name = map->ident;
+
+      if (call.func == "count" || call.func == "hist" || call.func == "lhist" ||
+          call.func == "tseries") {
+        graph_[&call].emplace_back(
+            get_map_value_name(map_name),
+            [this, &call, map_name](SizedType) -> SizedType {
+              SizedType agg_type;
+              if (call.func == "count") {
+                agg_type = CreateCount();
+              } else if (call.func == "hist") {
+                agg_type = CreateHist();
+              } else if (call.func == "lhist") {
+                agg_type = CreateLhist();
+              } else if (call.func == "tseries") {
+                agg_type = CreateTSeries();
+              }
+
+              return get_agg_map_value(map_name, agg_type, call);
+            });
+      } else {
+        // N.B. @a = sum(5); gets desugared to _ = sum(@x, 0, 5); so we have to
+        // set the consumer of this map aggregate function to be the map value
+        // name directly and also add the resolved call type in the callback
+        graph_[&call.vargs.at(2).node()].emplace_back(
+            get_map_value_name(map_name),
+            [this, &call, map_name](SizedType type) -> SizedType {
+              if (!type.IsIntegerTy()) {
+                call.addError()
+                    << call.func << "() only supports integer arguments ("
+                    << type << " provided)";
+                return CreateNone();
+              }
+
+              SizedType agg_type;
+              if (call.func == "avg") {
+                agg_type = CreateAvg(type.IsSigned());
+              } else if (call.func == "max") {
+                agg_type = CreateMax(type.IsSigned());
+              } else if (call.func == "min") {
+                agg_type = CreateMin(type.IsSigned());
+              } else if (call.func == "stats") {
+                agg_type = CreateStats(type.IsSigned());
+              } else if (call.func == "sum") {
+                agg_type = CreateSum(type.IsSigned());
+              }
+
+              // Check if the arguments passed are compatible with each other
+              auto found = agg_map_args_.find(map_name);
+              if (found == agg_map_args_.end()) {
+                agg_map_args_[map_name] = type;
+              } else {
+                auto promoted = get_promoted_type(found->second, type);
+                if (!promoted) {
+                  call.addError() << "Type mismatch for " << call.func << ": "
+                                  << "trying to call function with type '"
+                                  << type << "' when it already has a type '"
+                                  << found->second << "'";
+                  return CreateNone();
+                } else {
+                  found->second = *promoted;
+                }
+              }
+
+              return get_agg_map_value(map_name, agg_type, call);
+            });
+      }
+
+      // 2nd arg is the key
+      graph_[&call.vargs.at(1).node()].emplace_back(
+          get_map_key_name(map_name),
+          [this, &call, map_name](SizedType type) -> SizedType {
+            return get_map_key(map_name, type, call);
+          });
+
+      add_resolved_type(&call, CreateVoid());
+    } else {
+      call.vargs.at(0).node().addError()
+          << call.func << "() expects a map argument";
+    }
+  } else {
+    // Compute intrinsic return type
+    SizedType return_type = CreateNone();
+    if (VOID_RETURNING_FUNCS.contains(call.func)) {
+      return_type = CreateVoid();
+    } else if (auto it = SIMPLE_CALL_TYPES.find(call.func);
+               it != SIMPLE_CALL_TYPES.end()) {
+      return_type = it->second();
+    } else if (call.func == "str") {
+      auto strlen = bpftrace_.config_->max_strlen;
+      if (call.vargs.size() == 2) {
+        if (auto *integer = call.vargs.at(1).as<Integer>()) {
+          if (integer->value + 1 > strlen) {
+            call.addWarning() << "length param (" << integer->value
+                              << ") is too long and will be shortened to "
+                              << strlen << " bytes (see BPFTRACE_MAX_STRLEN)";
+          } else {
+            strlen = integer->value + 1;
+          }
+        }
+
+        if (auto *integer = dynamic_cast<NegativeInteger *>(
+                call.vargs.at(1).as<NegativeInteger>())) {
+          call.addError() << call.func << "cannot use negative length ("
+                          << integer->value << ")";
+        }
+      }
+      return_type = CreateString(strlen);
+      return_type.SetAS(AddrSpace::kernel);
+    } else if (call.func == "buf") {
+      const uint64_t max_strlen = bpftrace_.config_->max_strlen;
+      uint32_t max_buffer_size = max_strlen - sizeof(AsyncEvent::Buf);
+      uint32_t buffer_size = max_buffer_size;
+
+      if (call.vargs.size() == 1) {
+        graph_[&call.vargs.at(0).node()].emplace_back(
+            &call, [this, &call, max_buffer_size](SizedType type) -> SizedType {
+              uint32_t buffer_size = max_buffer_size;
+              if (type.IsArrayTy()) {
+                buffer_size = type.GetNumElements() *
+                              type.GetElementTy().GetSize();
+              }
+              buffer_size = std::min(buffer_size, max_buffer_size);
+
+              auto return_type = CreateBuffer(buffer_size);
+              return_type.SetAS(AddrSpace::kernel);
+              return return_type;
+            });
+        return;
+      } else if (call.vargs.size() == 2) {
+        if (auto *integer = call.vargs.at(1).as<Integer>()) {
+          buffer_size = integer->value;
+        }
+      }
+
+      buffer_size = std::min(buffer_size, max_buffer_size);
+
+      return_type = CreateBuffer(buffer_size);
+      return_type.SetAS(AddrSpace::kernel);
+    } else if (call.func == "ntop") {
+      int buffer_size = 24;
+      return_type = CreateInet(buffer_size);
+    } else if (call.func == "pton") {
+      int af_type = 0, addr_size = 0;
+      std::string addr;
+      if (call.vargs.size() == 1) {
+        if (auto *str = call.vargs.at(0).as<String>()) {
+          addr = str->value;
+          if (addr.find(".") != std::string::npos) {
+            af_type = AF_INET;
+            addr_size = 4;
+          } else if (addr.find(":") != std::string::npos) {
+            af_type = AF_INET6;
+            addr_size = 16;
+          } else {
+            call.addError()
+                << call.func
+                << "() expects an string argument of an IPv4/IPv6 address, got "
+                << addr;
+            return;
+          }
+        } else {
+          call.addError()
+              << call.func
+              << "() expects an string literal at the first argument";
+          return;
+        }
+      }
+
+      std::vector<char> dst(addr_size);
+      auto ret = inet_pton(af_type, addr.c_str(), dst.data());
+      if (ret != 1) {
+        call.addError() << call.func
+                        << "() expects a valid IPv4/IPv6 address, got " << addr;
+        return;
+      }
+
+      return_type = CreateArray(addr_size, CreateUInt8());
+      return_type.SetAS(AddrSpace::kernel);
+      return_type.is_internal = true;
+    } else if (call.func == "reg") {
+      return_type = CreateUInt64();
+      if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
+        ProbeType pt = probe->get_probetype();
+        return_type.SetAS(find_addrspace(pt));
+      } else {
+        return_type.SetAS(AddrSpace::kernel);
+      }
+    } else if (call.func == "kaddr") {
+      return_type = CreateUInt64();
+      return_type.SetAS(AddrSpace::kernel);
+    } else if (call.func == "percpu_kaddr") {
+      return_type = CreateUInt64();
+      return_type.SetAS(AddrSpace::kernel);
+    } else if (call.func == "__builtin_uaddr") {
+      auto *probe = get_probe(call, call.func);
+      if (probe == nullptr)
+        return;
+
+      struct symbol sym = {};
+
+      if (!call.vargs.empty() && call.vargs.at(0).is<String>()) {
+        auto name = call.vargs.at(0).as<String>()->value;
+        const auto &target = probe->attach_points[0]->target;
+
+        int err = bpftrace_.resolve_uname(name, &sym, target);
+        if (err < 0 || sym.address == 0) {
+          call.addError() << "Could not resolve symbol: " << target << ":"
+                          << name;
+        }
+      }
+
+      size_t pointee_size = 0;
+      switch (sym.size) {
+        case 1:
+        case 2:
+        case 4:
+          pointee_size = sym.size * 8;
+          break;
+        default:
+          pointee_size = 64;
+      }
+
+      return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
+    } else if (call.func == "kstack") {
+      check_stack_call(call, true);
+      return_type = call.return_type;
+    } else if (call.func == "ustack") {
+      check_stack_call(call, false);
+      return_type = call.return_type;
+    } else if (call.func == "path") {
+      auto call_type_size = bpftrace_.config_->max_strlen;
+      if (call.vargs.size() == 2) {
+        if (auto *size = call.vargs.at(1).as<Integer>()) {
+          call_type_size = size->value;
+        }
+      }
+      return_type = SizedType(Type::string, call_type_size);
+    } else if (call.func == "kptr" || call.func == "uptr") {
+      graph_[&call.vargs.at(0).node()].emplace_back(
+          &call, [this, &call](SizedType type) -> SizedType {
+            type.SetAS(call.func == "kptr" ? AddrSpace::kernel
+                                           : AddrSpace::user);
+            return type;
+          });
+      return;
+    } else if (call.func == "bswap") {
+      graph_[&call.vargs.at(0).node()].emplace_back(
+          &call, [this, &call](SizedType type) -> SizedType {
+            auto int_bit_width = 1;
+            if (!type.IsIntTy()) {
+              call.addError()
+                  << call.func << "() only supports integer arguments ("
+                  << type.GetTy() << " provided)";
+              return CreateNone();
+            }
+            int_bit_width = type.GetIntBitWidth();
+            return CreateUInt(int_bit_width);
+          });
+      return;
+    } else if (call.func == "nsecs") {
+      if (call.vargs.size() == 1) {
+        graph_[&call.vargs.at(0).node()].emplace_back(
+            &call, [this, &call](SizedType type) -> SizedType {
+              auto ret_type = CreateUInt64();
+              ret_type.ts_mode = type.ts_mode;
+              return ret_type;
+            });
+        return;
+      } else {
+        return_type = CreateUInt64();
+        return_type.ts_mode = TimestampMode::boot;
+      }
+    } else if (auto bit = SIMPLE_BUILTIN_TYPES.find(call.func);
+               bit != SIMPLE_BUILTIN_TYPES.end()) {
+      return_type = bit->second();
+    }
+
+    if (!return_type.IsNoneTy()) {
+      add_resolved_type(&call, return_type);
+    } else {
+      // BTF function lookup
+      auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
+      if (!maybe_func) {
+        call.addError() << "Unknown function: '" << call.func << "'";
+        return;
+      }
+
+      const auto &func = *maybe_func;
+
+      if (func.linkage() != btf::Function::Linkage::Global &&
+          func.linkage() != btf::Function::Linkage::Extern) {
+        call.addError() << "Unsupported function linkage: '" << call.func
+                        << "'";
+        return;
+      }
+
+      auto proto = func.type();
+      if (!proto) {
+        call.addError() << "Unable to find function proto: "
+                        << proto.takeError();
+        return;
+      }
+      // Extract our return type.
+      auto btf_return_type = proto->return_type();
+      if (!btf_return_type) {
+        call.addError() << "Unable to read return type: "
+                        << btf_return_type.takeError();
+        return;
+      }
+      auto compat_return_type = getCompatType(*btf_return_type);
+      if (!compat_return_type) {
+        call.addError() << "Unable to convert return type: "
+                        << compat_return_type.takeError();
+        return;
+      }
+      add_resolved_type(&call, *compat_return_type);
+    }
+  }
+}
+
+void TypeGraph::visit(Binop &op)
+{
+  visit(op.left);
+  visit(op.right);
+
+  graph_[&op.left.node()].emplace_back(&op,
+                                       [&op, this](SizedType lht) -> SizedType {
+                                         auto rht = get_resolved_type(
+                                             &op.right.node());
+                                         return get_binop_type(op, lht, rht);
+                                       });
+
+  graph_[&op.right.node()].emplace_back(
+      &op, [&op, this](SizedType rht) -> SizedType {
+        auto lht = get_resolved_type(&op.left.node());
+        return get_binop_type(op, lht, rht);
+      });
+}
+
+void TypeGraph::visit(BlockExpr &block)
+{
+  scope_stack_.push_back(&block);
+  visit(block.stmts);
+  visit(block.expr);
+
+  add_consumer(&block.expr.node(), &block);
+  scope_stack_.pop_back();
+}
+
+void TypeGraph::visit(Boolean &boolean)
+{
+  add_resolved_type(&boolean, boolean.type());
+}
+
+SizedType update_cast_expr(const SizedType &cast_ty,
+                           const SizedType &expr_ty,
+                           Probe *probe)
+{
+  auto updated_ty = cast_ty;
+  if (updated_ty.IsArrayTy()) {
+    if (updated_ty.GetNumElements() == 0) {
+      if (updated_ty.GetElementTy().GetSize() != 0) {
+        if (expr_ty.GetSize() % updated_ty.GetElementTy().GetSize() == 0) {
+          // casts to unsized arrays (e.g. int8[]) need to determine size from
+          // RHS
+          auto num_elems = expr_ty.GetSize() /
+                           updated_ty.GetElementTy().GetSize();
+          updated_ty = CreateArray(num_elems, updated_ty.GetElementTy());
+        }
+      }
+    }
+
+    if (expr_ty.IsIntTy() || expr_ty.IsBoolTy())
+      updated_ty.is_internal = true;
+  }
+
+  if (expr_ty.IsCtxAccess() && !updated_ty.IsIntTy()) {
+    updated_ty.MarkCtxAccess();
+  }
+  updated_ty.SetAS(expr_ty.GetAS());
+  // case : begin { @foo = (struct Foo)0; }
+  // case : profile:hz:99 $task = (struct task_struct *)curtask.
+  if (updated_ty.GetAS() == AddrSpace::none) {
+    if (probe) {
+      ProbeType type = probe->get_probetype();
+      updated_ty.SetAS(find_addrspace(type));
+    } else {
+      // Assume kernel space for data in subprogs.
+      updated_ty.SetAS(AddrSpace::kernel);
+    }
+  }
+  return updated_ty;
+}
+
+void TypeGraph::visit(Cast &cast)
+{
+  visit(cast.expr);
+
+  // Account for the race condition whereby the expression type may resolve
+  // before the cast type even though they both need resolution to determine the
+  // final cast type, e.g. `@ = (int8[])"hello"`
+  graph_[&cast.expr.node()].emplace_back(
+      &cast, [this, &cast](SizedType expr_ty) -> SizedType {
+        auto cast_ty = get_resolved_type(&cast);
+        if (cast_ty.IsNoneTy()) {
+          return CreateNone();
+        }
+        return update_cast_expr(cast_ty,
+                                expr_ty,
+                                dynamic_cast<Probe *>(top_level_node_));
+      });
+
+  if (std::holds_alternative<SizedType>(cast.typeof->record)) {
+    auto &ty = std::get<SizedType>(cast.typeof->record);
+    if (!resolve_struct_type(ty, *cast.typeof)) {
+      return;
+    }
+    add_resolved_type(&cast, ty);
+  } else {
+    visit(cast.typeof);
+    graph_[cast.typeof].emplace_back(
+        &cast, [this, &cast](SizedType cast_ty) -> SizedType {
+          auto expr_ty = get_resolved_type(&cast.expr.node());
+
+          if (!expr_ty.IsNoneTy()) {
+            return update_cast_expr(cast_ty,
+                                    expr_ty,
+                                    dynamic_cast<Probe *>(top_level_node_));
+          }
+          return cast_ty;
+        });
+  }
+}
+
+void TypeGraph::visit(Comptime &comptime)
+{
+  visit(comptime.expr);
+  unresolved_comptimes_.emplace_back(&comptime);
+}
+
+void TypeGraph::visit(ExprStatement &expr)
+{
+  visit(expr.expr);
+}
+
+void TypeGraph::visit(FieldAccess &acc)
+{
+  visit(acc.expr);
+
+  graph_[&acc.expr.node()].emplace_back(
+      &acc, [this, &acc](SizedType expr_type) -> SizedType {
+        // FieldAccesses will automatically resolve through any number of
+        // pointer dereferences. For now, we inject the `Unop` operator
+        // directly, as codegen stores the underlying structs as pointers
+        // anyways. In the future, we will likely want to do this in a different
+        // way if we are tracking l-values.
+        bool is_ctx = expr_type.IsCtxAccess();
+        bool is_internal = expr_type.is_internal;
+        while (expr_type.IsPtrTy()) {
+          expr_type = expr_type.GetPointeeTy();
+        }
+
+        SizedType result_type = CreateNone();
+
+        if (!expr_type.IsCStructTy() && !expr_type.IsRecordTy()) {
+          acc.addError() << "Can not access field '" << acc.field
+                         << "' on expression of type '" << expr_type << "'";
+          return CreateNone();
+        }
+
+        if (expr_type.is_funcarg) {
+          auto *probe = get_probe();
+          if (probe == nullptr) {
+            return CreateNone();
+          }
+          const auto *arg = bpftrace_.structs.GetProbeArg(*probe, acc.field);
+          if (arg) {
+            result_type = arg->type;
+            result_type.SetAS(expr_type.GetAS());
+
+            if (result_type.IsNoneTy()) {
+              acc.addError() << acc.field << " has unsupported type";
+            }
+          } else {
+            acc.addError() << "Can't find function parameter " << acc.field;
+          }
+          return result_type;
+        }
+
+        if (!expr_type.IsRecordTy() &&
+            !bpftrace_.structs.Has(expr_type.GetName())) {
+          acc.addError() << "Unknown struct/union: '" << expr_type.GetName()
+                         << "'";
+          return CreateNone();
+        }
+
+        const auto &record = expr_type.GetStruct();
+
+        if (!record->HasField(acc.field)) {
+          if (expr_type.IsRecordTy()) {
+            acc.addError() << "Record does not contain " << "a field named '"
+                           << acc.field << "'";
+          } else {
+            acc.addError() << "Struct/union of type '" << expr_type.GetName()
+                           << "' does not contain " << "a field named '"
+                           << acc.field << "'";
+          }
+          return CreateNone();
+        } else {
+          const auto &field = record->GetField(acc.field);
+
+          if (field.type.IsPtrTy()) {
+            const auto &tags = field.type.GetBtfTypeTags();
+            // Currently only "rcu" is safe. "percpu", for example, requires
+            // special unwrapping with `bpf_per_cpu_ptr` which is not yet
+            // supported.
+            static const std::string_view allowed_tag = "rcu";
+            for (const auto &tag : tags) {
+              if (tag != allowed_tag) {
+                acc.addError()
+                    << "Attempting to access pointer field '" << acc.field
+                    << "' with unsupported tag attribute: " << tag;
+              }
+            }
+          }
+
+          result_type = field.type;
+          if (is_ctx &&
+              (result_type.IsArrayTy() || result_type.IsCStructTy())) {
+            // e.g., ((struct bpf_perf_event_data*)ctx)->regs.ax
+            result_type.MarkCtxAccess();
+          }
+          result_type.is_internal = is_internal;
+          result_type.SetAS(expr_type.GetAS());
+
+          return result_type;
+        }
+      });
+}
+
+SizedType get_range_type(const SizedType &start_type,
+                         const SizedType &end_type,
+                         Range *range)
+{
+  if (start_type.IsNoneTy() || end_type.IsNoneTy()) {
+    return CreateNone();
+  }
+
+  if (!start_type.IsIntTy()) {
+    range->addError() << "Loop range requires an integer for the start value";
+  }
+  if (!end_type.IsIntTy()) {
+    range->addError() << "Loop range requires an integer for the end value";
+  }
+
+  auto range_type = start_type;
+  if (start_type.IsIntTy() && end_type.IsIntTy()) {
+    if (start_type.GetSize() > end_type.GetSize() ||
+        start_type.GetSize() < end_type.GetSize()) {
+      auto promoted = get_promoted_type(start_type, end_type);
+      if (promoted) {
+        range_type = *promoted;
+      }
+    }
+  }
+
+  return range_type;
+}
+
+void TypeGraph::visit(For &f)
+{
+  if (auto *map = f.iterable.as<Map>()) {
+    if (map_metadata_.bad_iterator.contains(map)) {
+      map->addError() << map->ident
+                      << " has no explicit keys (scalar map), and "
+                         "cannot be used for iteration";
+    }
+  }
+
+  const auto &decl_name = f.decl->ident;
+
+  // Collect a list of unique variables which are referenced in the loop's
+  // body and declared before the loop. These will be passed into the loop
+  // callback function as the context parameter.
+  std::unordered_set<std::string> found_vars;
+  auto [iter, _] = for_vars_referenced_.try_emplace(&f);
+  auto &collector = iter->second;
+  collector.visit(f.block, [this, &found_vars, &decl_name](const auto &var) {
+    if (found_vars.contains(var.ident) || var.ident == decl_name)
+      return false;
+
+    Node *scope = find_variable_scope(var.ident, false);
+    if (scope && variables_[scope].contains(var.ident)) {
+      found_vars.insert(var.ident);
+      return true;
+    }
+
+    return false;
+  });
+
+  visit(f.decl);
+
+  ScopedVariable scoped_var = std::make_pair(scope_stack_.back(), decl_name);
+
+  if (auto *map = f.iterable.as<Map>()) {
+    visit(map);
+    auto key_name = get_map_key_name(map->ident);
+    auto value_name = get_map_value_name(map->ident);
+    graph_[map].emplace_back(
+        scoped_var,
+        [&f, map, key_name, value_name, scoped_var, this](
+            SizedType) -> SizedType {
+          auto key_type = get_resolved_type(key_name);
+          auto value_type = get_resolved_type(value_name);
+          if (key_type.IsNoneTy() || value_type.IsNoneTy()) {
+            return CreateNone();
+          }
+          if (!value_type.IsMapIterableTy()) {
+            map->addError()
+                << "Loop expression does not support type: " << value_type;
+          }
+          auto tuple_type = CreateTuple(
+              Struct::CreateTuple({ key_type, value_type }));
+
+          auto current_var_type = get_resolved_type(scoped_var);
+          if (tuple_type == current_var_type) {
+            // This prevents an infinite loop - example:
+            // @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0] = 2; }
+            return CreateNone();
+          }
+
+          return tuple_type;
+        });
+
+  } else if (auto *range = f.iterable.as<Range>()) {
+    visit(range->start);
+    visit(range->end);
+    graph_[&range->start.node()].emplace_back(
+        scoped_var, [range, this](SizedType) -> SizedType {
+          auto start_type = get_resolved_type(&range->start.node());
+          auto end_type = get_resolved_type(&range->end.node());
+
+          return get_range_type(start_type, end_type, range);
+        });
+    graph_[&range->end.node()].emplace_back(
+        scoped_var, [range, this](SizedType) -> SizedType {
+          auto start_type = get_resolved_type(&range->start.node());
+          auto end_type = get_resolved_type(&range->end.node());
+
+          return get_range_type(start_type, end_type, range);
+        });
+  }
+
+  scope_stack_.push_back(&f);
+
+  visit(f.block);
+
+  scope_stack_.pop_back();
+
+  for (Variable &var : collector.nodes()) {
+    graph_[&var].emplace_back(&f, [this, &f](SizedType type) -> SizedType {
+      if (type.IsNoneTy()) {
+        return CreateNone();
+      }
+      // Finally, create the context tuple now that all variables
+      // inside the loop have been resolved.
+      std::vector<SizedType> ctx_types;
+      std::vector<std::string_view> ctx_idents;
+      auto [iter, _] = for_vars_referenced_.try_emplace(&f);
+      auto &collector = iter->second;
+      for (const Variable &var : collector.nodes()) {
+        auto var_type = get_resolved_type(
+            const_cast<Node *>(static_cast<const Node *>(&var)));
+        ctx_types.push_back(CreatePointer(var_type, AddrSpace::none));
+        ctx_idents.push_back(var.ident);
+      }
+
+      f.ctx_type = CreateCStruct(Struct::CreateRecord(ctx_types, ctx_idents));
+      // Nothing should be dependent upon this for loop
+      return CreateNone();
+    });
+  }
+
+  // Create an empty ctx struct in case there are no referenced vars in the loop
+  // body
+  std::vector<SizedType> ctx_types;
+  std::vector<std::string_view> ctx_idents;
+  f.ctx_type = CreateCStruct(Struct::CreateRecord(ctx_types, ctx_idents));
+}
+
+void TypeGraph::visit(Identifier &identifier)
+{
+  SizedType ident_type = CreateNone();
+  if (c_definitions_.enums.contains(identifier.ident)) {
+    const auto &enum_name = std::get<1>(c_definitions_.enums[identifier.ident]);
+    ident_type = CreateEnum(64, enum_name);
+  } else if (bpftrace_.structs.Has(identifier.ident)) {
+    ident_type = CreateCStruct(identifier.ident,
+                               bpftrace_.structs.Lookup(identifier.ident));
+  } else if (func_ == "nsecs") {
+    ident_type = CreateTimestampMode();
+    if (identifier.ident == "monotonic") {
+      ident_type.ts_mode = TimestampMode::monotonic;
+    } else if (identifier.ident == "boot") {
+      ident_type.ts_mode = TimestampMode::boot;
+    } else if (identifier.ident == "tai") {
+      ident_type.ts_mode = TimestampMode::tai;
+    } else if (identifier.ident == "sw_tai") {
+      ident_type.ts_mode = TimestampMode::sw_tai;
+    } else {
+      identifier.addError() << "Invalid timestamp mode: " << identifier.ident;
+    }
+  } else {
+    ConfigParser<StackMode> parser;
+    StackMode mode;
+    auto ok = parser.parse(func_, &mode, identifier.ident);
+    if (ok) {
+      ident_type = CreateStack(true, StackType{ .mode = mode });
+    }
+  }
+
+  if (ident_type.IsNoneTy() && introspection_level_ > 0) {
+    ident_type = bpftrace_.btf_->get_stype(identifier.ident);
+  }
+
+  add_resolved_type(&identifier, ident_type);
+}
+
+void TypeGraph::visit(IfExpr &if_expr)
+{
+  if (auto *comptime = if_expr.cond.as<Comptime>()) {
+    visit(comptime->expr);
+    unresolved_comptimes_.emplace_back(comptime);
+    return; // Skip visiting this `if` for now.
+  }
+
+  visit(if_expr.cond);
+  visit(if_expr.left);
+  visit(if_expr.right);
+
+  graph_[&if_expr.left.node()].emplace_back(
+      &if_expr, [&if_expr, this](SizedType left_type) -> SizedType {
+        auto current = get_resolved_type(&if_expr);
+        auto promoted = get_promoted_type(current, left_type);
+        if (!promoted) {
+          if_expr.addError()
+              << "Branches must return the same type or compatible types: "
+              << "have '" << left_type << "' and '" << current << "'";
+          return CreateNone();
+        }
+        return *promoted;
+      });
+
+  graph_[&if_expr.right.node()].emplace_back(
+      &if_expr, [&if_expr, this](SizedType right_type) -> SizedType {
+        auto current = get_resolved_type(&if_expr);
+        auto promoted = get_promoted_type(current, right_type);
+        if (!promoted) {
+          if_expr.addError()
+              << "Branches must return the same type or compatible types: "
+              << "have '" << current << "' and '" << right_type << "'";
+          return CreateNone();
+        }
+        return *promoted;
+      });
+}
+
+void TypeGraph::visit(Integer &integer)
+{
+  add_resolved_type(&integer, integer.type());
+}
+
+void TypeGraph::visit(Jump &jump)
+{
+  if (jump.ident == JumpType::RETURN) {
+    visit(jump.return_value);
+  }
+}
+
+void TypeGraph::visit(Map &map)
+{
+  if (map_metadata_.bad_indexed_access.contains(&map)) {
+    map.addError()
+        << map.ident
+        << " used as a map without an explicit key (scalar map), previously "
+           "used with an explicit key (non-scalar map)";
+    return;
+  }
+
+  auto key_name = get_map_key_name(map.ident);
+  auto value_name = get_map_value_name(map.ident);
+
+  graph_[key_name].emplace_back(&map, [](SizedType key_type) -> SizedType {
+    return key_type;
+  });
+
+  graph_[value_name].emplace_back(&map, [](SizedType value_type) -> SizedType {
+    return value_type;
+  });
+
+  if (introspection_level_ > 0) {
+    introspected_nodes_.insert(map.ident);
+  }
+}
+
+void TypeGraph::visit(MapAccess &acc)
+{
+  visit(acc.map);
+  visit(acc.key);
+
+  if (map_metadata_.bad_scalar_access.contains(acc.map)) {
+    acc.addError() << acc.map->ident
+                   << " used as a map with an explicit key (non-scalar map), "
+                      "previously used without an explicit key (scalar map)";
+    return;
+  }
+
+  auto key_name = get_map_key_name(acc.map->ident);
+  auto ptr_source = get_pointer_source(acc.key);
+
+  graph_[&acc.key.node()].emplace_back(
+      key_name,
+      [this, &acc, key_name, ptr_source](SizedType type) -> SizedType {
+        if (!is_valid_assignment(type, get_resolved_type(key_name))) {
+          acc.addError() << "Value '" << type
+                         << "' cannot be used as a map key.";
+          return CreateNone();
+        }
+
+        return get_map_key(acc.map->ident, type, acc, ptr_source);
+      });
+
+  add_consumer(get_map_value_name(acc.map->ident), &acc);
+}
+
+void TypeGraph::visit(MapAddr &map_addr)
+{
+  visit(map_addr.map);
+
+  // This needs to be fixed as neither the map value or map key are the actual
+  // map's type
+  graph_[get_map_value_name(map_addr.map->ident)].emplace_back(
+      &map_addr, [](SizedType type) -> SizedType {
+        return CreatePointer(type, type.GetAS());
+      });
+}
+
+void TypeGraph::visit(NegativeInteger &integer)
+{
+  add_resolved_type(&integer, integer.type());
+}
+
+void TypeGraph::visit(Offsetof &offof)
+{
+  // This type will change later depending on what integer literal it resolves
+  // to for now set it to the smallest uint
+  if (std::holds_alternative<SizedType>(offof.record)) {
+    auto &ty = std::get<SizedType>(offof.record);
+    resolve_struct_type(ty, offof);
+    if (!check_offsetof_type(offof, ty)) {
+      return;
+    }
+    add_resolved_type(&offof, CreateUInt8());
+  } else {
+    auto &expr = std::get<Expression>(offof.record);
+    visit(expr);
+    if (auto *ident = expr.as<Identifier>()) {
+      if (ident->type().IsNoneTy()) {
+        offof.addError() << "'" << ident->ident << "' "
+                         << "is not a c_struct type.";
+        return;
+      }
+    }
+    graph_[&expr.node()].emplace_back(
+        &offof, [this, &offof](SizedType type) -> SizedType {
+          resolve_struct_type(type, offof);
+          if (!check_offsetof_type(offof, type)) {
+            return CreateNone();
+          }
+          return CreateUInt8();
+        });
+  }
+}
+
+void TypeGraph::visit(Probe &probe)
+{
+  top_level_node_ = &probe;
+  visit(probe.attach_points);
+  visit(probe.block);
+}
+
+void TypeGraph::visit(Record &record)
+{
+  for (auto *named_arg : record.elems) {
+    auto &elem = named_arg->expr;
+    visit(elem);
+
+    graph_[&elem.node()].emplace_back(
+        &record, [&record, this](SizedType) -> SizedType {
+          std::vector<SizedType> elements;
+          std::vector<std::string_view> names;
+          for (auto *named_arg : record.elems) {
+            auto &elem = named_arg->expr;
+            auto elem_type = get_resolved_type(&elem.node());
+            if (elem_type.IsNoneTy()) {
+              return CreateNone();
+            }
+            elements.emplace_back(elem_type);
+            names.emplace_back(named_arg->name);
+          }
+          return CreateRecord(Struct::CreateRecord(elements, names));
+        });
+  }
+}
+
+void TypeGraph::visit(Sizeof &szof)
+{
+  if (std::holds_alternative<SizedType>(szof.record)) {
+    auto &ty = std::get<SizedType>(szof.record);
+    resolve_struct_type(ty, szof);
+    add_resolved_type(&szof, ty);
+  } else {
+    auto &expr = std::get<Expression>(szof.record);
+    visit(expr);
+    graph_[&expr.node()].emplace_back(&szof, [&szof](SizedType) -> SizedType {
+      // This will change later depending on what integer literal it resolves to
+      // for now set it to the smallest uint
+      return CreateUInt8();
+    });
+  }
+}
+
+void TypeGraph::visit(String &str)
+{
+  add_resolved_type(&str, str.type());
+}
+
+void TypeGraph::visit(Subprog &subprog)
+{
+  // Note that we visit the subprogram and process arguments *after*
+  // constructing the stack with the variable states. This is because the
+  // arguments, etc. may have types defined in terms of the arguments
+  // themselves. We already handle detecting circular dependencies.
+  scope_stack_.push_back(&subprog);
+  top_level_node_ = &subprog;
+
+  for (SubprogArg *arg : subprog.args) {
+    ScopedVariable scoped_var = std::make_pair(&subprog, arg->var->ident);
+
+    if (std::holds_alternative<SizedType>(arg->typeof->record)) {
+      auto &ty = std::get<SizedType>(arg->typeof->record);
+      if (resolve_struct_type(ty, *arg->typeof)) {
+        add_resolved_type(scoped_var, ty);
+        if (ty.GetSize() != 0) {
+          decl_variables_.insert(scoped_var);
+        }
+      }
+    } else {
+      decl_variables_.insert(scoped_var);
+      visit(arg->typeof);
+      graph_[arg->typeof].emplace_back(
+          scoped_var, [](SizedType type) -> SizedType { return type; });
+    }
+
+    visit(arg->var);
+  }
+
+  visit(subprog.block);
+  visit(subprog.return_type);
+
+  scope_stack_.pop_back();
+}
+
+void TypeGraph::visit(Typeof &typeof)
+{
+  if (std::holds_alternative<SizedType>(typeof.record)) {
+    auto &ty = std::get<SizedType>(typeof.record);
+    resolve_struct_type(ty, typeof);
+    add_resolved_type(&typeof, ty);
+  } else {
+    auto &expr = std::get<Expression>(typeof.record);
+    visit(expr);
+
+    if (auto *ident = expr.as<Identifier>()) {
+      auto stype = bpftrace_.btf_->get_stype(ident->ident);
+      add_resolved_type(&typeof, stype);
+    } else if (auto *map = expr.as<Map>()) {
+      // Typeof for a raw (scalar) map returns the key type.
+      // Subscribe directly to the map's key name to avoid getting the
+      // value type (both propagate through the Map node).
+      add_consumer(get_map_key_name(map->ident), &typeof);
+    } else {
+      add_consumer(&expr.node(), &typeof);
+    }
+  }
+}
+
+void TypeGraph::visit(Tuple &tuple)
+{
+  for (auto &elem : tuple.elems) {
+    visit(elem);
+
+    graph_[&elem.node()].emplace_back(
+        &tuple, [&tuple, this](SizedType) -> SizedType {
+          std::vector<SizedType> elements;
+          for (auto &elem : tuple.elems) {
+            auto elem_type = get_resolved_type(&elem.node());
+            if (elem_type.IsNoneTy()) {
+              return CreateNone();
+            }
+            elements.emplace_back(elem_type);
+          }
+          return CreateTuple(Struct::CreateTuple(elements));
+        });
+  }
+}
+
+void TypeGraph::visit(TupleAccess &acc)
+{
+  visit(acc.expr);
+
+  graph_[&acc.expr.node()].emplace_back(&acc,
+                                        [&acc](SizedType type) -> SizedType {
+                                          if (!type.IsTupleTy()) {
+                                            return CreateNone();
+                                          }
+
+                                          if (acc.index >=
+                                              type.GetFields().size()) {
+                                            return CreateNone();
+                                          }
+
+                                          return type.GetField(acc.index).type;
+                                        });
+}
+
+void TypeGraph::visit(Typeinfo &typeinfo)
+{
+  ++introspection_level_;
+  visit(typeinfo.typeof);
+  --introspection_level_;
+  graph_[typeinfo.typeof].emplace_back(
+      &typeinfo, [](SizedType type) -> SizedType {
+        auto base_ty_str = to_string(type.GetTy());
+        auto full_ty_str = typestr(type);
+        std::vector<SizedType> elements = {
+          CreateUInt64(),
+          CreateString(base_ty_str.size() + 1),
+          CreateString(full_ty_str.size() + 1)
+        };
+        std::vector<std::string_view> names = { "btf_id",
+                                                "base_type",
+                                                "full_type" };
+        return CreateRecord(Struct::CreateRecord(elements, names));
+      });
+}
+
+void TypeGraph::visit(Unop &unop)
+{
+  visit(unop.expr);
+
+  bool is_inc_dec_op = false;
+
+  switch (unop.op) {
+    case Operator::PRE_INCREMENT:
+    case Operator::PRE_DECREMENT:
+    case Operator::POST_INCREMENT:
+    case Operator::POST_DECREMENT:
+      is_inc_dec_op = true;
+      break;
+    default:;
+  }
+
+  // Unops are special in that they can be both assignments and expressions. If
+  // we're dealing with a map access or variable then treat these like
+  // assignments and resolved_types whereby we resolve the type of unop
+  // expression and creates a chain that attemps to assign this integer type to
+  // the stored map value or variable. This enables us to get error messages on
+  // the correct node if we attempt to increment a string or some other invalid
+  // type.
+  if (is_inc_dec_op) {
+    if (auto *acc = unop.expr.as<MapAccess>()) {
+      auto map_name = acc->map->ident;
+      auto map_value_name = get_map_value_name(map_name);
+
+      add_resolved_type(&unop, CreateInt64());
+      graph_[&unop].emplace_back(
+          map_value_name, [this, &unop, map_name](SizedType type) -> SizedType {
+            auto current_type = get_resolved_type(get_map_value_name(map_name));
+            if (current_type.IsPtrTy()) {
+              return current_type;
+            }
+            return get_map_value(map_name, type, unop);
+          });
+
+      return;
+    } else if (auto *var = unop.expr.as<Variable>()) {
+      Node *scope = find_variable_scope(var->ident);
+      ScopedVariable scoped_var = std::make_pair(scope, var->ident);
+
+      add_resolved_type(&unop, CreateInt64());
+      graph_[&unop].emplace_back(
+          scoped_var, [this, &unop, scoped_var](SizedType type) -> SizedType {
+            if (decl_variables_.contains(scoped_var)) {
+              return CreateNone();
+            }
+
+            auto current_type = get_resolved_type(scoped_var);
+            if (current_type.IsPtrTy()) {
+              return current_type;
+            }
+
+            return get_variable_type(scoped_var, type, unop);
+          });
+
+      return;
+    }
+
+    unop.addError() << "The " << opstr(unop)
+                    << " operator must be applied to a map or variable";
+    return;
+  }
+
+  auto valid_ptr_op = is_inc_dec_op || unop.op == Operator::MUL;
+
+  graph_[&unop.expr.node()].emplace_back(
+      &unop, [&unop, valid_ptr_op](SizedType type) -> SizedType {
+        bool invalid = false;
+        // Unops are only allowed on ints (e.g. ~$x), dereference only on
+        // pointers and context (we allow args->field for backwards
+        // compatibility)
+        if (type.IsBoolTy()) {
+          invalid = unop.op != Operator::LNOT;
+        } else if (!type.IsIntegerTy() &&
+                   !((type.IsPtrTy() || type.IsCtxAccess()) && valid_ptr_op)) {
+          invalid = true;
+        }
+        if (invalid) {
+          unop.addError()
+              << "The " << opstr(unop)
+              << " operator can not be used on expressions of type '" << type
+              << "'";
+          return CreateNone();
+        }
+
+        SizedType result = CreateNone();
+        if (unop.op == Operator::MUL) {
+          if (type.IsPtrTy()) {
+            result = type.GetPointeeTy();
+            if (type.IsCtxAccess())
+              result.MarkCtxAccess();
+            result.is_internal = type.is_internal;
+            result.SetAS(type.GetAS());
+          } else if (type.IsCStructTy()) {
+            // We allow dereferencing "args" with no effect (for backwards
+            // compat)
+            if (type.IsCtxAccess())
+              result = type;
+            else {
+              unop.addError() << "Can not dereference struct/union of type '"
+                              << type.GetName() << "'. It is not a pointer.";
+            }
+          } else if (type.IsIntTy()) {
+            result = CreateUInt64();
+          } else {
+            unop.addError() << "Can not dereference type '" << type
+                            << "'. It is not a pointer.";
+          }
+        } else if (unop.op == Operator::LNOT) {
+          result = CreateBool();
+        } else if (type.IsPtrTy() && valid_ptr_op) {
+          result = type;
+        } else {
+          result = CreateInt64();
+        }
+
+        return result;
+      });
+}
+
+void TypeGraph::visit(VarDeclStatement &decl)
+{
+  if (find_variable_scope(decl.var->ident, false) != nullptr) {
+    LOG(BUG) << "Variable shadowing should have been caught by now";
+  }
+
+  if (!decl.typeof) {
+    // If the declaration has no type then we can rely on the assignments to
+    // this variable to determine the type. Otherwise we exclusively rely on the
+    // type specified in the declaration and ignore the right side (issuing
+    // errors later).
+    visit(decl.var);
+    return;
+  }
+
+  auto *scope = scope_stack_.back();
+  ScopedVariable scoped_var = std::make_pair(scope, decl.var->ident);
+
+  if (std::holds_alternative<SizedType>(decl.typeof->record)) {
+    auto &ty = std::get<SizedType>(decl.typeof->record);
+    if (!resolve_struct_type(ty, *decl.typeof)) {
+      return;
+    }
+    add_resolved_type(scoped_var, ty);
+    // Some declared types like 'string' have no size so we can factor in the
+    // size of the assignment
+    if (ty.GetSize() != 0) {
+      decl_variables_.insert(scoped_var);
+    }
+  } else {
+    decl_variables_.insert(scoped_var);
+    visit(decl.typeof);
+    graph_[decl.typeof].emplace_back(
+        scoped_var, [](SizedType type) -> SizedType { return type; });
+  }
+
+  visit(decl.var);
+}
+
+void TypeGraph::visit(Variable &var)
+{
+  Node *scope = find_variable_scope(var.ident, false);
+  if (scope == nullptr) {
+    scope = scope_stack_.back();
+  }
+  variables_[scope].insert({ var.ident, CreateNone() });
+
+  ScopedVariable scoped_var = std::make_pair(scope, var.ident);
+
+  graph_[scoped_var].emplace_back(&var, [](SizedType type) -> SizedType {
+    return type;
+  });
+
+  if (introspection_level_ > 0) {
+    introspected_nodes_.insert(scoped_var);
+  }
+}
+
+void TypeGraph::visit(VariableAddr &var_addr)
+{
+  visit(var_addr.var);
+  graph_[var_addr.var].emplace_back(&var_addr, [](SizedType type) -> SizedType {
+    return CreatePointer(type, type.GetAS());
+  });
+}
+
+bool TypeGraph::resolve_struct_type(SizedType &type, Node &node)
+{
+  SizedType inner_type = type;
+  int pointer_level = 0;
+  while (inner_type.IsPtrTy()) {
+    inner_type = inner_type.GetPointeeTy();
+    pointer_level++;
+  }
+  if (inner_type.IsCStructTy() && !inner_type.GetStruct()) {
+    auto struct_type = bpftrace_.structs.Lookup(inner_type.GetName()).lock();
+    if (!struct_type) {
+      // Try to find the type as something other than a struct, e.g. 'char' or
+      // 'uint64_t'
+      auto stype = bpftrace_.btf_->get_stype(inner_type.GetName());
+      if (stype.IsNoneTy()) {
+        node.addError() << "Cannot resolve unknown type \""
+                        << inner_type.GetName() << "\"\n";
+        return false;
+      } else {
+        type = stype;
+        while (pointer_level > 0) {
+          type = CreatePointer(type);
+          pointer_level--;
+        }
+      }
+    } else {
+      type = CreateCStruct(inner_type.GetName(), struct_type);
+      while (pointer_level > 0) {
+        type = CreatePointer(type);
+        pointer_level--;
+      }
+    }
+  }
+  return true;
+}
+
+SizedType TypeGraph::get_variable_type(const ScopedVariable &scoped_var,
+                                       const SizedType &type,
+                                       Node &error_node,
+                                       std::optional<GraphNode> ptr_source)
+{
+  const auto &var = scoped_var.second;
+
+  auto locked_type = get_locked_node(scoped_var, type, error_node, var);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  auto current_type = get_resolved_type(scoped_var);
+  auto promoted = get_promoted_type(current_type, type);
+  if (promoted) {
+    if (promoted->IsPtrTy() && ptr_source.has_value()) {
+      pointer_sources_[scoped_var] = *ptr_source;
+    }
+
+    return *promoted;
+  }
+
+  // The types are incompatible, check if it's ok for same-source pointers
+  if (ptr_source.has_value() &&
+      is_same_pointer_source(scoped_var, *ptr_source, type, current_type)) {
+    return type;
+  }
+
+  error_node.addError() << "Type mismatch for " << var << ": "
+                        << "trying to assign value of type '" << type
+                        << "' when variable already has a type '"
+                        << current_type << "'";
+  return CreateNone();
+}
+
+SizedType TypeGraph::get_map_value(const std::string map_name,
+                                   const SizedType &type,
+                                   Node &error_node,
+                                   std::optional<GraphNode> ptr_source)
+{
+  auto value_name = get_map_value_name(map_name);
+
+  auto locked_type = get_locked_node(value_name, type, error_node, map_name);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  auto current_type = get_resolved_type(value_name);
+
+  auto add_error = [&]() {
+    error_node.addError() << "Type mismatch for " << map_name << ": "
+                          << "trying to assign value of type '" << type
+                          << "' when map already has a type '" << current_type
+                          << "'";
+  };
+
+  // @a = count();                  // OK
+  // @a = 1; @b = count(); @a = @b; // OK
+  // @b = count(); @a = @b;         // NOK
+  // @a = 1; @a = count();          // NOK
+  // @a = count(); @a = 1;          // NOK
+  // @a = count(); @a = sum(5);     // NOK
+  if (!current_type.IsIntegerTy() && current_type.IsCastableMapTy()) {
+    add_error();
+    return CreateNone();
+  }
+
+  auto promoted = get_promoted_type(current_type, type);
+  if (promoted) {
+    if (promoted->IsPtrTy() && ptr_source.has_value()) {
+      pointer_sources_[value_name] = *ptr_source;
+    }
+
+    // Data stored in a BPF map is internal (managed by BPF runtime), so
+    // structs and arrays should be marked as such.
+    if (promoted->IsCStructTy() || promoted->IsArrayTy()) {
+      promoted->is_internal = true;
+    }
+
+    return *promoted;
+  }
+
+  // The types are incompatible, check if it's ok for same-source pointers
+  if (ptr_source.has_value() &&
+      is_same_pointer_source(value_name, *ptr_source, type, current_type)) {
+    auto result = type;
+    if (result.IsCStructTy() || result.IsArrayTy()) {
+      result.is_internal = true;
+    }
+    return result;
+  }
+
+  add_error();
+  return CreateNone();
+}
+
+SizedType TypeGraph::get_agg_map_value(const std::string map_name,
+                                       const SizedType &type,
+                                       Call &call)
+{
+  auto value_name = get_map_value_name(map_name);
+
+  auto locked_type = get_locked_node(value_name, type, call, map_name);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  auto current_type = get_resolved_type(value_name);
+  if (current_type.IsNoneTy()) {
+    return type;
+  }
+
+  if (current_type.GetTy() == type.GetTy()) {
+    auto promoted = get_promoted_type(current_type, type);
+    if (promoted) {
+      return *promoted;
+    }
+  }
+
+  call.addError() << "Type mismatch for " << map_name << ": "
+                  << "trying to assign value of type '" << type
+                  << "' when map already has a type '" << current_type << "'";
+  return CreateNone();
+}
+
+SizedType TypeGraph::get_map_key(const std::string map_name,
+                                 const SizedType &type,
+                                 Node &error_node,
+                                 std::optional<GraphNode> ptr_source)
+{
+  auto val = map_metadata_.scalar.find(map_name);
+  if (val != map_metadata_.scalar.end() && val->second) {
+    // N.B. all scalar map keys are int64
+    return CreateInt64();
+  }
+
+  auto key_name = get_map_key_name(map_name);
+
+  auto locked_type = get_locked_node(key_name, type, error_node, map_name);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  auto current_type = get_resolved_type(key_name);
+  auto promoted = get_promoted_type(current_type, type);
+  if (promoted) {
+    if (promoted->IsPtrTy() && ptr_source.has_value()) {
+      pointer_sources_[key_name] = *ptr_source;
+    }
+
+    return *promoted;
+  }
+
+  // The types are incompatible, check if it's ok for same-source pointers
+  if (ptr_source.has_value() &&
+      is_same_pointer_source(key_name, *ptr_source, type, current_type)) {
+    return type;
+  }
+
+  error_node.addError() << "Argument mismatch for " << map_name << ": "
+                        << "trying to access with arguments: '" << type
+                        << "' when map expects arguments: '" << current_type
+                        << "'";
+  return CreateNone();
+}
+
+void TypeGraph::add_resolved_type(const GraphNode &node, const SizedType &type)
+{
+  if (type.IsNoneTy()) {
+    return;
+  }
+  resolved_types_[node] = type;
+  queue_.emplace(node, type);
+}
+
+void TypeGraph::propagate_resolved_types()
+{
+  // BFS to avoid stale updates with statements like $a = 0; $a = $a + 1;
+  while (!queue_.empty()) {
+    auto [current_source, current_type] = std::move(queue_.front());
+    queue_.pop();
+
+    auto found = graph_.find(current_source);
+    if (found == graph_.end()) {
+      continue;
+    }
+
+    for (auto &consumer : found->second) {
+      auto result_type = consumer.callback(current_type);
+      if (!result_type.IsNoneTy()) {
+        if (consumer.last_propagated) {
+          if (*consumer.last_propagated == result_type &&
+              consumer.last_propagated->IsCtxAccess() ==
+                  result_type.IsCtxAccess()) {
+            continue;
+          }
+        }
+        // N.B. this tracks the last edge type. We can't just use the consumer
+        // because map nodes have two edges: the key type and the value type
+        consumer.last_propagated = result_type;
+        resolved_types_[consumer.node] = result_type;
+        queue_.emplace(consumer.node, result_type);
+      }
+    }
+  }
+}
+
+void TypeGraph::add_consumer(const GraphNode &source, const GraphNode &consumer)
+{
+  graph_[source].emplace_back(consumer,
+                              [](SizedType type) -> SizedType { return type; });
+}
+
+SizedType TypeGraph::get_locked_node(const GraphNode &node,
+                                     const SizedType &type,
+                                     Node &error_node,
+                                     const std::string &name)
+{
+  if (auto found_locked = locked_nodes_.find(node);
+      found_locked != locked_nodes_.end()) {
+    if (!type.FitsInto(found_locked->second)) {
+      error_node.addError()
+          << "Type mismatch for " << name << ": "
+          << "this type has been locked because it was used "
+             "in another part of the type graph that was already "
+             "resolved (e.g. `sizeof`, `typeinfo`, etc.). The new type '"
+          << type << "' doesn't fit into the locked type '"
+          << found_locked->second << "'";
+    }
+    return found_locked->second;
+  }
+  return CreateNone();
+}
+
+GraphNode TypeGraph::get_pointer_source(Expression &expr)
+{
+  if (auto *var_addr = expr.as<VariableAddr>()) {
+    Node *addr_scope = find_variable_scope(var_addr->var->ident);
+    return ScopedVariable{ addr_scope, var_addr->var->ident };
+  } else if (auto *map_addr = expr.as<MapAddr>()) {
+    return get_map_value_name(map_addr->map->ident);
+  } else {
+    return &expr.node();
+  }
+}
+
+bool TypeGraph::is_same_pointer_source(const GraphNode &node_key,
+                                       const GraphNode &ptr_source,
+                                       const SizedType &incoming_type,
+                                       const SizedType &current_type)
+{
+  if (!incoming_type.IsPtrTy() || !current_type.IsPtrTy()) {
+    return false;
+  }
+  auto existing_source = pointer_sources_.find(node_key);
+  if (existing_source == pointer_sources_.end()) {
+    LOG(BUG) << "Original pointer source should exist";
+  }
+  return existing_source->second == ptr_source;
+}
+
+Probe *TypeGraph::get_probe()
+{
+  auto *probe = dynamic_cast<Probe *>(top_level_node_);
+  return probe;
+}
+
+Probe *TypeGraph::get_probe(Node &node, std::string name)
+{
+  auto *probe = dynamic_cast<Probe *>(top_level_node_);
+  if (probe == nullptr) {
+    if (name.empty()) {
+      node.addError() << "Feature not supported outside probe";
+    } else {
+      node.addError() << "Builtin " << name << " not supported outside probe";
+    }
+  }
+  return probe;
+}
+
+void TypeGraph::check_stack_call(Call &call, bool kernel)
+{
+  call.return_type = CreateStack(kernel);
+  StackType stack_type;
+  stack_type.mode = bpftrace_.config_->stack_mode;
+
+  switch (call.vargs.size()) {
+    case 0:
+      break;
+    case 1: {
+      if (auto *ident = call.vargs.at(0).as<Identifier>()) {
+        ConfigParser<StackMode> parser;
+        auto ok = parser.parse(call.func, &stack_type.mode, ident->ident);
+        if (!ok) {
+          ident->addError() << "Error parsing stack mode: " << ok.takeError();
+        }
+      } else if (auto *limit = call.vargs.at(0).as<Integer>()) {
+        stack_type.limit = limit->value;
+      } else {
+        call.addError() << call.func << ": invalid limit value";
+      }
+      break;
+    }
+    case 2: {
+      if (auto *ident = call.vargs.at(0).as<Identifier>()) {
+        ConfigParser<StackMode> parser;
+        auto ok = parser.parse(call.func, &stack_type.mode, ident->ident);
+        if (!ok) {
+          ident->addError() << "Error parsing stack mode: " << ok.takeError();
+        }
+      } else {
+        call.addError() << "Expected stack mode as first argument";
+      }
+      if (auto *limit = call.vargs.at(1).as<Integer>()) {
+        stack_type.limit = limit->value;
+      } else {
+        call.addError() << call.func << ": invalid limit value";
+      }
+      break;
+    }
+    default:
+      call.addError() << "Invalid number of arguments";
+      break;
+  }
+  constexpr int MAX_STACK_SIZE = 1024;
+  if (stack_type.limit > MAX_STACK_SIZE) {
+    call.addError() << call.func << "([int limit]): limit shouldn't exceed "
+                    << MAX_STACK_SIZE << ", " << stack_type.limit << " given";
+  }
+  if (stack_type.mode == StackMode::build_id && kernel) {
+    call.addError() << "'build_id' stack mode can only be used for ustack";
+  }
+  call.return_type = CreateStack(kernel, stack_type);
+}
+
+bool TypeGraph::resolve()
+{
+  propagate_resolved_types();
+
+  if (!ast_.diagnostics().ok()) {
+    return false;
+  }
+
+  // Create literals from expressions like `typeinfo`, `offsetof`, etc.
+  // Also handles AST transformations like tuple/record comparisons.
+  AstTransformer folder(ast_, macro_registry_, resolved_types_);
+  folder.visit(ast_.root);
+  needs_rerun_ = folder.had_transforms();
+  // Fold literals like `comptime (typeof($a).base_ty == "int")` that relied on
+  // type information to resolve
+  fold(ast_);
+
+  return ast_.diagnostics().ok();
+}
+
+LockedNodes TypeGraph::get_locked_nodes()
+{
+  LockedNodes locked_nodes;
+  for (const auto &node : introspected_nodes_) {
+    if (const auto *scoped_var = std::get_if<ScopedVariable>(&node)) {
+      auto type = get_resolved_type(*scoped_var);
+      if (!type.IsNoneTy()) {
+        locked_nodes.insert({ *scoped_var, type });
+      }
+    } else if (const auto *map_ident = std::get_if<std::string>(&node)) {
+      auto key_type = get_resolved_type(get_map_key_name(*map_ident));
+      if (!key_type.IsNoneTy()) {
+        locked_nodes.insert({ get_map_key_name(*map_ident), key_type });
+      }
+      auto value_type = get_resolved_type(get_map_value_name(*map_ident));
+      if (!value_type.IsNoneTy()) {
+        locked_nodes.insert({ get_map_value_name(*map_ident), value_type });
+      }
+    }
+  }
+  return locked_nodes;
+}
+
+Node *TypeGraph::find_variable_scope(const std::string &var_ident, bool safe)
+{
+  for (auto *scope : scope_stack_) {
+    if (auto search_val = variables_[scope].find(var_ident);
+        search_val != variables_[scope].end()) {
+      return scope;
+    }
+  }
+  if (safe) {
+    LOG(BUG) << "No scope found for variable: " << var_ident;
+  }
+  return nullptr;
+}
+
+std::optional<Expression> AstTransformer::visit(Binop &binop)
+{
+  visit(binop.left);
+  visit(binop.right);
+
+  const auto &lht = get_type(&binop.left.node());
+  const auto &rht = get_type(&binop.right.node());
+
+  if (binop.op != Operator::EQ && binop.op != Operator::NE)
+    return std::nullopt;
+
+  if (!lht.IsTupleTy() && !lht.IsRecordTy())
+    return std::nullopt;
+
+  if (!lht.IsCompatible(rht))
+    return std::nullopt;
+
+  if (binop.left.is_literal() && binop.right.is_literal()) {
+    // This will get folded.
+    return std::nullopt;
+  }
+
+  bool is_tuple = lht.IsTupleTy();
+  auto updatedTy = is_tuple ? get_promoted_tuple(lht, rht)
+                            : get_promoted_record(lht, rht);
+  if (!updatedTy) {
+    binop.addError() << "Type mismatch for '" << opstr(binop) << "': comparing "
+                     << lht << " with " << rht;
+    return std::nullopt;
+  }
+
+  if (*updatedTy != lht) {
+    if (is_tuple) {
+      try_tuple_cast(ast_, binop.left, lht, *updatedTy);
+    } else {
+      try_record_cast(ast_, binop.left, lht, *updatedTy);
+    }
+  }
+  if (*updatedTy != rht) {
+    if (is_tuple) {
+      try_tuple_cast(ast_, binop.right, rht, *updatedTy);
+    } else {
+      try_record_cast(ast_, binop.right, rht, *updatedTy);
+    }
+  }
+
+  bool types_equal = binop.left.type() == binop.right.type();
+
+  auto *size = ast_.make_node<Integer>(binop.loc,
+                                       updatedTy->GetSize(),
+                                       CreateUInt64());
+  // N.B. if the types aren't equal at this point it means that
+  // we're dealing with record types that are same except for
+  // their fields are in a different order so we need to use a
+  // different memcmp that saves off both the left and right to
+  // variables but sets the type of the right variable to the left
+  // before assignment (e.g. `let $right: typeof($left) = right;`)
+  // as this ensures the temporary `$right` variable has the same
+  // field ordering as the `$left`.
+  auto *call = ast_.make_node<Call>(binop.loc,
+                                    types_equal ? "memcmp" : "memcmp_record",
+                                    ExpressionList{
+                                        binop.left, binop.right, size });
+  auto *typeof_node = ast_.make_node<Typeof>(binop.loc, CreateBool());
+  auto *cast = ast_.make_node<Cast>(binop.loc, typeof_node, call);
+  if (binop.op == Operator::NE) {
+    return cast;
+  } else {
+    return ast_.make_node<Unop>(binop.loc, cast, Operator::LNOT);
+  }
+}
+
+std::optional<Expression> AstTransformer::visit(Expression &expr)
+{
+  auto r = Visitor<AstTransformer, std::optional<Expression>>::visit(
+      expr.value);
+  if (r) {
+    had_transforms_ = true;
+    expr.value = r->value;
+    expand_macro(ast_, expr, macro_registry_);
+  }
+  return std::nullopt;
+}
+
+std::optional<Expression> AstTransformer::visit(FieldAccess &acc)
+{
+  visit(acc.expr);
+
+  // FieldAccesses will automatically resolve through any number of pointer
+  // dereferences. For now, we inject the `Unop` operator directly, as codegen
+  // stores the underlying structs as pointers anyways. In the future, we will
+  // likely want to do this in a different way if we are tracking l-values.
+  auto type = get_type(&acc.expr.node());
+  while (type.IsPtrTy()) {
+    auto *unop = ast_.make_node<Unop>(acc.expr.node().loc,
+                                      acc.expr,
+                                      Operator::MUL);
+    unop->result_type = type.GetPointeeTy();
+    if (type.IsCtxAccess())
+      unop->result_type.MarkCtxAccess();
+    unop->result_type.is_internal = type.is_internal;
+    unop->result_type.SetAS(type.GetAS());
+    acc.expr.value = unop;
+    had_transforms_ = true;
+    type = unop->result_type;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Expression> AstTransformer::visit(Offsetof &offof)
+{
+  SizedType cstruct;
+  if (std::holds_alternative<SizedType>(offof.record)) {
+    cstruct = std::get<SizedType>(offof.record);
+  } else {
+    cstruct = get_type(&std::get<Expression>(offof.record).node());
+  }
+
+  if (cstruct.IsNoneTy()) {
+    return std::nullopt;
+  }
+
+  size_t offset = 0;
+  for (const auto &field : offof.field) {
+    if (!cstruct.IsCStructTy() || !cstruct.HasField(field)) {
+      return std::nullopt;
+    }
+    const auto &f = cstruct.GetField(field);
+    offset += f.offset;
+    cstruct = f.type;
+  }
+
+  return ast_.make_node<Integer>(Location(offof.loc), offset);
+}
+
+std::optional<Expression> AstTransformer::visit(Sizeof &szof)
+{
+  size_t size = 0;
+  if (std::holds_alternative<SizedType>(szof.record)) {
+    auto &ty = std::get<SizedType>(szof.record);
+    if (ty.IsNoneTy()) {
+      return std::nullopt;
+    }
+    size = ty.GetSize();
+  } else {
+    const auto &ty = get_type(&std::get<Expression>(szof.record).node());
+    if (ty.IsNoneTy()) {
+      return std::nullopt;
+    }
+    size = ty.GetSize();
+  }
+
+  return ast_.make_node<Integer>(Location(szof.loc), size);
+}
+
+std::optional<Expression> AstTransformer::visit(Typeinfo &typeinfo)
+{
+  const auto &type = get_type(typeinfo.typeof);
+  if (type.IsNoneTy()) {
+    return std::nullopt;
+  }
+
+  // We currently lack a globally-unique enumeration of types. For
+  // simplicity, just use the type string with a placeholder identifier.
+  auto *id = ast_.make_node<Integer>(typeinfo.loc, 0);
+  auto *base_ty = ast_.make_node<String>(typeinfo.loc, to_string(type.GetTy()));
+  auto *full_ty = ast_.make_node<String>(typeinfo.loc, typestr(type));
+
+  std::vector<SizedType> elements = { CreateUInt64(),
+                                      base_ty->type(),
+                                      full_ty->type() };
+  std::vector<std::string_view> names = { "btf_id", "base_type", "full_type" };
+
+  auto record_type = CreateRecord(Struct::CreateRecord(elements, names));
+
+  auto *record = make_record(
+      ast_,
+      typeinfo.loc,
+      { { "btf_id", id }, { "base_type", base_ty }, { "full_type", full_ty } });
+
+  record->record_type = record_type;
+
+  return record;
+}
+
+void TypeApplicator::visit(ArrayAccess &arr)
+{
+  Visitor<TypeApplicator>::visit(arr);
+  apply(arr, arr.element_type);
+}
+
+void TypeApplicator::visit(Binop &binop)
+{
+  Visitor<TypeApplicator>::visit(binop);
+  apply(binop, binop.result_type);
+}
+
+void TypeApplicator::visit(Builtin &builtin)
+{
+  apply(builtin, builtin.builtin_type);
+}
+
+void TypeApplicator::visit(Call &call)
+{
+  Visitor<TypeApplicator>::visit(call);
+  apply(call, call.return_type);
+}
+
+void TypeApplicator::visit(Cast &cast)
+{
+  Visitor<TypeApplicator>::visit(cast);
+  if (std::holds_alternative<SizedType>(cast.typeof->record)) {
+    apply(cast, std::get<SizedType>(cast.typeof->record));
+  }
+}
+
+void TypeApplicator::visit(FieldAccess &acc)
+{
+  Visitor<TypeApplicator>::visit(acc);
+  apply(acc, acc.field_type);
+}
+
+void TypeApplicator::visit(IfExpr &if_expr)
+{
+  Visitor<TypeApplicator>::visit(if_expr);
+  apply(if_expr, if_expr.result_type);
+}
+
+void TypeApplicator::visit(Identifier &identifier)
+{
+  apply(identifier, identifier.ident_type);
+}
+
+void TypeApplicator::visit(Map &map)
+{
+  auto key_it = resolved_types_.find(get_map_key_name(map.ident));
+  if (key_it != resolved_types_.end()) {
+    map.key_type = key_it->second;
+  }
+  auto val_it = resolved_types_.find(get_map_value_name(map.ident));
+  if (val_it != resolved_types_.end()) {
+    map.value_type = val_it->second;
+  }
+}
+
+void TypeApplicator::visit(MapAddr &map_addr)
+{
+  Visitor<TypeApplicator>::visit(map_addr);
+  apply(map_addr, map_addr.map_addr_type);
+}
+
+void TypeApplicator::visit(Record &record)
+{
+  Visitor<TypeApplicator>::visit(record);
+  apply(record, record.record_type);
+}
+
+void TypeApplicator::visit(Tuple &tuple)
+{
+  Visitor<TypeApplicator>::visit(tuple);
+  apply(tuple, tuple.tuple_type);
+}
+
+void TypeApplicator::visit(TupleAccess &acc)
+{
+  Visitor<TypeApplicator>::visit(acc);
+  apply(acc, acc.element_type);
+}
+
+void TypeApplicator::visit(Unop &unop)
+{
+  Visitor<TypeApplicator>::visit(unop);
+  apply(unop, unop.result_type);
+}
+
+void TypeApplicator::visit(Variable &var)
+{
+  apply(var, var.var_type);
+}
+
+void TypeApplicator::visit(VariableAddr &var_addr)
+{
+  Visitor<TypeApplicator>::visit(var_addr);
+  apply(var_addr, var_addr.var_addr_type);
+}
+
+Pass CreateTypeGraphPass()
+{
+  return Pass::create(
+      "TypeGraph",
+      [](ASTContext &ast,
+         BPFtrace &b,
+         MapMetadata &mm,
+         CDefinitions &c_definitions,
+         TypeMetadata &types,
+         MacroRegistry &macro_registry) {
+        // Fold up front
+        fold(ast);
+
+        auto type_graph = TypeGraph(
+            ast, b, mm, c_definitions, types, macro_registry);
+        // Collect the graph callbacks (sources -> consumers)
+        type_graph.visit(ast.root);
+        // Resolve the types in the graph until the queue is empty
+        bool resolve_ok = type_graph.resolve();
+
+        // This is passed to TypeApplicator when we're done with all runs
+        auto resolved_types = type_graph.get_resolved_types();
+
+        // These two are passed to future TypeGraph runs
+        auto prev_comptimes = type_graph.get_unresolved_comptimes();
+        LockedNodes locked_nodes = type_graph.get_locked_nodes();
+
+        // Check if there are unresolved comptime expressions or there were AST
+        // transformations, if so we need to re-create the graph
+        bool should_rerun = !prev_comptimes.empty() || type_graph.needs_rerun();
+        bool has_comptime_error = false;
+        while (should_rerun && resolve_ok) {
+          auto next_pass = TypeGraph(
+              ast, b, mm, c_definitions, types, macro_registry, locked_nodes);
+          next_pass.visit(ast.root);
+
+          resolve_ok = next_pass.resolve();
+          resolved_types = next_pass.get_resolved_types();
+
+          auto next_comptimes = next_pass.get_unresolved_comptimes();
+          if (prev_comptimes == next_comptimes && !next_pass.needs_rerun()) {
+            for (auto *comptime : next_comptimes) {
+              comptime->addError() << "Unable to resolve comptime expression";
+            }
+            has_comptime_error = !next_comptimes.empty();
+            break;
+          }
+          prev_comptimes = next_comptimes;
+          locked_nodes = next_pass.get_locked_nodes();
+          should_rerun = !prev_comptimes.empty() || next_pass.needs_rerun();
+        }
+
+        if (has_comptime_error || !resolve_ok) {
+          return;
+        }
+
+        TypeApplicator(resolved_types).visit(ast.root);
+        CastCreator(ast, b).visit(ast.root);
+      });
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/type_graph.h
+++ b/src/ast/passes/type_graph.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateTypeGraphPass();
+
+} // namespace bpftrace::ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "ast/passes/recursion_check.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/type_checker.h"
+#include "ast/passes/type_graph.h"
 #include "ast/passes/type_resolver.h"
 #include "ast/passes/type_system.h"
 #include "benchmark.h"
@@ -345,7 +346,7 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreatePreTypeCheckPass());
-  add(ast::CreateTypeResolverPass());
+  add(ast::CreateTypeGraphPass());
   add(ast::CreateTypeCheckerPass());
   add(ast::CreateResourcePass());
 }
@@ -356,7 +357,7 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreatePreTypeCheckPass());
-  add(ast::CreateTypeResolverPass());
+  add(ast::CreateTypeGraphPass());
   add(ast::CreateTypeCheckerPass());
   add(ast::CreateResourcePass());
 }

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -47,7 +47,7 @@ macro check_key(@map, key, func)
   if comptime is_scalar(@map) {
     fail("call to %s expects a map with explicit keys (non-scalar map)", func);
   } else {
-    // The typeinfo(@map[key]) is a bit of a hack as it both checks if the passed key is compatible
+    // This is a bit of a hack as it both checks if the passed key is compatible
     // with the map key and it also possibly changes the key type to make them
     // compatible if possible, e.g.
     // @c[1, ("hello", (int8)5)] = 0;

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -83,7 +83,8 @@ std::shared_ptr<Struct> Struct::CreateRecord(
     offset += padding;
 
     record->fields.push_back(Field{
-        .name = field_names.empty() ? "" : std::string{ field_names[i] },
+        .name = field_names.empty() ? std::to_string(i)
+                                    : std::string{ field_names[i] },
         .type = field,
         .offset = offset,
         .bitfield = std::nullopt,

--- a/src/types.h
+++ b/src/types.h
@@ -8,6 +8,7 @@
 #include <compare>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <sys/types.h>
@@ -518,6 +519,7 @@ public:
     return type_ == Type::count_t || type_ == Type::sum_t ||
            type_ == Type::max_t || type_ == Type::min_t || type_ == Type::avg_t;
   }
+
   bool IsMapIterableTy() const
   {
     if (IsMultiKeyMapTy()) {
@@ -606,6 +608,15 @@ SizedType CreateTimestamp();
 SizedType CreateMacAddress();
 SizedType CreateCgroupPath();
 SizedType CreateTimestampMode();
+
+std::optional<SizedType> get_promoted_int(const SizedType &currentType,
+                                          const SizedType &newType);
+std::optional<SizedType> get_promoted_tuple(const SizedType &currentType,
+                                            const SizedType &newType);
+std::optional<SizedType> get_promoted_record(const SizedType &currentType,
+                                             const SizedType &newType);
+std::optional<SizedType> get_promoted_type(const SizedType &currentType,
+                                           const SizedType &newType);
 
 std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(bpftrace_test
   required_resources.cpp
   scopeguard.cpp
   type_checker.cpp
+  type_graph.cpp
   temp.cpp
   tracepoint_format_parser.cpp
   types.cpp

--- a/tests/type_graph.cpp
+++ b/tests/type_graph.cpp
@@ -1,0 +1,1191 @@
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "arch/arch.h"
+#include "ast/ast.h"
+#include "ast/passes/ap_probe_expansion.h"
+#include "ast/passes/args_resolver.h"
+#include "ast/passes/attachpoint_passes.h"
+#include "ast/passes/builtins.h"
+#include "ast/passes/c_macro_expansion.h"
+#include "ast/passes/clang_parser.h"
+#include "ast/passes/control_flow_analyser.h"
+#include "ast/passes/field_analyser.h"
+#include "ast/passes/fold_literals.h"
+#include "ast/passes/import_scripts.h"
+#include "ast/passes/loop_return.h"
+#include "ast/passes/macro_expansion.h"
+#include "ast/passes/map_sugar.h"
+#include "ast/passes/named_param.h"
+#include "ast/passes/resolve_imports.h"
+#include "ast/passes/type_graph.h"
+#include "ast/passes/type_system.h"
+#include "ast_matchers.h"
+#include "bpftrace.h"
+#include "btf_common.h"
+#include "driver.h"
+#include "mocks.h"
+#include "struct.h"
+
+namespace bpftrace::test::type_graph {
+
+using bpftrace::test::AssignMapStatement;
+using bpftrace::test::AssignVarStatement;
+using bpftrace::test::Binop;
+using bpftrace::test::Block;
+using bpftrace::test::Builtin;
+using bpftrace::test::Cast;
+using bpftrace::test::ExprStatement;
+using bpftrace::test::FieldAccess;
+using bpftrace::test::For;
+using bpftrace::test::If;
+using bpftrace::test::Integer;
+using bpftrace::test::Map;
+using bpftrace::test::MapAccess;
+using bpftrace::test::MapAddr;
+using bpftrace::test::NamedArgument;
+using bpftrace::test::Probe;
+using bpftrace::test::Program;
+using bpftrace::test::Record;
+using bpftrace::test::SizedType;
+using bpftrace::test::String;
+using bpftrace::test::Tuple;
+using bpftrace::test::Typeof;
+using bpftrace::test::Unop;
+using bpftrace::test::VarDeclStatement;
+using bpftrace::test::Variable;
+using bpftrace::test::VariableAddr;
+using ::testing::_;
+using ::testing::HasSubstr;
+
+auto IntTy(size_t size, bool is_signed = false)
+{
+  return SizedType(Type::integer).WithSize(size).WithSigned(is_signed);
+}
+
+auto StringTy(size_t size)
+{
+  return SizedType(Type::string).WithSize(size);
+}
+
+auto IntVar(const std::string &name, size_t size, bool is_signed = false)
+{
+  return Variable(name).WithType(
+      SizedType(Type::integer).WithSize(size).WithSigned(is_signed));
+}
+
+auto IntMapValue(const std::string &name, size_t size, bool is_signed = false)
+{
+  return Map(name).WithType(
+      SizedType(Type::integer).WithSize(size).WithSigned(is_signed));
+}
+
+auto IntMapKey(const std::string &name, size_t size, bool is_signed = false)
+{
+  return Map(name).WithKeyType(
+      SizedType(Type::integer).WithSize(size).WithSigned(is_signed));
+}
+
+struct Mock {
+  BPFtrace &bpftrace;
+};
+enum class UnsafeMode {
+  Enable = 0, // Default is safe.
+};
+enum class Child {
+  Enable = 0, // Default is no child.
+};
+enum class NoFeatures {
+  Enable = 0, // Default is full features.
+};
+struct Warning {
+  std::string_view str;
+};
+struct NoWarning {
+  std::string_view str;
+};
+struct Error {
+  std::string_view str;
+};
+struct Types {
+  ast::TypeMetadata &types;
+};
+struct ExpectedAST {
+  ProgramMatcher matcher;
+};
+
+template <typename T, typename First, typename... Ts>
+std::optional<T> extract(First &&arg, Ts &&...rest)
+{
+  if constexpr (std::is_same_v<std::decay_t<First>, T>) {
+    // Assert that nothing in the rest matches T.
+    static_assert(!(std::is_same_v<std::decay_t<Ts>, T> || ...),
+                  "Only one argument of each type is allowed");
+    return arg;
+  }
+  if constexpr (sizeof...(Ts) != 0) {
+    return extract<T, Ts...>(std::forward<Ts>(rest)...);
+  }
+  return std::nullopt;
+}
+
+template <typename T>
+std::optional<T> extract()
+{
+  return std::nullopt;
+}
+
+std::string_view clean_prefix(std::string_view view)
+{
+  while (!view.empty() && view[0] == '\n')
+    view.remove_prefix(1); // Remove initial '\n'
+  return view;
+}
+
+// This exists as a test fixture because the types may refer to `bpftrace`, so
+// this objects lifetime must exceed the tests lifetime. This is easier with a
+// fixture, and allows us to have a single harness.
+class TypeGraphHarness {
+public:
+  template <typename... Ts>
+    requires((std::is_same_v<std::decay_t<Ts>, Mock> ||
+              std::is_same_v<std::decay_t<Ts>, UnsafeMode> ||
+              std::is_same_v<std::decay_t<Ts>, Child> ||
+              std::is_same_v<std::decay_t<Ts>, NoFeatures> ||
+              std::is_same_v<std::decay_t<Ts>, Warning> ||
+              std::is_same_v<std::decay_t<Ts>, NoWarning> ||
+              std::is_same_v<std::decay_t<Ts>, Error> ||
+              std::is_same_v<std::decay_t<Ts>, ExpectedAST> ||
+              std::is_same_v<std::decay_t<Ts>, Types>) &&
+             ...)
+  ast::ASTContext test(std::string_view input, Ts &&...args)
+  {
+    ast::ASTContext ast("stdin", std::string(clean_prefix(input)));
+
+    // Reset for each iteration. We only guarantee that the types remain
+    // valid after the ASTContext has been returned.
+    bpftrace_.reset();
+    types_.reset();
+
+    // Extract all extra arguments.
+    auto mock = extract<Mock>(args...);
+    auto unsafe_mode = extract<UnsafeMode>(args...);
+    auto child = extract<Child>(args...);
+    auto no_features = extract<NoFeatures>(args...);
+    auto warning = extract<Warning>(args...);
+    auto nowarning = extract<NoWarning>(args...);
+    auto error = extract<Error>(args...);
+    auto types = extract<Types>(args...);
+    auto expected_ast = extract<ExpectedAST>(args...);
+
+    if (!mock) {
+      // Create a fresh instance.
+      bpftrace_ = get_mock_bpftrace();
+      mock.emplace(*bpftrace_);
+    }
+    mock->bpftrace.safe_mode_ = !unsafe_mode.has_value();
+    mock->bpftrace.feature_ = std::make_unique<MockBPFfeature>(
+        !no_features.has_value());
+    if (child.has_value()) {
+      mock->bpftrace.cmd_ = "not-empty"; // Used by TypeChecker.
+    }
+    if (!types) {
+      types_.emplace();
+      types.emplace(*types_);
+    }
+
+    auto ok = ast::PassManager()
+                  .put(ast)
+                  .put(mock->bpftrace)
+                  .put(types->types)
+                  .add(CreateParsePass())
+                  .add(ast::CreateMacroExpansionPass())
+                  .add(ast::CreateClangParsePass())
+                  .add(ast::CreateFoldLiteralsPass())
+                  .add(ast::CreateBuiltinsPass())
+                  .add(ast::CreateMapSugarPass())
+                  .add(ast::CreateTypeGraphPass())
+                  .run();
+    EXPECT_TRUE(bool(ok));
+
+    std::stringstream out;
+    ast.diagnostics().emit(out, ast::Diagnostics::Severity::Warning);
+    if (warning) {
+      EXPECT_TRUE(!warning->str.empty());
+      EXPECT_THAT(out.str(), HasSubstr(clean_prefix(warning->str)))
+          << out.str();
+    }
+    if (nowarning) {
+      EXPECT_TRUE(!nowarning->str.empty());
+      EXPECT_THAT(out.str(), Not(HasSubstr(clean_prefix(nowarning->str))))
+          << out.str();
+    }
+    out.str("");
+    ast.diagnostics().emit(out, ast::Diagnostics::Severity::Error);
+    const auto errstr = out.str();
+    if (error) {
+      if (!error->str.empty()) {
+        EXPECT_THAT(errstr, HasSubstr(clean_prefix(error->str))) << errstr;
+      } else {
+        EXPECT_TRUE(!errstr.empty()) << errstr;
+      }
+    } else {
+      EXPECT_EQ(errstr, "") << errstr;
+    }
+    out.str("");
+    if (expected_ast) {
+      EXPECT_THAT(ast, expected_ast->matcher);
+    }
+
+    return ast;
+  }
+
+private:
+  std::unique_ptr<MockBPFtrace> bpftrace_;
+  std::optional<ast::TypeMetadata> types_;
+};
+
+class TypeGraphTest : public TypeGraphHarness, public testing::Test {};
+
+TEST_F(TypeGraphTest, variable_basic)
+{
+  test(R"(begin { $a = 1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 1), _) })) });
+
+  test(R"(begin { $a = true; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { AssignVarStatement(
+               Variable("$a").WithType(SizedType(Type::boolean)), _) })) });
+
+  test(R"(begin { $a = "str"; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { AssignVarStatement(Variable("$a").WithType(StringTy(4)), _) })) });
+
+  test(R"(begin { let $b; $a = ($b != 1); $b = 10; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 1)),
+                   AssignVarStatement(
+                       Variable("$a").WithType(SizedType(Type::boolean)), _),
+                   AssignVarStatement(IntVar("$b", 1), _) })) });
+
+  test(R"(begin { let $b; $a = $b; $b = 10; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 1)),
+                   AssignVarStatement(IntVar("$a", 1), IntVar("$b", 1)),
+                   AssignVarStatement(IntVar("$b", 1), _) })) });
+
+  test(R"(begin { let $y; $z = $y + 10; $y = 10; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$y", 1)),
+                   AssignVarStatement(IntVar("$z", 8), _),
+                   AssignVarStatement(IntVar("$y", 1), _) })) });
+
+  test(R"(begin { let $h; let $g; $i = $g + $h + 10; $h = 10; $g = 10; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$h", 1)),
+                   VarDeclStatement(IntVar("$g", 1)),
+                   AssignVarStatement(IntVar("$i", 8), _),
+                   AssignVarStatement(IntVar("$h", 1), _),
+                   AssignVarStatement(IntVar("$g", 1), _) })) });
+  test(R"(begin { if (true) { $x = 10; } else { $x = "str"; } })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { ExprStatement(If(
+                     _,
+                     Block({ AssignVarStatement(IntVar("$x", 1), _) }),
+                     Block({ AssignVarStatement(
+                         Variable("$x").WithType(StringTy(4)), _) }))) })) });
+  test(
+      R"(begin { let $y; if (true) { $x = $y; } else { $x = $y + 10; } $y = -1; })",
+      ExpectedAST{ Program().WithProbe(Probe(
+          _,
+          { VarDeclStatement(IntVar("$y", 1, true)),
+            ExprStatement(
+                If(_,
+                   Block({ AssignVarStatement(IntVar("$x", 1, true),
+                                              IntVar("$y", 1, true)) }),
+                   Block({ AssignVarStatement(IntVar("$x", 8, true),
+                                              Binop(Operator::PLUS, _, _)) }))),
+            AssignVarStatement(IntVar("$y", 1, true), _) })) });
+
+  test(
+      R"(begin { let $a: uint32 = (uint8)1; })",
+      ExpectedAST{ Program().WithProbe(Probe(
+          _,
+          { AssignVarStatement(
+              IntVar("$a", 4),
+              Cast(Typeof(bpftrace::test::SizedType(Type::integer).WithSize(4)),
+                   Cast(Typeof(bpftrace::test::SizedType(Type::integer)
+                                   .WithSize(1)),
+                        Integer(1)))) })) });
+
+  test(R"(begin { let $a: uint32 = 1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 4), Integer(1)) })) });
+
+  test(R"(begin { $a = 0; $a = $a + 1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(IntVar("$a", 8), _),
+                   AssignVarStatement(IntVar("$a", 8), _) })) });
+
+  test(R"(begin { $a = 0; $a = $a - 1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(IntVar("$a", 8), _),
+                   AssignVarStatement(IntVar("$a", 8), _) })) });
+
+  test(R"(begin { $a = 1; $a = "str"; })", Error{ R"(
+stdin:1:17-27: ERROR: Type mismatch for $a: trying to assign value of type 'string[4]' when variable already has a type 'uint8'
+begin { $a = 1; $a = "str"; }
+                ~~~~~~~~~~
+)" });
+
+  test(
+      R"(begin { let $y; if (true) { $x = $y; if (true) { $x = "str"; } } else { $x = $y + 10; } $y = -1; })",
+      Error{ R"(
+ERROR: Type mismatch for $x: trying to assign value of type 'int8' when variable already has a type 'string[4]'
+begin { let $y; if (true) { $x = $y; if (true) { $x = "str"; } } else { $x = $y + 10; } $y = -1; }
+                            ~~~~~~~
+)" });
+
+  test(R"(begin { let $a: uint32 = -1; })", Error{});
+  test(R"(begin { let $a: uint32 = (uint64)1; })", Error{});
+  test(R"(begin { let $b; let $a: typeof($b) = (uint64)1; $b = (uint32)2; })",
+       Error{});
+  test(
+      R"(begin {let $a; let $x: uint32 = (typeof($a))10; $a = (uint16)1; $a = (uint64)2;})",
+      Error{});
+  test(R"(begin { let $a: string[2] = "muchlongerstr"; })", Error{});
+}
+
+TEST_F(TypeGraphTest, variable_no_type)
+{
+  test(R"(begin { let $z; $a = 1; $b = typeinfo($z); })", Error{ R"(
+stdin:1:13-15: ERROR: Could not resolve the type of this variable
+begin { let $z; $a = 1; $b = typeinfo($z); }
+            ~~
+stdin:1:39-41: ERROR: Could not resolve the type of this variable
+begin { let $z; $a = 1; $b = typeinfo($z); }
+                                      ~~
+stdin:1:25-27: ERROR: Could not resolve the type of this variable
+begin { let $z; $a = 1; $b = typeinfo($z); }
+                        ~~
+)" });
+
+  test(R"(begin { let $a; let $b; $b = $a; $a = $b; })", Error{});
+}
+
+TEST_F(TypeGraphTest, variable_with_type_decl)
+{
+  test(R"(begin { let $a: uint32 = 1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 4), _) })) });
+  test(
+      R"(begin { let $b; let $a: typeof($b) = (uint64)1; $b = (uint32)2; $b = (uint64)3; })",
+      ExpectedAST{ Program().WithProbe(
+          Probe(_,
+                { VarDeclStatement(IntVar("$b", 8)),
+                  AssignVarStatement(IntVar("$a", 8), _),
+                  AssignVarStatement(IntVar("$b", 8), _),
+                  AssignVarStatement(IntVar("$b", 8), _) })) });
+  test(R"(begin { let $b; let $a: typeof($b) = (uint16)1; $b = (uint32)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 4)),
+                   AssignVarStatement(IntVar("$a", 4), _),
+                   AssignVarStatement(IntVar("$b", 4), _) })) });
+}
+
+TEST_F(TypeGraphTest, map_value_basic)
+{
+  // Basic type assignments
+  test(R"(begin { @a = 1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignMapStatement(IntMapValue("@a", 1), _, _) })) });
+  test(R"(begin { @a = true; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignMapStatement(
+                     Map("@a").WithType(SizedType(Type::boolean)), _, _) })) });
+  test(R"(begin { @a = "str"; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { AssignMapStatement(Map("@a").WithType(StringTy(4)), _, _) })) });
+
+  test(R"(begin { @a[1] = 2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignMapStatement(IntMapValue("@a", 1), _, _) })) });
+
+  test(R"(begin { @a = 1; @a = (uint64)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignMapStatement(IntMapValue("@a", 8), _, _),
+                   AssignMapStatement(IntMapValue("@a", 8), _, _) })) });
+
+  test(R"(begin { @a = (uint32)1; @a = (int32)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignMapStatement(IntMapValue("@a", 8, true), _, _),
+                   AssignMapStatement(IntMapValue("@a", 8, true), _, _) })) });
+
+  test(R"(begin { @a = "hi"; @a = "hello world"; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { AssignMapStatement(Map("@a").WithType(StringTy(12)), _, _),
+             AssignMapStatement(Map("@a").WithType(StringTy(12)), _, _) })) });
+
+  // If/else with different types in branches (first assignment wins)
+  test(R"(begin { if (true) { @x = 10; } else { @x = "str"; } })", Error{});
+
+  test(R"(begin { if (true) { @x = (uint32)1; } else { @x = (uint64)2; } })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { ExprStatement(If(
+               _,
+               Block({ AssignMapStatement(IntMapValue("@x", 8), _, _) }),
+               Block(
+                   { AssignMapStatement(IntMapValue("@x", 8), _, _) }))) })) });
+
+  test(R"(begin { let $v; @a = $v; $v = 10; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$v", 1)),
+                   AssignMapStatement(IntMapValue("@a", 1), _, IntVar("$v", 1)),
+                   AssignVarStatement(IntVar("$v", 1), _) })) });
+
+  test(R"(begin { let $v; @a = $v + 10; $v = 5; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { VarDeclStatement(IntVar("$v", 1)),
+             AssignMapStatement(IntMapValue("@a", 8),
+                                _,
+                                Binop(Operator::PLUS, IntVar("$v", 1), _)),
+             AssignVarStatement(IntVar("$v", 1), _) })) });
+
+  test(R"(begin { @x = (uint32)1; } end { @x = (uint64)2; })",
+       ExpectedAST{ Program().WithProbes(
+           { Probe(_, { AssignMapStatement(IntMapValue("@x", 8), _, _) }),
+             Probe(_, { AssignMapStatement(IntMapValue("@x", 8), _, _) }) }) });
+}
+
+TEST_F(TypeGraphTest, map_key_basic)
+{
+  test(R"(begin { @a[1] = 2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignMapStatement(IntMapKey("@a", 1), _, _) })) });
+
+  test(
+      R"(begin { @a["key"] = 10; })",
+      ExpectedAST{ Program().WithProbe(Probe(
+          _,
+          { AssignMapStatement(Map("@a").WithKeyType(StringTy(4)), _, _) })) });
+
+  test(R"(begin { @a[1] = 1; @a[(uint64)2] = 2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignMapStatement(IntMapKey("@a", 8), _, _),
+                   AssignMapStatement(IntMapKey("@a", 8), _, _) })) });
+
+  test(R"(begin { @a[(uint32)1] = 1; @a[(int32)2] = 2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignMapStatement(IntMapKey("@a", 8, true), _, _),
+                   AssignMapStatement(IntMapKey("@a", 8, true), _, _) })) });
+
+  test(R"(begin { @a["hi"] = 1; @a["hello world"] = 2; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { AssignMapStatement(Map("@a").WithKeyType(StringTy(12)), _, _),
+             AssignMapStatement(
+                 Map("@a").WithKeyType(StringTy(12)), _, _) })) });
+
+  test(R"(begin { @x[(uint32)1] = 1; } end { @x[(uint64)2] = 2; })",
+       ExpectedAST{ Program().WithProbes(
+           { Probe(_, { AssignMapStatement(IntMapKey("@x", 8), _, _) }),
+             Probe(_, { AssignMapStatement(IntMapKey("@x", 8), _, _) }) }) });
+
+  test(R"(begin { let $k; @a[$k] = 1; $k = 10; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$k", 1)),
+                   AssignMapStatement(IntMapKey("@a", 1), IntVar("$k", 1), _),
+                   AssignVarStatement(IntVar("$k", 1), _) })) });
+
+  test(R"(begin { let $k; @a[$k + 10] = 1; $k = 5; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$k", 1)),
+                   AssignMapStatement(IntMapKey("@a", 8),
+                                      Binop(Operator::PLUS, IntVar("$k", 1), _),
+                                      _),
+                   AssignVarStatement(IntVar("$k", 1), _) })) });
+
+  test(R"(begin { @a[1] = 2; } end { @a["str"] = 1; })", Error{});
+}
+
+TEST_F(TypeGraphTest, variable_map_promotion)
+{
+  test(
+      R"(begin { $a = 1; @x = (uint32)1; $a = @x; @y = $a; } end { @x = (uint64)2; })",
+      ExpectedAST{ Program().WithProbes(
+          { Probe(_,
+                  { AssignVarStatement(IntVar("$a", 8), _),
+                    AssignMapStatement(IntMapValue("@x", 8), _, _),
+                    AssignVarStatement(IntVar("$a", 8),
+                                       MapAccess(IntMapValue("@x", 8), _)),
+                    AssignMapStatement(
+                        IntMapValue("@y", 8), _, IntVar("$a", 8)) }),
+            Probe(_, { AssignMapStatement(IntMapValue("@x", 8), _, _) }) }) });
+
+  test(
+      R"(begin { $a = 1; @x = (uint32)1; if comptime (typeinfo(@x).full_type == "uint64") { $a = (int16)2; } } end { @x = (uint64)2; })",
+      ExpectedAST{ Program().WithProbes(
+          { Probe(_,
+                  { AssignVarStatement(IntVar("$a", 2, true), _),
+                    AssignMapStatement(IntMapValue("@x", 8), _, _),
+                    _ }),
+            Probe(_, { AssignMapStatement(IntMapValue("@x", 8), _, _) }) }) });
+}
+
+TEST_F(TypeGraphTest, typeof)
+{
+  test(R"(begin { $a = (typeof(uint64))1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 8), _) })) });
+  test(R"(begin { let $b; $a = (typeof($b))1; $b = 1; $b = (uint64)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 8)),
+                   AssignVarStatement(IntVar("$a", 8), _),
+                   AssignVarStatement(IntVar("$b", 8), Integer(1)),
+                   AssignVarStatement(IntVar("$b", 8), _) })) });
+  test(
+      R"(begin { let $b; let $c; $a = (typeof($b))1; $b = (typeof($c))1; $c = (int64)2; })",
+      ExpectedAST{ Program().WithProbe(
+          Probe(_,
+                { VarDeclStatement(IntVar("$b", 8, true)),
+                  VarDeclStatement(IntVar("$c", 8, true)),
+                  AssignVarStatement(IntVar("$a", 8, true), _),
+                  AssignVarStatement(IntVar("$b", 8, true), _),
+                  AssignVarStatement(IntVar("$c", 8, true), _) })) });
+
+  test(R"(begin { @x = 2; $a = (typeof(@x))1; } end { @x = (int32)1; })",
+       ExpectedAST{ Program().WithProbes(
+           { Probe(_, { _, AssignVarStatement(IntVar("$a", 4, true), _) }),
+             Probe(_,
+                   { AssignMapStatement(
+                       IntMapValue("@x", 4, true), _, _) }) }) });
+  test(R"(begin { @x[(int16)1] = 1; $a = (typeof(@x))1; })",
+       ExpectedAST{ Program().WithProbes(
+           { Probe(_,
+                   { AssignMapStatement(IntMapKey("@x", 2, true), _, _),
+                     AssignVarStatement(IntVar("$a", 2, true), _) }) }) });
+
+  test(R"(begin { @x[(int16)1] = 1; $a = (typeof({ print(1); @x[0] }))1; })",
+       ExpectedAST{ Program().WithProbes(
+           { Probe(_,
+                   { AssignMapStatement(IntMapValue("@x", 1), _, _),
+                     AssignVarStatement(IntVar("$a", 1), _) }) }) });
+}
+
+TEST_F(TypeGraphTest, typeinfo)
+{
+  test(
+      R"(begin { $a = 1; $b = typeinfo($a); })",
+      ExpectedAST{ Program().WithProbe(Probe(
+          _,
+          { AssignVarStatement(IntVar("$a", 1), _),
+            AssignVarStatement(
+                Variable("$b").WithType(SizedType(Type::record)),
+                Record({ NamedArgument("btf_id", Integer(0)),
+                         NamedArgument("base_type", String("int")),
+                         NamedArgument("full_type", String("uint8")) })) })) });
+
+  test(R"(begin { $a = 1; $b = typeinfo({ $z = (uint64)2; $z }); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(IntVar("$a", 1), _),
+                   AssignVarStatement(
+                       Variable("$b").WithType(SizedType(Type::record)),
+                       Record({ NamedArgument("btf_id", Integer(0)),
+                                NamedArgument("base_type", String("int")),
+                                NamedArgument("full_type",
+                                              String("uint64")) })) })) });
+
+  test(R"(begin { let $a; $b = typeinfo($a); $a = (uint32)1; $a = (int32)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$a", 8, true)),
+                   AssignVarStatement(
+                       Variable("$b").WithType(SizedType(Type::record)),
+                       Record({ NamedArgument("btf_id", Integer(0)),
+                                NamedArgument("base_type", String("int")),
+                                NamedArgument("full_type", String("int64")) })),
+                   _,
+                   _ })) });
+
+  test(
+      R"(begin { let $a; $b = typeinfo($a); if comptime (true) { $a = (int64)2; } })",
+      ExpectedAST{ Program().WithProbe(
+          Probe(_,
+                { VarDeclStatement(IntVar("$a", 8, true)),
+                  AssignVarStatement(
+                      Variable("$b").WithType(SizedType(Type::record)),
+                      Record({ NamedArgument("btf_id", Integer(0)),
+                               NamedArgument("base_type", String("int")),
+                               NamedArgument("full_type", String("int64")) })),
+                  _ })) });
+
+  test(
+      R"(begin { @m[(int32)1] = 1; $b = typeinfo(@m); })",
+      ExpectedAST{ Program().WithProbe(Probe(
+          _,
+          { AssignMapStatement(IntMapKey("@m", 4, true), _, _),
+            AssignVarStatement(
+                Variable("$b").WithType(SizedType(Type::record)),
+                Record({ NamedArgument("btf_id", Integer(0)),
+                         NamedArgument("base_type", String("int")),
+                         NamedArgument("full_type", String("int32")) })) })) });
+
+  test(R"(begin { @m[(int64)1] = 1; $b = typeinfo(@m); })",
+       ExpectedAST{ Program().WithProbes(
+           { Probe(_,
+                   { _,
+                     AssignVarStatement(
+                         Variable("$b").WithType(SizedType(Type::record)),
+                         Record({ NamedArgument("btf_id", Integer(0)),
+                                  NamedArgument("base_type", String("int")),
+                                  NamedArgument("full_type",
+                                                String("int64")) })) }) }) });
+}
+
+TEST_F(TypeGraphTest, sizeof)
+{
+  test(R"(begin { $a = sizeof(uint64); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 1), Integer(8)) })) });
+
+  test(R"(begin { let $b; $a = sizeof($b); $b = (uint64)1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 8)),
+                   AssignVarStatement(IntVar("$a", 1), Integer(8)),
+                   AssignVarStatement(IntVar("$b", 8), _) })) });
+
+  test(R"(begin { let $b; $a = sizeof($b); $b = (uint32)1; $b = (uint64)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 8)),
+                   AssignVarStatement(IntVar("$a", 1), Integer(8)),
+                   AssignVarStatement(IntVar("$b", 8), _),
+                   AssignVarStatement(IntVar("$b", 8), _) })) });
+
+  test(R"(begin { @x = 2; $a = sizeof(@x); } end { @x = (int32)1; })",
+       ExpectedAST{ Program().WithProbes(
+           { Probe(_, { _, AssignVarStatement(IntVar("$a", 1), Integer(4)) }),
+             Probe(_,
+                   { AssignMapStatement(
+                       IntMapValue("@x", 4, true), _, _) }) }) });
+}
+
+TEST_F(TypeGraphTest, offsetof)
+{
+  test(R"(struct Foo { int x; long l; char c; }
+          begin { $a = offsetof(struct Foo, x); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 1), _) })) });
+
+  test(R"(struct Foo { int x; long l; char c; }
+          begin { $foo = (struct Foo *)0; $a = offsetof(*$foo, l); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { _, AssignVarStatement(IntVar("$a", 1), _) })) });
+
+  test(R"(struct Foo { int x; long l; }
+          struct Bar { struct Foo foo; int y; }
+          begin { $a = offsetof(struct Bar, foo.l); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 1), _) })) });
+}
+
+TEST_F(TypeGraphTest, tuple)
+{
+  test(R"(begin { $a = (1, 2); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::tuple)
+                                              .WithField("0", IntTy(1))
+                                              .WithField("1", IntTy(1))),
+                                      _) })) });
+
+  test(R"(begin { $a = (1, "hello"); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::tuple)
+                                              .WithField("0", IntTy(1))
+                                              .WithField("1", StringTy(6))),
+                                      _) })) });
+
+  test(R"(begin { let $b; $a = (1, $b); $b = (uint64)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 8)),
+                   AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::tuple)
+                                              .WithField("0", IntTy(1))
+                                              .WithField("1", IntTy(8))),
+                                      _),
+                   AssignVarStatement(IntVar("$b", 8), _) })) });
+
+  test(R"(begin { let $b; $a = ($b, 1); $b = "str"; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(_),
+                   AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::tuple)
+                                              .WithField("0", StringTy(4))
+                                              .WithField("1", IntTy(1))),
+                                      _),
+                   _ })) });
+
+  test(R"(begin { $b = 1; $a = ($b, (int16)1); $b = (uint64)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { _,
+                   AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::tuple)
+                                              .WithField("0", IntTy(8))
+                                              .WithField("1", IntTy(2, true))),
+                                      _),
+                   _ })) });
+
+  test(
+      R"(
+      begin { $a = (@b, @c[0], (typeof(@c))3, (typeof({ print(1); @b }))10); @b = 1; }
+      end { @c[(uint32)2] = "str"; @b = (int16)2; })",
+      ExpectedAST{ Program().WithProbes(
+          { Probe(_,
+                  { AssignVarStatement(Variable("$a").WithType(
+                                           SizedType(Type::tuple)
+                                               .WithField("0", IntTy(2, true))
+                                               .WithField("1", StringTy(4))
+                                               .WithField("2", IntTy(4))
+                                               .WithField("3", IntTy(2, true))),
+                                       _),
+                    _ }),
+            Probe(_, { _, _ }) }) });
+}
+
+TEST_F(TypeGraphTest, record)
+{
+  test(R"(begin { $a = ( x = 1, y = 2 ); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::record)
+                                              .WithField("x", IntTy(1))
+                                              .WithField("y", IntTy(1))),
+                                      _) })) });
+
+  test(R"(begin { $a = ( name = "hello", count = 42 ); })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::record)
+                                              .WithField("name", StringTy(6))
+                                              .WithField("count", IntTy(1))),
+                                      _) })) });
+
+  test(R"(begin { let $b; $a = ( x = 1, y = $b ); $b = (uint64)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(IntVar("$b", 8)),
+                   AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::record)
+                                              .WithField("x", IntTy(1))
+                                              .WithField("y", IntTy(8))),
+                                      _),
+                   _ })) });
+
+  test(R"(begin { let $b; $a = ( s = $b, n = 1 ); $b = "str"; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { VarDeclStatement(_),
+                   AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::record)
+                                              .WithField("s", StringTy(4))
+                                              .WithField("n", IntTy(1))),
+                                      _),
+                   _ })) });
+
+  test(R"(begin { $b = 1; $a = ( x = $b, y = (int16)1 ); $b = (uint64)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { _,
+                   AssignVarStatement(Variable("$a").WithType(
+                                          SizedType(Type::record)
+                                              .WithField("x", IntTy(8))
+                                              .WithField("y", IntTy(2, true))),
+                                      _),
+                   _ })) });
+
+  test(
+      R"(
+      begin { $a = (a=@b, b=@c[0], c=(typeof(@c))3, d=(typeof({ print(1); @b }))10); @b = 1; }
+      end { @c[(uint32)2] = "str"; @b = (int16)2; })",
+      ExpectedAST{ Program().WithProbes(
+          { Probe(_,
+                  { AssignVarStatement(Variable("$a").WithType(
+                                           SizedType(Type::record)
+                                               .WithField("a", IntTy(2, true))
+                                               .WithField("b", StringTy(4))
+                                               .WithField("c", IntTy(4))
+                                               .WithField("d", IntTy(2, true))),
+                                       _),
+                    _ }),
+            Probe(_, { _, _ }) }) });
+
+  auto $a_assign_stmt = AssignVarStatement(
+      Variable("$a").WithType(SizedType(Type::record)
+                                  .WithField("a", IntTy(8, true))
+                                  .WithField("b", StringTy(10))
+                                  .WithField("c", IntTy(4))
+                                  .WithField("d", IntTy(2, true))),
+      _);
+  test(
+      R"(
+      begin {
+        $a = (d=1, c=2, b="longerstr", a=(int64)1);
+        $a = (a=@b, b=@c[0], c=(typeof(@c))3, d=(typeof({ print(1); @b }))10); @b = 1;
+      }
+      end { @c[(uint32)2] = "str"; @b = (int16)2; })",
+      ExpectedAST{ Program().WithProbes(
+          { Probe(_, { $a_assign_stmt, $a_assign_stmt, _ }),
+            Probe(_, { _, _ }) }) });
+}
+
+TEST_F(TypeGraphTest, comptime)
+{
+  test(
+      R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { $c = (int64)2; } $a = (uint64)2; })",
+      ExpectedAST{ Program().WithProbe(
+          Probe(_,
+                { VarDeclStatement(IntVar("$c", 8, true)),
+                  AssignVarStatement(IntVar("$a", 8), _),
+                  ExprStatement(
+                      Block({ AssignVarStatement(IntVar("$c", 8, true), _) })),
+                  AssignVarStatement(IntVar("$a", 8), _) })) });
+
+  test(
+      R"(begin { let $c; $a = 1; if comptime (typeinfo(sizeof($a)).base_type == "int") { $c = (int64)2; } $a = (uint64)2; })",
+      ExpectedAST{ Program().WithProbe(
+          Probe(_,
+                { VarDeclStatement(IntVar("$c", 8, true)),
+                  AssignVarStatement(IntVar("$a", 8), _),
+                  ExprStatement(
+                      Block({ AssignVarStatement(IntVar("$c", 8, true), _) })),
+                  AssignVarStatement(IntVar("$a", 8), _) })) });
+
+  test(
+      R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { let $d; if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $d = (int64)2; } $a = (uint64)2; })",
+      ExpectedAST{ Program().WithProbe(
+          Probe(_, { VarDeclStatement(IntVar("$c", 2, true)), _, _, _ })) });
+
+  test(
+      R"(begin { let $c; let $e; let $d; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $e = (int32)1; } $a = (uint64)2; if comptime (typeinfo($e).full_type == "int32") { $d = (int64)3; } })",
+      ExpectedAST{ Program().WithProbe(Probe(
+          _, { VarDeclStatement(IntVar("$c", 2, true)), _, _, _, _, _, _ })) });
+
+  test(
+      R"(begin { let $c; if comptime (typeinfo($c).base_type == "int") { 1 } })",
+      Error{ R"(
+ERROR: Unable to resolve comptime expression
+begin { let $c; if comptime (typeinfo($c).base_type == "int") { 1 } }
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)" });
+
+  test(
+      R"(begin { let $c; if comptime (typeinfo({ let $x = $c; $x }).full_type == "uint32") { $c = (uint64)2; } $c = (uint32)1; })",
+      Error{});
+  test(
+      R"(begin { @x = 1; if comptime (typeinfo(@y[1]).full_type == "uint64") { @x = (int32)2; } } end { @y[1] = (uint64)2; })",
+      ExpectedAST{ Program().WithProbes(
+          { Probe(_,
+                  { AssignMapStatement(IntMapValue("@x", 4, true), _, _), _ }),
+            Probe(_, { AssignMapStatement(IntMapValue("@y", 8), _, _) }) }) });
+  test(
+      R"(begin { @x = 1; if comptime (typeinfo(@y[1]).full_type != "uint64") { @x = (int32)2; } } end { @y[1] = (uint64)2; })",
+      ExpectedAST{ Program().WithProbes(
+          { Probe(_, { AssignMapStatement(IntMapValue("@x", 1), _, _) }),
+            Probe(_, { AssignMapStatement(IntMapValue("@y", 8), _, _) }) }) });
+}
+
+TEST_F(TypeGraphTest, locked_types)
+{
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = 2; } @a = (uint32)1; })");
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[2] = 2; } @a[(uint32)1] = 1; })");
+  test(
+      R"(begin { let $c; if comptime (typeinfo($c).full_type == "uint32") { $c = (uint16)2; } $c = (uint32)1; })");
+
+  test(
+      R"(begin { let $c; if comptime (typeinfo($c).full_type == "uint32") { $c = (uint64)2; } $c = (uint32)1; })",
+      Error{});
+
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = (uint64)2; } @a = (uint32)1; })",
+      Error{});
+
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[(uint64)2] = 2; } @a[(uint32)1] = 1; })",
+      Error{ R"(
+ERROR: Type mismatch for @a: this type has been locked because it was used in another part of the type graph that was already resolved (e.g. `sizeof`, `typeinfo`, etc.). The new type 'uint64' doesn't fit into the locked type 'uint32'
+begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[(uint64)2] = 2; } @a[(uint32)1] = 1; }
+                                                           ~~~~~~~~~~~~~
+)" });
+}
+
+TEST_F(TypeGraphTest, variable_addr)
+{
+  test(R"(begin { $a = 1; $b = &$a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { _,
+                   AssignVarStatement(
+                       Variable("$b").WithType(
+                           SizedType(Type::pointer).WithElement(IntTy(1))),
+                       _) })) });
+
+  test(R"(begin { $a = "str"; $b = &$a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { _,
+                   AssignVarStatement(
+                       Variable("$b").WithType(
+                           SizedType(Type::pointer).WithElement(StringTy(4))),
+                       _) })) });
+
+  test(R"(begin { let $a; $b = &$a; $a = (uint64)1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { _,
+                   AssignVarStatement(
+                       Variable("$b").WithType(
+                           SizedType(Type::pointer).WithElement(IntTy(8))),
+                       _),
+                   _ })) });
+
+  // Same source and a promotion - ok
+  test(R"(begin { $a = (uint32)2; $b = &$a; $a = (int32)1; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { _,
+             AssignVarStatement(
+                 Variable("$b").WithType(
+                     SizedType(Type::pointer).WithElement(IntTy(8, true))),
+                 _),
+             _ })) });
+  test(R"(begin { $a = (uint32)2; @b = &$a; $a = (int32)1; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { _,
+             AssignMapStatement(
+                 Map("@b").WithType(
+                     SizedType(Type::pointer).WithElement(IntTy(8, true))),
+                 _,
+                 _),
+             _ })) });
+  test(R"(begin { $a = (uint32)2; @b[&$a] = 1; $a = (int32)1; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { _,
+             AssignMapStatement(
+                 Map("@b").WithKeyType(
+                     SizedType(Type::pointer).WithElement(IntTy(8, true))),
+                 _,
+                 _),
+             _ })) });
+
+  // Two different sources of different sizes - not ok
+  test(R"(begin { $a = (int16)2; $b = &$a; $c = (int32)1; $b = &$c; })",
+       Error{});
+  test(R"(begin { $a = (int16)2; @b = &$a; $c = (int32)1; @b = &$c; })",
+       Error{});
+  test(R"(begin { $a = (int16)2; @b[&$a] = 1; $c = (int32)1; @b[&$c] = 1; })",
+       Error{});
+
+  // Two different sources and same size - ok
+  test(R"(begin { $a = (int16)2; $b = &$a; $c = (int16)1; $b = &$c; })");
+  test(R"(begin { $a = (int16)2; @b = &$a; $c = (int16)1; @b = &$c; })");
+  test(R"(begin { $a = (int16)2; @b[&$a] = 1; $c = (int16)1; @b[&$c] = 1; })");
+
+  // Two different sources and a promotion - not ok
+  test(
+      R"(begin { $a = (int16)2; $b = &$a; $c = (int16)1; $b = &$c; $a = (int32)3; })",
+      Error{});
+  test(
+      R"(begin { $a = (int16)2; @b = &$a; $c = (int16)1; @b = &$c; $a = (int32)3; })",
+      Error{});
+  test(
+      R"(begin { $a = (int16)2; @b[&$a] = 1; $c = (int16)1; @b[&$c] = 1; $a = (int32)3; })",
+      Error{});
+}
+
+TEST_F(TypeGraphTest, map_addr)
+{
+  test(R"(begin { @a = 1; $b = &@a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { _,
+                   AssignVarStatement(
+                       Variable("$b").WithType(
+                           SizedType(Type::pointer).WithElement(IntTy(1))),
+                       _) })) });
+
+  test(R"(begin { @a = "str"; $b = &@a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { _,
+                   AssignVarStatement(
+                       Variable("$b").WithType(
+                           SizedType(Type::pointer).WithElement(StringTy(4))),
+                       _) })) });
+
+  test(R"(begin { $b = &@a; @a = (uint64)1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignVarStatement(
+                       Variable("$b").WithType(
+                           SizedType(Type::pointer).WithElement(IntTy(8))),
+                       _),
+                   _ })) });
+
+  // Same source and a promotion - ok
+  test(R"(begin { @a = (int32)1; $b = &@a; @a = (uint32)1; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { _,
+             AssignVarStatement(
+                 Variable("$b").WithType(
+                     SizedType(Type::pointer).WithElement(IntTy(8, true))),
+                 _),
+             _ })) });
+  test(R"(begin { @a = (int32)1; @b = &@a; @a = (uint32)1; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { _,
+             AssignMapStatement(
+                 Map("@b").WithType(
+                     SizedType(Type::pointer).WithElement(IntTy(8, true))),
+                 _,
+                 _),
+             _ })) });
+  test(R"(begin { @a = (int32)1; @b[&@a] = 1; @a = (uint32)1; })",
+       ExpectedAST{ Program().WithProbe(Probe(
+           _,
+           { _,
+             AssignMapStatement(
+                 Map("@b").WithKeyType(
+                     SizedType(Type::pointer).WithElement(IntTy(8, true))),
+                 _,
+                 _),
+             _ })) });
+
+  // Two different sources of different sizes - not ok
+  test(R"(begin { @a = (int16)2; $b = &@a; @c = (int32)1; $b = &@c; })",
+       Error{});
+  test(R"(begin { @a = (int16)2; @b = &@a; @c = (int32)1; @b = &@c; })",
+       Error{});
+  test(R"(begin { @a = (int16)2; @b[&@a] = 1; @c = (int32)1; @b[&@c] = 1; })",
+       Error{});
+
+  // Two different sources and same size - ok
+  test(R"(begin { @a = (int16)2; $b = &@a; @c = (int16)1; $b = &@c; })");
+  test(R"(begin { @a = (int16)2; @b = &@a; @c = (int16)1; @b = &@c; })");
+  test(R"(begin { @a = (int16)2; @b[&@a] = 1; @c = (int16)1; @b[&@c] = 1; })");
+
+  // Two different sources and a promotion - not ok
+  test(
+      R"(begin { @a = (int16)2; $b = &@a; $c = (int16)1; $b = &$c; @a = (int32)3; })",
+      Error{});
+  test(
+      R"(begin { @a = (int16)2; @b = &@a; $c = (int16)1; @b = &$c; @a = (int32)3; })",
+      Error{});
+  test(
+      R"(begin { @a = (int16)2; @b[&@a] = 1; $c = (int16)1; @b[&$c] = 1; @a = (int32)3; })",
+      Error{});
+}
+
+TEST_F(TypeGraphTest, unop)
+{
+  test(R"(begin { @a = (int16)2; ++@a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_,
+                 { AssignMapStatement(IntMapValue("@a", 8, true), _, _),
+                   ExprStatement(Unop(Operator::PRE_INCREMENT, _)
+                                     .WithType(IntTy(8, true))) })) });
+
+  test(R"(begin { ++@a; $b = @a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { _, AssignVarStatement(IntVar("$b", 8, true), _) })) });
+
+  test(R"(begin { $a = 1; ++$a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 8, true), _), _ })) });
+
+  test(R"(begin { ++$a; $a = 1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { _, AssignVarStatement(IntVar("$a", 8, true), _) })) });
+
+  test(R"(begin { let $a; ++$a; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { VarDeclStatement(IntVar("$a", 8, true)), _ })) });
+
+  test(R"(begin { $a = 1; $b = &$a; $c = *$b; $a = (uint32)2; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { _, _, AssignVarStatement(IntVar("$c", 4), _), _ })) });
+
+  // Errors
+  test(R"(begin { ++@a; @a = "hello"; })", Error{});
+  test(R"(begin { ++$a; $a = "hello"; })", Error{});
+}
+
+TEST_F(TypeGraphTest, builtin)
+{
+  // Just a few basic sanity tests
+  test(R"(begin { $a = pid; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 4), _) })) });
+
+  test(R"(begin { $a = __builtin_cpu; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 8), _) })) });
+}
+
+TEST_F(TypeGraphTest, tuple_access)
+{
+  test(R"(begin { $a = (1, 2).0; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { AssignVarStatement(IntVar("$a", 1), _) })) });
+
+  test(R"(begin { $b = (1, (int64)2); $a = $b.1; })",
+       ExpectedAST{ Program().WithProbe(
+           Probe(_, { _, AssignVarStatement(IntVar("$a", 8, true), _) })) });
+}
+
+TEST_F(TypeGraphTest, jordan)
+{
+  //
+}
+
+} // namespace bpftrace::test::type_graph

--- a/type_dependency_graph.md
+++ b/type_dependency_graph.md
@@ -1,0 +1,194 @@
+# Variables
+
+## Case 1
+
+let $x: uint32 = $y;
+
+$y = (uint32)2;
+
+$y = (uint64)3;
+
+**Result**: Error
+**Reason**: Because $y was promoted to a uint64 but $x has a concrete type of uint32 and can't be resized
+
+## Case 2
+
+let $x: uint32 = $y;
+
+$y = (uint8)2;
+$y = (uint16)3;
+
+**Result**: Success
+**Reason**: Because $y was promoted to a uint16 which fits into uint32, the concrete type of $x
+
+## Case 3
+
+let $x;
+let $y;
+
+$x = $y;
+$y = $x;
+
+**Result**: Error
+**Reason**: Cyclic type dependency
+
+## Case 4
+
+$x = $y + 1;
+
+$y = (uint32)1;
+$y = (uint64)2;
+
+**Result**: Success
+**Reason**: Both $x and $y are of type uint64
+
+## Case 5
+
+let $a;
+let $x: typeof($a) = (uint64)10;
+
+$a = (uint16)1;
+$a = (uint32)2;
+
+**Result**: Error
+**Reason**: $a gets promoted to a uint32 so the `typeof($a)` resolves to a uint32 making the type of $x a concrete type of uint32 so the assignment on the right of a uint64 is invalid.
+
+## Case 6
+
+let $a;
+let $x: uint32 = (typeof($a))10;
+
+$a = (uint16)1;
+$a = (uint64)2;
+
+**Result**: Error
+**Reason**: $a gets promoted to a uint64 so the `typeof($a)` cast resolves to a uint64 which is incompatible with the concrete type of $x which is uint32
+
+## Case 6
+
+let $a;
+let $x = (typeof($a))10;
+
+$a = (uint64)2;
+
+**Result**: Success
+**Reason**: $a gets promoted to a uint64 so the `typeof($a)` cast resolves to a uint64 so the type of $x is a uint64
+
+## Case 7
+
+let $a;
+let $b;
+
+if comptime typeinfo($b).base_ty == "str" {
+    $a = "hello";
+} else {
+    $a = 1;
+}
+
+$b = 1;
+
+**Result**: Success
+**Reason**: The type of $a is a uint8 because `typeinfo($b).base_ty` resolves to "int" which is not equal to "str" so the else branch is taken assigning 1 to $a which is a uint8
+
+## Case 8
+
+let $a;
+let $b;
+
+if comptime typeinfo($b).base_ty == "str" {
+    $a = "hello";
+} else {
+    $a = 1;
+    $b = 1;
+}
+
+**Result**: Error
+**Reason**: Because we never can resolve the type of $b because the assignment to $b is nested in a comptime branch that depends on knowing the type of $b
+
+## Case 9
+
+let $b;
+
+if comptime typeinfo($b).full_type == "uint32" {
+    $b = (uint64)1;
+}
+
+$b = (uint32)2;
+
+
+**Result**: Error
+**Reason**: Because in order to resolve the comptime expression and visit `$b = (uint64)1` we need the final type of `$b` but the type is changed from a uint32 to a uint64 in this nested assignment.
+
+## Case 10
+
+let $a;
+$b = $a;
+$c = (typeof($b))"reallylongstr";
+
+$a = "hi";
+
+**Result**: Error
+**Reason**: Because $a resolves to a string[2] type making $b also have a type of string[2] therefore the cast expression resolve to `(string[2])"reallylongstr"` which is invalid because you can't cast a long string to a shorter string
+
+
+## Case 11
+
+let $b;
+
+if comptime typeinfo($b).full_type == "uint32" {
+    $b = (uint64)1;
+}
+
+**Result**: Error
+**Reason**: We can't resolve the type of $b without evaluating the comptime branch which we can't do unless we know the type of $b
+
+
+## Case 12
+
+let $b;
+let $a = (uint32)1;
+
+if comptime typeinfo($a).full_type == "uint32" {
+    $b = (uint64)1;
+}
+
+$z = $b;
+
+**Result**: Success
+**Reason**: We can resolve the comptime expression which then visits the branch which resolves the type of $b and then $z;
+
+## Case 13
+
+let $b;
+let $a = (uint32)1;
+
+if comptime true {
+    $b = (uint64)1;
+}
+
+$z = $b;
+
+**Result**: Success
+**Reason**: We're able to resolve the comptime in the first pass so we can set the type of $b and $z.
+
+## Case 14
+
+$b = 2;
+$z = (uint32)1;
+
+if comptime typeinfo($z).full_type == "uint32" {
+    $b = (uint64)1;
+}
+
+$z = $b;
+
+**Result**: Error
+**Reason**: $z becomes locked/stable to uint32 so when $b is updated to a uint64 and then tries to update the type of $z it's invalid
+
+
+$a = 1;
+$a = (uint32)2;
+$a = "str";
+
+[1].push($a); [$a].push(1);
+[(uint32)2].push($a);


### PR DESCRIPTION
This moves more checks that don't involve types before the type resolving
and checking passes. It adds more visitors to the variable_precheck and
changes the name of this pass to be more general: pre_type_check.

The primary motivation is to have error messages surface earlier so we
don't have to deal with certain error path scenarios (like function
argument count validation) in type passes.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
