### PR TITLE
getopt: allow declaration as map decls

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -117,6 +117,12 @@ Here `getopt("aa", 1)` would evaluate to `20` and `getopt("bb")` would evaluate 
 
 Named parameters require the `=` to set their value unless they are boolean parameters (like 'bb' above). The supported types are string, number, and boolean.
 
+Named parameters can also be used in map declarations, e.g.,
+```
+# bpftrace -e 'let @a = getopt("aa", 1); begin { print(@a); }' -- --aa
+```
+Here, `@a` will have the constant value `true`, and can be used anywhere in the program.
+
 ### Positional Parameters
 
 Positional parameters can be accessed in a bpftrace program via, what looks like, a numbered scratch variable, e.g. `$1`, `$2`, ..., `$N`. So `$1` would be the first positional parameter and so on.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -341,6 +341,7 @@ Name of the current function being traced (kprobes,uprobes,fentry)
 Get the named command line argument/option e.g.
 ```
 # bpftrace -e 'BEGIN { print(getopt("hello", 1)); }' -- --hello=5
+# bpftrace -e 'let @hello = getopt("hello", 1); BEGIN { print(@hello); }' -- --hello=5
 
 ```
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -859,38 +859,32 @@ class MapDeclStatement : public Node {
 public:
   explicit MapDeclStatement(ASTContext &ctx,
                             Location &&loc,
-                            std::string ident,
-                            std::string bpf_type,
-                            int max_entries)
+                            std::string  ident,
+                            Call *call)
       : Node(ctx, std::move(loc)),
         ident(std::move(ident)),
-        bpf_type(std::move(bpf_type)),
-        max_entries(max_entries) {};
+        call(call) {};
   explicit MapDeclStatement(ASTContext &ctx,
                             const Location &loc,
                             const MapDeclStatement &other)
       : Node(ctx, loc + other.loc),
         ident(other.ident),
-        bpf_type(other.bpf_type),
-        max_entries(other.max_entries) {};
+        call(clone(ctx, loc, other.call)) {};
 
   bool operator==(const MapDeclStatement &other) const
   {
-    return ident == other.ident && bpf_type == other.bpf_type &&
-           max_entries == other.max_entries;
+    return ident == other.ident && *call == *other.call;
   }
   std::strong_ordering operator<=>(const MapDeclStatement &other) const
   {
-    if (auto cmp = ident <=> other.ident; cmp != 0)
+    if (auto cmp = ident <=> other.ident; cmp != 0) {
       return cmp;
-    if (auto cmp = bpf_type <=> other.bpf_type; cmp != 0)
-      return cmp;
-    return max_entries <=> other.max_entries;
+    }
+    return *call <=> *other.call;
   }
 
   const std::string ident;
-  const std::string bpf_type;
-  const int max_entries;
+  Call *call;
 };
 using MapDeclList = std::vector<MapDeclStatement *>;
 

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -4,6 +4,7 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/visitor.h"
+#include "types.h"
 
 namespace bpftrace::ast {
 
@@ -179,7 +180,7 @@ void MapDefaultKey::visit(Statement &stmt)
   // Replace with a statement that has the default index, in the same way as
   // above. This will be type-checked in a later pass.
   if (auto *map = stmt.as<AssignScalarMapStatement>()) {
-    auto *index = ast_.make_node<Integer>(map->loc, 0, CreateInt64());
+    auto *index = ast_.make_node<Integer>(map->loc, 0);
     auto *acc = ast_.make_node<MapAccess>(map->loc, map->map, index);
     stmt.value = ast_.make_node<AssignMapStatement>(map->loc, acc, map->expr);
   }

--- a/src/ast/passes/named_param.cpp
+++ b/src/ast/passes/named_param.cpp
@@ -1,75 +1,107 @@
+
 #include "ast/passes/named_param.h"
+
 #include "ast/ast.h"
+#include "ast/clone.h"
 #include "ast/context.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
 
 namespace bpftrace::ast {
 
-class NamedParamPass : public Visitor<NamedParamPass> {
+class NamedParamPass : public Visitor<NamedParamPass, MapAccess *> {
 public:
   NamedParamPass(ASTContext &ast, BPFtrace &bpftrace)
       : ast_(ast), bpftrace_(bpftrace) {};
 
-  using Visitor<NamedParamPass>::visit;
-  void visit(Expression &expr);
+  using Visitor<NamedParamPass, MapAccess *>::visit;
+  MapAccess *visit(Expression &expr);
+  MapAccess *visit(Call &call);
+  MapAccess *visit(MapDeclStatement &map_decl);
+  MapAccess *visit(Program &program);
 
   std::unordered_map<std::string, globalvars::GlobalVarValue> used_args;
   NamedParamDefaults defaults;
+  std::map<std::string, MapAccess *> map_rewrites;
 
 private:
   ASTContext &ast_;
   BPFtrace &bpftrace_;
 };
 
-void NamedParamPass::visit(Expression &expr)
+class MapRewriter : public Visitor<MapRewriter> {
+public:
+  explicit MapRewriter(ASTContext &ast,
+                       std::map<std::string, MapAccess *> map_rewrites)
+      : ast_(ast), map_rewrites(std::move(map_rewrites)) {};
+
+  using Visitor<MapRewriter>::visit;
+  void visit(Expression &expr);
+  void visit(MapAccess &map_access);
+  void visit(AssignMapStatement &map_assign);
+
+private:
+  ASTContext &ast_;
+  std::map<std::string, MapAccess *> map_rewrites;
+};
+
+MapAccess *NamedParamPass::visit(Expression &expr)
 {
-  auto *call = expr.as<Call>();
-  if (!call || call->func != "getopt") {
-    Visitor<NamedParamPass>::visit(expr);
-    return;
+  auto *access = Visitor<NamedParamPass, MapAccess *>::visit(expr);
+  if (access) {
+    expr.value = access;
+  }
+  return nullptr;
+}
+
+MapAccess *NamedParamPass::visit(Call &call)
+{
+  Visitor<NamedParamPass, MapAccess *>::visit(call);
+
+  if (call.func != "getopt") {
+    return nullptr;
   }
 
-  auto *arg_name = call->vargs.at(0).as<String>();
+  auto *arg_name = call.vargs.at(0).as<String>();
   if (!arg_name) {
-    call->vargs.at(0).node().addError()
+    call.vargs.at(0).node().addError()
         << "First argument to 'getopt' must be a string literal.";
-    return;
+    return nullptr;
   }
 
-  if (call->vargs.size() == 2) {
-    if (!call->vargs.at(1).as<Integer>() &&
-        !call->vargs.at(1).as<NegativeInteger>() &&
-        !call->vargs.at(1).as<String>() && !call->vargs.at(1).as<Boolean>()) {
-      call->vargs.at(1).node().addError()
+  if (call.vargs.size() == 2) {
+    if (!call.vargs.at(1).as<Integer>() &&
+        !call.vargs.at(1).as<NegativeInteger>() &&
+        !call.vargs.at(1).as<String>() && !call.vargs.at(1).as<Boolean>()) {
+      call.vargs.at(1).node().addError()
           << "Second argument to 'getopt' must be a string literal, integer "
              "literal, or a boolean literal.";
-      return;
+      return nullptr;
     }
   }
 
   globalvars::GlobalVarValue np_default;
 
-  auto *map_node = ast_.make_node<Map>(call->loc, arg_name->value);
+  auto *map_node = ast_.make_node<Map>(call.loc, arg_name->value);
   map_node->key_type = CreateInt64();
 
-  if (call->vargs.size() == 1) {
+  if (call.vargs.size() == 1) {
     // boolean
     map_node->value_type = CreateBool();
     np_default = false;
-  } else if (auto *default_value = call->vargs.at(1).as<Boolean>()) {
+  } else if (auto *default_value = call.vargs.at(1).as<Boolean>()) {
     // boolean
     map_node->value_type = CreateBool();
     np_default = default_value->value;
-  } else if (auto *default_value = call->vargs.at(1).as<String>()) {
+  } else if (auto *default_value = call.vargs.at(1).as<String>()) {
     // string
     map_node->value_type = CreateString(bpftrace_.config_->max_strlen);
     np_default = default_value->value;
-  } else if (auto *default_value = call->vargs.at(1).as<Integer>()) {
+  } else if (auto *default_value = call.vargs.at(1).as<Integer>()) {
     // unsigned integer
     map_node->value_type = CreateUInt64();
     np_default = default_value->value;
-  } else if (auto *default_value = call->vargs.at(1).as<NegativeInteger>()) {
+  } else if (auto *default_value = call.vargs.at(1).as<NegativeInteger>()) {
     // signed integer
     map_node->value_type = CreateInt64();
     np_default = default_value->value;
@@ -91,18 +123,85 @@ void NamedParamPass::visit(Expression &expr)
       pre_value = std::get<bool>(used_args.at(arg_name->value)) ? "true"
                                                                 : "false";
     }
-    call->addError() << "Command line option '" << arg_name->value
-                     << "' needs to have the same default value in all places "
-                        "it is used. Previous default value: "
-                     << pre_value;
-    return;
+    call.addError() << "Command line option '" << arg_name->value
+                    << "' needs to have the same default value in all places "
+                       "it is used. Previous default value: "
+                    << pre_value;
+    return nullptr;
   }
 
   auto *index = ast_.make_node<Integer>(map_node->loc, 0);
-  expr.value = ast_.make_node<MapAccess>(map_node->loc, map_node, index);
+  auto *access = ast_.make_node<MapAccess>(map_node->loc, map_node, index);
 
   used_args[arg_name->value] = np_default;
   defaults.defaults[arg_name->value] = std::move(np_default);
+  return access;
+}
+
+MapAccess *NamedParamPass::visit(MapDeclStatement &map_decl)
+{
+  auto *access = visit(map_decl.call);
+  if (access) {
+    // Record the renaming for below.
+    map_rewrites[map_decl.ident] = access;
+  }
+  return nullptr;
+}
+
+MapAccess *NamedParamPass::visit(Program &program)
+{
+  Visitor<NamedParamPass, MapAccess *>::visit(program);
+
+  // Remove all explicit declarations for getopt maps.
+  std::erase_if(program.map_decls, [](auto *map_decl) {
+    return map_decl->call->func == "getopt";
+  });
+  return nullptr;
+}
+
+void MapRewriter::visit(Expression &expr)
+{
+  Visitor<MapRewriter>::visit(expr);
+
+  // The naked map expression can come up in e.g. print(...) statements,
+  // and still needs to be rewritten to be the scalar value. It is basically
+  // always flattened, unlike other maps which are only mostly flattened.
+  if (auto *map = expr.as<Map>()) {
+    auto it = map_rewrites.find(map->ident);
+    if (it != map_rewrites.end()) {
+      expr.value = clone(ast_, map->loc, it->second);
+    }
+  }
+}
+
+void MapRewriter::visit(MapAccess &map_access)
+{
+  // We validate that this has been desugared in a way that we
+  // expect for a scalar map access, and then we simply replace
+  // the map name with the generated name for the getopt variable.
+  auto it = map_rewrites.find(map_access.map->ident);
+  if (it != map_rewrites.end()) {
+    if (map_access.key != it->second->key) {
+      map_access.addError() << "getopt map access must be scalar";
+    } else {
+      // The key is already the same, we can just update the
+      // map entry to be the map entry of the getopt map.
+      map_access.map = clone(ast_, map_access.map->loc, it->second->map);
+    }
+  }
+
+  Visitor<MapRewriter>::visit(map_access);
+}
+
+void MapRewriter::visit(AssignMapStatement &map_assign)
+{
+  // Option maps must not be written to; they are fixed.
+  auto it = map_rewrites.find(map_assign.map_access->map->ident);
+  if (it != map_rewrites.end()) {
+    map_assign.addError() << "getopt map is immutable";
+  }
+
+  Visitor<MapRewriter>::visit(map_assign);
 }
 
 Pass CreateNamedParamsPass()
@@ -110,7 +209,8 @@ Pass CreateNamedParamsPass()
   auto fn = [](ASTContext &ast, BPFtrace &b) -> Result<NamedParamDefaults> {
     NamedParamPass np_pass(ast, b);
     np_pass.visit(ast.root);
-
+    MapRewriter map_rewriter(ast, std::move(np_pass.map_rewrites));
+    map_rewriter.visit(ast.root);
     return std::move(np_pass.defaults);
   };
 

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -517,16 +517,14 @@ Buffer Formatter::visit(Typeinfo& typeinfo)
 
 Buffer Formatter::visit(MapDeclStatement& decl)
 {
-  std::stringstream bpf_type;
-  bpf_type << decl.bpf_type;
+  auto expr = format(
+      *decl.call, metadata, max_width - 8 - decl.ident.size(), true);
   return Buffer()
       .text("let ")
       .text(decl.ident)
       .text(" = ")
-      .text(bpf_type.str())
-      .text("(")
-      .text(std::to_string(decl.max_entries))
-      .text(");");
+      .append(std::move(expr))
+      .text(";");
 }
 
 Buffer Formatter::visit(Map& map)

--- a/src/ast/passes/type_checker.cpp
+++ b/src/ast/passes/type_checker.cpp
@@ -788,16 +788,10 @@ Probe *TypeChecker::get_probe()
 
 void TypeChecker::visit(MapDeclStatement &decl)
 {
-  const auto bpf_type = get_bpf_map_type(decl.bpf_type);
-  if (!bpf_type) {
-    auto &err = decl.addError();
-    err << "Invalid bpf map type: " << decl.bpf_type;
-    auto &hint = err.addHint();
-    add_bpf_map_types_hint(hint);
-  } else {
-    bpf_map_type_.insert({ decl.ident, *bpf_type });
-  }
-
+  // N.B. We do not specifically visit the call for this
+  // map declaration, as this will be done later on by the
+  // resource analyser pass (which instantiates the map).
+  // The only thing we check for is unreferenced maps.
   map_decls_.insert({ decl.ident, &decl });
 }
 

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -101,6 +101,8 @@ public:
   }
   R visit([[maybe_unused]] MapDeclStatement &decl)
   {
+    // This isn't a regular expression, and therefore the call
+    // will not be visited unless specifically overrden.
     return default_value();
   }
   R visit([[maybe_unused]] Map &map)

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -617,7 +617,7 @@ assign_stmt:
         ;
 
 map_decl_stmt:
-                LET MAP ASSIGN IDENT LPAREN integer RPAREN ";" { $$ = driver.ctx.make_node<ast::MapDeclStatement>(@$, $2, $4, $6->value); }
+                LET MAP ASSIGN call_expr ";" { $$ = driver.ctx.make_node<ast::MapDeclStatement>(@$, $2, $4); }
         ;
 
 var_decl_stmt:

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -397,6 +397,7 @@ macro func()
 // Get the named command line argument/option e.g.
 // ```
 // # bpftrace -e 'BEGIN { print(getopt("hello", 1)); }' -- --hello=5
+// # bpftrace -e 'let @hello = getopt("hello", 1); BEGIN { print(@hello); }' -- --hello=5
 //
 // ```
 //

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -1261,28 +1261,20 @@ inline StatementImportMatcher StatementImport(const std::string& name)
 class MapDeclStatementMatcher
     : public NodeMatcher<MapDeclStatementMatcher, ast::MapDeclStatement> {
 public:
-  MapDeclStatementMatcher& WithBpfType(const std::string& bpf_type)
+  MapDeclStatementMatcher& WithCall(const Matcher<const ast::Call&>& call_matcher)
   {
-    return Where(
-        CheckField(&ast::MapDeclStatement::bpf_type, bpf_type, "BPF type"));
-  }
-
-  MapDeclStatementMatcher& WithMaxEntries(int max_entries)
-  {
-    return Where(CheckField(&ast::MapDeclStatement::max_entries,
-                            max_entries,
-                            "max entries"));
+    return Where([call_matcher](const ast::MapDeclStatement& node) {
+      return MatchWith(node, call_matcher, *node.call);
+    });
   }
 };
 
 inline MapDeclStatementMatcher MapDeclStatement(const std::string& ident,
-                                                const std::string& bpf_type,
-                                                int max_entries)
+                                                const Matcher<const ast::Call&>& call_matcher)
 {
   return MapDeclStatementMatcher()
       .WithIdent(ident)
-      .WithBpfType(bpf_type)
-      .WithMaxEntries(max_entries);
+      .WithCall(call_matcher);
 }
 
 class MacroMatcher : public NodeMatcher<MacroMatcher, ast::Macro> {

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2567,7 +2567,8 @@ TEST(Parser, prog_body_items)
   test("i:s:1 {} macro add_one() {} fn f1(): void {} let @a = hash(5); i:s:1 "
        "{} fn f2(): void {} macro add_two() {}",
        Program()
-           .WithMapDecls({ MapDeclStatement("@a", "hash", 5) })
+           .WithMapDecls(
+               { MapDeclStatement("@a", Call("hash", { Integer(5) })) })
            .WithFunctions(
                { Subprog("f1", Typeof(SizedType(Type::voidtype)), {}, {}),
                  Subprog("f2", Typeof(SizedType(Type::voidtype)), {}, {}) })
@@ -2934,25 +2935,21 @@ TEST(Parser, map_declarations)
 {
   test("let @a = hash(5); begin { $x; }",
        Program()
-           .WithMapDecls({ MapDeclStatement("@a", "hash", 5) })
+           .WithMapDecls(
+               { MapDeclStatement("@a", Call("hash", { Integer(5) })) })
            .WithProbe(Probe({ "begin" }, { ExprStatement(Variable("$x")) })));
 
   test("let @a = hash(2); let @b = per__cpuhash(7); begin { $x; }",
        Program()
-           .WithMapDecls({ MapDeclStatement("@a", "hash", 2),
-                           MapDeclStatement("@b", "per__cpuhash", 7) })
+           .WithMapDecls(
+               { MapDeclStatement("@a", Call("hash", { Integer(2) })),
+                 MapDeclStatement("@b", Call("per__cpuhash", { Integer(7) })) })
            .WithProbe(Probe({ "begin" }, { ExprStatement(Variable("$x")) })));
 
   test_parse_failure("@a = hash(); begin { $x; }", R"(
 stdin:1:1-3: ERROR: syntax error, unexpected map
 @a = hash(); begin { $x; }
 ~~
-)");
-
-  test_parse_failure("let @a = hash(); begin { $x; }", R"(
-stdin:1:15-16: ERROR: syntax error, unexpected ), expecting integer
-let @a = hash(); begin { $x; }
-              ~
 )");
 }
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -389,6 +389,11 @@ RUN {{BPFTRACE}} runtime/scripts/named_params.bt -- --aa=20
 EXPECT 20
 TIMEOUT 1
 
+NAME named command line params with map decl
+RUN {{BPFTRACE}} -e 'let @a = getopt("foo", false); begin { print(@a); }' -- --foo
+EXPECT true
+TIMEOUT 1
+
 NAME named command line params before double dash
 RUN {{BPFTRACE}} -e 'begin {  }' --aa=20
 EXPECT USAGE:


### PR DESCRIPTION
Stacked PRs:
 * __->__#5004


--- --- ---

### getopt: allow declaration as map decls


Since `getopt` lowers into constant maps anyways, we can easily allow
the `getopt` function in map declarations. It is a hard intrinsic, and
therefore this presents minimal internal changes. This allows users to
declare their preferred map directly, without having to assign another
map at startup (which is far less efficient, since it will not be
inlined by the verified!).

```
let @a = getopt("a");
begin {
  print(@a);
}
```

Signed-off-by: Adin Scannell <amscanne@meta.com>
