### PR TITLE
Stabilize map declaration syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to
   - [#4818](https://github.com/bpftrace/bpftrace/pull/4818)
 - Warn on all discarded expressions
   - [#4836](https://github.com/bpftrace/bpftrace/pull/4836)
+- Stabilize map declarations (remove 'unstable_map_decl' flag)
+  - [#5005](https://github.com/bpftrace/bpftrace/pull/5005)
 #### Deprecated
 - `while` is now deprecated in favor of range-based for loops
   - [#4886](https://github.com/bpftrace/bpftrace/pull/4886)

--- a/docs/language.md
+++ b/docs/language.md
@@ -371,7 +371,6 @@ Controls whether maps are printed on exit. Set to `false` in order to change the
 ### unstable features
 
 These are the list of unstable features:
-- `unstable_map_decl` - feature flag for map declarations
 - `unstable_tseries` - feature flag for time series map type
 - `unstable_addr` - feature flag for address of operator (&)
 

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -24,12 +24,6 @@ private:
 
 } // namespace
 
-static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
-  "symbol_source",
-  "max_type_res_iterations",
-  "unstable_macro"
-};
-
 void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
 {
   // If this is deprecated, just emit a warning and move on. This is done here

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -41,7 +41,6 @@ public:
   explicit UnstableFeature(BPFtrace &bpftrace) : bpftrace_(bpftrace) {};
 
   using Visitor<UnstableFeature>::visit;
-  void visit(MapDeclStatement &decl);
   void visit(MapAddr &map_addr);
   void visit(VariableAddr &var_addr);
   void visit(RootImport &imp);
@@ -63,19 +62,6 @@ private:
 // as this also prints the code location which is overly noisy. We just
 // want to notify users they're using an unstable feature. For errors it's ok to
 // print the location because the script is going to fail anyway.
-
-void UnstableFeature::visit(MapDeclStatement &decl)
-{
-  if (bpftrace_.config_->unstable_map_decl == ConfigUnstable::error) {
-    decl.addError() << get_error(MAP_DECL, UNSTABLE_MAP_DECL);
-    return;
-  }
-  if (bpftrace_.config_->unstable_map_decl == ConfigUnstable::warn &&
-      !warned_features.contains(UNSTABLE_MAP_DECL)) {
-    LOG(WARNING) << get_warning(MAP_DECL, UNSTABLE_MAP_DECL);
-    warned_features.insert(UNSTABLE_MAP_DECL);
-  }
-}
 
 void UnstableFeature::visit(StatementImport &imp)
 {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -328,14 +328,13 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
   { UNSTABLE_IMPORT, CONFIG_FIELD_PARSER(unstable_import) },
   { UNSTABLE_IMPORT_STATEMENT, CONFIG_FIELD_PARSER(unstable_import_statement) },
-  { UNSTABLE_MAP_DECL, CONFIG_FIELD_PARSER(unstable_map_decl) },
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
   { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },
   { UNSTABLE_TYPEINFO, CONFIG_FIELD_PARSER(unstable_typeinfo) },
 };
 
 // These symbols are deprecated, and have been remapped elsewhere.
-const std::map<std::string, std::string> DEPRECATED = {
+const std::map<std::string, std::string> RENAMED = {
   { "strlen", "max_strlen" },
   { "no_cpp_demangle", "cpp_demangle" },
   { "cat_bytes_max", "max_cat_bytes" },
@@ -369,8 +368,8 @@ static Result<AnyParser> lookup(const std::string &original_key)
   auto key = restore(original_key);
   auto it = CONFIG_KEY_MAP.find(key);
   if (it == CONFIG_KEY_MAP.end()) {
-    auto dep = DEPRECATED.find(key);
-    if (dep != DEPRECATED.end()) {
+    auto dep = RENAMED.find(key);
+    if (dep != RENAMED.end()) {
       return make_error<RenameError>(dep->second);
     }
     auto env = ENV_ONLY.find(key);

--- a/src/config.h
+++ b/src/config.h
@@ -32,10 +32,16 @@ enum CompatibleBPFLicense {
 
 static const auto UNSTABLE_IMPORT = "unstable_import";
 static const auto UNSTABLE_IMPORT_STATEMENT = "unstable_import_statement";
-static const auto UNSTABLE_MAP_DECL = "unstable_map_decl";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
 static const auto UNSTABLE_ADDR = "unstable_addr";
 static const auto UNSTABLE_TYPEINFO = "unstable_typeinfo";
+
+static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
+  "symbol_source",
+  "max_type_res_iterations",
+  "unstable_macro",
+  "unstable_map_decl"
+};
 
 class Config {
 public:
@@ -57,7 +63,6 @@ public:
   bool cpp_demangle = true;
   bool lazy_symbolication = true;
   bool print_maps_on_exit = true;
-  ConfigUnstable unstable_map_decl = ConfigUnstable::warn;
   ConfigUnstable unstable_import = ConfigUnstable::warn;
   ConfigUnstable unstable_import_statement = ConfigUnstable::error;
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -4998,52 +4998,36 @@ TEST_F(TypeCheckerTest, block_expressions)
 
 TEST_F(TypeCheckerTest, map_declarations)
 {
-  auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = ConfigUnstable::enable;
-
-  test("let @a = hash(2); begin { @a = 1; }", Mock{ *bpftrace });
-  test("let @a = lruhash(2); begin { @a = 1; }", Mock{ *bpftrace });
-  test("let @a = percpuhash(2); begin { @a[1] = count(); }", Mock{ *bpftrace });
-  test("let @a = percpulruhash(2); begin { @a[1] = count(); }",
-       Mock{ *bpftrace });
-  test("let @a = percpulruhash(2); begin { @a[1] = count(); }",
-       Mock{ *bpftrace });
+  test("let @a = hash(2); begin { @a = 1; }");
+  test("let @a = lruhash(2); begin { @a = 1; }");
+  test("let @a = percpuhash(2); begin { @a[1] = count(); }");
+  test("let @a = percpulruhash(2); begin { @a[1] = count(); }");
+  test("let @a = percpulruhash(2); begin { @a[1] = count(); }");
 
   test("let @a = hash(2); begin { print(1); }",
-       Mock{ *bpftrace },
        Warning{ "WARNING: Unused map: @a" });
 
-  test("let @a = percpuhash(2); begin { @a = 1; }",
-       Mock{ *bpftrace },
-       Error{ R"(
+  test("let @a = percpuhash(2); begin { @a = 1; }", Error{ R"(
 stdin:1:33-35: ERROR: Incompatible map types. Type from declaration: percpuhash. Type from value/key type: hash
 let @a = percpuhash(2); begin { @a = 1; }
                                 ~~
 )" });
-  test("let @a = percpulruhash(2); begin { @a = 1; }",
-       Mock{ *bpftrace },
-       Error{ R"(
+  test("let @a = percpulruhash(2); begin { @a = 1; }", Error{ R"(
 stdin:1:36-38: ERROR: Incompatible map types. Type from declaration: percpulruhash. Type from value/key type: hash
 let @a = percpulruhash(2); begin { @a = 1; }
                                    ~~
 )" });
-  test("let @a = hash(2); begin { @a = count(); }",
-       Mock{ *bpftrace },
-       Error{ R"(
+  test("let @a = hash(2); begin { @a = count(); }", Error{ R"(
 stdin:1:27-29: ERROR: Incompatible map types. Type from declaration: hash. Type from value/key type: percpuhash
 let @a = hash(2); begin { @a = count(); }
                           ~~
 )" });
-  test("let @a = lruhash(2); begin { @a = count(); }",
-       Mock{ *bpftrace },
-       Error{ R"(
+  test("let @a = lruhash(2); begin { @a = count(); }", Error{ R"(
 stdin:1:30-32: ERROR: Incompatible map types. Type from declaration: lruhash. Type from value/key type: percpuhash
 let @a = lruhash(2); begin { @a = count(); }
                              ~~
 )" });
-  test("let @a = potato(2); begin { @a[1] = count(); }",
-       Mock{ *bpftrace },
-       Error{ R"(
+  test("let @a = potato(2); begin { @a[1] = count(); }", Error{ R"(
 stdin:1:1-20: ERROR: Invalid bpf map type: potato
 let @a = potato(2); begin { @a[1] = count(); }
 ~~~~~~~~~~~~~~~~~~~

--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -44,12 +44,6 @@ void test_error(const std::string& input, const std::string& error)
 
 TEST(unstable_feature, check_error)
 {
-  test_error("config = { unstable_map_decl=0 } let @a = lruhash(5); begin { "
-             "@a[0] = 0; }",
-             "map declarations feature is not enabled by default. To enable "
-             "this unstable "
-             "feature, "
-             "set the config flag to enable. unstable_map_decl=enable");
   test("config = { unstable_tseries=warn } begin { @ = tseries(4, 1s, 10); }");
   test_error(
       "config = { unstable_tseries=error } begin { @ = tseries(4, 1s, 10); }",


### PR DESCRIPTION
Stacked PRs:
 * __->__#5005


--- --- ---

### Stabilize map declaration syntax


This syntax has been around for almost a year. Let's stabilize it for 0.25.

Issue: https://github.com/bpftrace/bpftrace/issues/4077

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>