### PR TITLE
Refactor TypeResolver pass

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1671,7 +1671,7 @@ A record is a struct-like type where every element has a name and a type.
 
 Records are a comma separated list of named expressions, enclosed in parenthesis, `(color="green", size=2)`.
 Individual fields can be accessed with the `.` operator and the field name.
-Records maintain their initial ordering but maybe assigned to out of order, e.g. `$a = (color="green", size=2); $a = (size=10, color="blue");`. Note that evaluation order is maintained, e.g. `$a = (size={ print("first"); 20 }, color={ print("second"); "pink" });` will print "first" then "second" but `$a` will now contain `(color="pink", size=20)` in that order.
+If records are assigned in a different order to the same variable, map key, or map value then the final ordering is ambiguous. Note that the evaluation order is maintained, e.g. `$a = (size={ print("first"); 20 }, color={ print("second"); "pink" });` will print "first" then "second" regardless of the ordering of the final type.
 Examples:
 
 ```
@@ -1681,7 +1681,6 @@ interval:s:1 {
   print($a.size);   // 2
   $a = (size=10, color="blue");
   print($a.color);  // blue
-  print($a);        // { .color = "blue", .size = 10 }
 }
 ```
 

--- a/docs/type_resolution.md
+++ b/docs/type_resolution.md
@@ -1,0 +1,120 @@
+# Type Resolution
+
+This explains how bpftrace handles type inference and resolution resulting in static types at runtime. The pass that does this is called the `TypeResolver` (type_resolver.cpp) and inside this pass is the `TypeRuleCollector` visitor, which walks the AST and emits rules into a `TypeResolver`. The solver then propagates types through the rule graph using a worklist-based algorithm until a fixpoint is reached (basically a `TypeVariable` is fully resolved). However, there a lot of additional non-standard complexities that are included as part of the bpftrace language.
+
+It consists of 4 different visitors:
+
+#### `TypeRuleCollector`
+Walks the AST and collects type rules into a `TypeResolver`. For leaf nodes with known types (e.g. integer literals), it seeds the solver directly. For compound nodes, it registers rules that compute output types from input types. Does not mutate the AST but may run multiple times due to AST transformations in the `AstTransformer`.
+
+#### `AstTransformer`
+Utilizes the resolve types from the `TypeRuleCollector`/`TypeResolver` to transform introspection functions (e.g. `sizeof`, `typeinfo`) and create/expand calls to memcmp (for tuples and records).
+
+#### `TypeApplicator`
+Utilizes the resolved Types from the *final* `TypeRuleCollector`/`TypeResolver` run to add the `SizedType` to the AST nodes themselves. Note: this may go away in the future if future passes just consume the map of resolved types instead of relying on state in the AST nodes.
+
+#### `CastCreator`
+Injects casts based on the resolved types of the AST, e.g. so the left and right of a binop are the same type and size.
+
+## The Basics
+The `TypeRuleCollector` visitor walks the AST and builds up a set of rules in a `TypeResolver`. Each rule has an output `TypeVariable`, a set of input `TypeVariable`s, and a `resolve` function (lambda) that computes the output type from the input types. A `TypeVariable` is a variant of `Node *`, `ScopedVariable`, or `std::string` (the last one being used for map keys/values, as these are often resolved separately by different statements/expressions, e.g. `@a = 1; $b = @b["str"]`).
+
+For nodes with already-known types (e.g. integer literals, builtins), the collector calls `resolver.set_type()` to seed the resolver. For compound nodes (e.g. binops, field accesses), it calls `resolver.add_type_rule()` with a lambda describing how the output type derives from input types. For simple type forwarding (e.g. variable references), it calls `resolver.add_pass_through()`.
+
+After all rules are collected, `resolver.resolve()` runs a worklist-based propagation algorithm:
+1. Seed the worklist from nodes with known types by enqueuing all rules that depend on them.
+2. Pop a rule from the worklist and check if all its inputs are resolved (non-NoneTy).
+3. Invoke the rule's solve lambda with the resolved input types.
+4. If the result differs from the rule's previous result, update the output type and enqueue all rules that depend on this output.
+5. Repeat until the worklist is empty (fixpoint reached).
+
+### Example Iteration
+```
+$a = 1; $b = $a;
+```
+
+**Collect (visiting the AST)**
+1. the `ScopedVariable` `$a` depends on the `Node *` on the right side of the assignment (integer literal `1`) via a rule
+1. variable `Node *` `$a` on the left side of the assignment depends on `ScopedVariable` `$a` via a pass-through rule
+1. the integer literal `1` gets seeded with a known type (`uint8`) in the resolver
+1. the `ScopedVariable` `$b` depends on the `Node *` on the right side of the assignment (Variable `$a`) via a rule
+1. `$a` (on the right side of `$b`) depends on the `ScopedVariable` `$a` via a pass-through rule
+
+Notice the distinction between the variable `Node *` `$a` and the `ScopedVariable` `$a`. The latter is not an AST object but something specific to the `TypeRuleCollector`. `ScopedVariable` is responsible for tracking the type of a variable and then updating the associated variable `Node *`s. This is needed because there are multiple variable AST objects associated with a single scratch variable (`ScopedVariable`), e.g., `$a = 1; print($a); $a = (uint32)2`.
+
+**Resolve (rule propagation)**
+1. start the worklist-based rule propagation
+1. pop from the worklist a rule whose input (`1`) has type `uint8`
+1. the rule's `resolve` function checks if `ScopedVariable` `$a` already has a compatible type
+1. it sees `$a` has a `None` type (by looking it up in the `types_` map). The lambda (`resolve`) returns `uint8`.
+1. the resolver sets `uint8` as the type for `ScopedVariable` `$a` in `types_` and enqueues all rules that depend on `$a`
+1. it processes the pass-through rules for the two variable `Node *`s for `$a`, setting both to `uint8`
+1. finally since `ScopedVariable` `$b` depends on Variable `Node *` `$a`, its type also gets set to `uint8` in the `types_` map
+
+The reason we store all the types in a separate map as opposed to on the AST nodes themselves is because the `TypeRuleCollector` visitor may need to run multiple times to resolve things like comptime branches (more on this later). We need a clean state every time we run or else weird things happen that are hard to debug. When the `TypeRuleCollector` visitor is done running (possibly multiple times). This `types_` map is then passed to the `TypeApplicator` visitor which uses it to set the types on the AST nodes.
+
+## Preventing Infinite Loops
+There is a really easy example that demonstrates how we might end up with an infinite loop when propagating types through the rule worklist. Consider this example:
+```
+$a = 1; $a = $a + 1;
+```
+The second statement demonstrates that `$a` depends on the result of the binop on the right side. The binop depends on both `$a` and `1`. So when `$a` is resolved from the first statement and `1` is resolved, we enter the infinite loop of resolving `$a` then resolving the binop then resolving `$a` again and so forth. The solver does something very simple in that if it sees that the type returned by the rule's solve function is the same as the type already previously returned by that rule then it simply stops propagating. In this case the binop resolves to a `uint64` so when `$a` becomes a `uint64` and re-triggers the binop rule, it already has this result and stops.
+
+## Breadth First Search
+The resolver utilizes a BFS (worklist/queue) to propagate types instead of a DFS to prevent an issue with stale updates.
+For example:
+```
+let $a; $a = $a + 1; $a = 1;
+```
+There are 4 `$a` variable `Node *`s that need types. They should all resolve to the same type with their input being the `ScopedVariable` `$a` in the rule graph. In a depth first search when we resolve the first integer literal `1` and set the type of the `ScopedVariable` `$a` to `uint8`, we have 4 rules to process. When we process the third one (the left operand in the binop) the binop resolves to a `uint64` setting this as the type of the `ScopedVariable` `$a`. We then process all 4 rules again setting the 4 `$a` variable nodes to type `uint64`. All is OK **BUT** we have one last rule left over from the first update to `ScopedVariable` `$a` which sets the last `$a` node (`$a = 1`) to a `uint8` - here is the stale update.
+
+## Comptime branches
+A large source of complication in the `TypeRuleCollector` visitor is the existance of `comptime` branches, e.g. `if comptime (...) { } else { }`. There are some `comptime` expressions that get resolved before we ever reach the `TypeRuleCollector` visitor (e.g. `if comptime (1 == 1)`) but some `comptime` expressions rely on knowing the types of things, e.g. `if comptime (typeinfo($a).full_ty == "uint64"))`. For these we need to wait to fully resolve the type of `$a` before we can evaluate this `comptime` expression. Additionally `comptime` branches may further expose parts of the rule graph that we couldn't visit before. For example:
+```
+$a = 1;
+if comptime (typeinfo($a).full_ty == "uint64") {
+  @map = 1;
+} else {
+  @map = "str";
+}
+$a = (uint64)2;
+```
+In this case the value type of map `@map` changes depending on which branch we take.
+
+So in order to resolve the type of `$a` we need a full resolution of the `TypeRuleCollector` visitor (minus the `comptime` branches). We then call upon the `AstTransformer` to transform `typeinfo($a)` into a literal record (e.g. `(btf_id=0, base_ty="int", full_ty="uint64")`). We can then evaluate/fold the comptime expression and, if it's part of a conditional in an `if` statement (like above), decide what branch to keep.
+
+We then need to re-run the `TypeRuleCollector` visitor because there are new branches to visit. We basically have to keep doing this until we either have no more `comptime` expressions (as they can be nested) OR we reach a point where we simply can't resolve them (and return an error).
+
+## Locked `TypeVariable`s
+
+Let's look at a slight variation to the `comptime` example above:
+```
+$a = 1;
+if comptime (typeinfo($a).full_ty == "uint32") {
+  $a = (uint64)3;
+}
+$a = (uint32)2;
+```
+Hopefully you spot the issue right away. We resolve the type of `$a` to be a `uint32`, the `comptime` expression evaluates to `true` and we take a branch that then sets the type of `ScopedVariable` `$a` to `uint64`. How can `$a` be both a `uint32` and a `uint64`? **It can't**. This is where `locked_nodes` comes in. It's a simple map that gets passed to subsequent `TypeRuleCollector` runs from former ones, indicating which `TypeVariable`s have "locked" types - meaning they can't be changed. In this case because `$a` was evaluated inside of a introspection function (`typeinfo`) it is locked and trying to change it's type results in an error.
+
+However, `TypeVariable`s that are not used inside of introspection functions (`typeinfo`, `typeof`, `sizeof`, `offsetof`) CAN be changed inside of `comptime` branches.
+
+## Variable Declarations
+One neat thing we can do with the `TypeRuleCollector`'s design is around the handling of variables with explicit type declarations.
+Example:
+```
+$b = 1;
+let $a: typeof($b) = "str";
+```
+This is clearly an error as the type of `$a` is a `uint8` and we're trying to assign a string literal to it. However, the error itself doesn't manifest in the `TypeRuleCollector` visitor. This is because we completely ignore the right side of the assignment to determine the type of `$a` because it has a type declaration. Then in a later pass, we simply issue an error if the right side type is not compatible with the left side. This reduces some complication and added state required to track what variables have explicit type declarations. Except types with no size - in these cases we need the RHS to know how big the type is, e.g. `let $a: string = "hello"`.
+
+## Casting
+Inserted casts are reserved for `CastCreator` based on the types resolved in the `TypeRuleCollector` visitor.
+Example:
+```
+$a = 1;
+$b = 1;
+$a = $b;
+$a = (uint32)2;
+```
+In this example both `$a` and `$b` start off as `uint8` but the last assignment transforms `$a` into a `uint32` (propagating to all the `$a` variable `Node *`s). So the statement `$a = $b` is valid because `uint8` fits into `uint32` but the type of `$b` shouldn't change, we just need to add a cast so both sides are of the same type. So `$a = $b` becomes `$a = (uint32)$b`. This is done in the `CastCreator` for the purposes of not overcomplicating the `TypeRuleCollector` visitor and separating the concern of cast injection, which doesn't change the types of the `TypeVariable`s but just inserts an expression that doesn't require type evaluation (namely the cast to a specific type).

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -25,6 +25,8 @@ add_library(ast STATIC
   passes/clang_parser.cpp
   passes/clang_build.cpp
   passes/named_param.cpp
+  passes/ast_transformer.cpp
+  passes/cast_creator.cpp
   passes/config_analyser.cpp
   passes/control_flow_analyser.cpp
   passes/deprecated.cpp
@@ -41,12 +43,13 @@ add_library(ast STATIC
   passes/args_resolver.cpp
   passes/probe_prune.cpp
   passes/resource_analyser.cpp
+  passes/type_applicator.cpp
   passes/type_checker.cpp
+  passes/type_resolver.cpp
   passes/codegen_llvm.cpp
   passes/resolve_imports.cpp
   passes/recursion_check.cpp
   passes/tracepoint_format_parser.cpp
-  passes/type_resolver.cpp
   passes/type_system.cpp
   passes/unstable_feature.cpp
   passes/usdt_arguments.cpp

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -959,7 +959,9 @@ public:
   explicit MapAddr(ASTContext &ctx, Location &&loc, Map *map)
       : Node(ctx, std::move(loc)), map(map) {};
   explicit MapAddr(ASTContext &ctx, const Location &loc, const MapAddr &other)
-      : Node(ctx, loc + other.loc), map(clone(ctx, loc, other.map)) {};
+      : Node(ctx, loc + other.loc),
+        map(clone(ctx, loc, other.map)),
+        map_addr_type(other.map_addr_type) {};
 
   const SizedType &type() const
   {
@@ -1031,7 +1033,8 @@ public:
   explicit Unop(ASTContext &ctx, const Location &loc, const Unop &other)
       : Node(ctx, loc + other.loc),
         expr(clone(ctx, loc, other.expr)),
-        op(other.op) {};
+        op(other.op),
+        result_type(other.result_type) {};
 
   const SizedType &type() const
   {
@@ -1112,7 +1115,8 @@ public:
                        const ArrayAccess &other)
       : Node(ctx, loc + other.loc),
         expr(clone(ctx, loc, other.expr)),
-        indexpr(clone(ctx, loc, other.indexpr)) {};
+        indexpr(clone(ctx, loc, other.indexpr)),
+        element_type(other.element_type) {};
 
   const SizedType &type() const
   {
@@ -1245,7 +1249,9 @@ public:
   explicit Tuple(ASTContext &ctx, Location &&loc, ExpressionList &&elems)
       : Node(ctx, std::move(loc)), elems(std::move(elems)) {};
   explicit Tuple(ASTContext &ctx, const Location &loc, const Tuple &other)
-      : Node(ctx, loc + other.loc), elems(clone(ctx, loc, other.elems)) {};
+      : Node(ctx, loc + other.loc),
+        elems(clone(ctx, loc, other.elems)),
+        tuple_type(other.tuple_type) {};
 
   const SizedType &type() const
   {
@@ -1304,7 +1310,8 @@ public:
       : Node(ctx, std::move(loc)), elems(std::move(named_args)) {};
   explicit Record(ASTContext &ctx, const Location &loc, const Record &other)
       : Node(ctx, loc + other.loc),
-        elems(clone(ctx, loc, other.elems)) {};
+        elems(clone(ctx, loc, other.elems)),
+        record_type(other.record_type) {};
 
   const SizedType &type() const
   {
@@ -1790,7 +1797,8 @@ public:
       : Node(ctx, loc + other.loc),
         decl(clone(ctx, loc, other.decl)),
         iterable(clone(ctx, loc, other.iterable)),
-        block(clone(ctx, loc, other.block)) {};
+        block(clone(ctx, loc, other.block)),
+        ctx_type(other.ctx_type) {};
 
   bool operator==(const For &other) const
   {

--- a/src/ast/passes/ast_transformer.cpp
+++ b/src/ast/passes/ast_transformer.cpp
@@ -1,0 +1,196 @@
+#include "ast/passes/ast_transformer.h"
+#include "ast/ast.h"
+#include "ast/passes/cast_creator.h"
+#include "ast/passes/macro_expansion.h"
+#include "struct.h"
+#include "types.h"
+
+namespace bpftrace::ast {
+
+std::optional<Expression> AstTransformer::visit(Binop &binop)
+{
+  visit(binop.left);
+  visit(binop.right);
+
+  const auto &lht = get_type(&binop.left.node());
+  const auto &rht = get_type(&binop.right.node());
+
+  if (binop.op != Operator::EQ && binop.op != Operator::NE)
+    return std::nullopt;
+
+  if (!lht.IsTupleTy() && !lht.IsRecordTy())
+    return std::nullopt;
+
+  if (!lht.IsCompatible(rht))
+    return std::nullopt;
+
+  if (binop.left.is_literal() && binop.right.is_literal()) {
+    // This will get folded.
+    return std::nullopt;
+  }
+
+  bool is_tuple = lht.IsTupleTy();
+  auto updatedTy = is_tuple ? get_promoted_tuple(lht, rht)
+                            : get_promoted_record(lht, rht);
+  if (!updatedTy) {
+    binop.addError() << "Type mismatch for '" << opstr(binop) << "': comparing "
+                     << lht << " with " << rht;
+    return std::nullopt;
+  }
+
+  if (*updatedTy != lht) {
+    if (is_tuple) {
+      try_tuple_cast(ast_, binop.left, lht, *updatedTy);
+    } else {
+      try_record_cast(ast_, binop.left, lht, *updatedTy);
+    }
+  }
+  if (*updatedTy != rht) {
+    if (is_tuple) {
+      try_tuple_cast(ast_, binop.right, rht, *updatedTy);
+    } else {
+      try_record_cast(ast_, binop.right, rht, *updatedTy);
+    }
+  }
+
+  bool types_equal = binop.left.type() == binop.right.type();
+
+  auto *size = ast_.make_node<Integer>(binop.loc,
+                                       updatedTy->GetSize(),
+                                       CreateUInt64());
+  // N.B. if the types aren't equal at this point it means that
+  // we're dealing with record types that are same except for
+  // their fields are in a different order so we need to use a
+  // different memcmp that saves off both the left and right to
+  // variables but sets the type of the right variable to the left
+  // before assignment (e.g. `let $right: typeof($left) = right;`)
+  // as this ensures the temporary `$right` variable has the same
+  // field ordering as the `$left`.
+  auto *call = ast_.make_node<Call>(binop.loc,
+                                    types_equal ? "memcmp" : "memcmp_record",
+                                    ExpressionList{
+                                        binop.left, binop.right, size });
+  auto *typeof_node = ast_.make_node<Typeof>(binop.loc, CreateBool());
+  auto *cast = ast_.make_node<Cast>(binop.loc, typeof_node, call);
+  if (binop.op == Operator::NE) {
+    return cast;
+  } else {
+    return ast_.make_node<Unop>(binop.loc, cast, Operator::LNOT);
+  }
+}
+
+std::optional<Expression> AstTransformer::visit(Expression &expr)
+{
+  auto r = Visitor<AstTransformer, std::optional<Expression>>::visit(
+      expr.value);
+  if (r) {
+    had_transforms_ = true;
+    expr.value = r->value;
+    expand_macro(ast_, expr, macro_registry_);
+  }
+  return std::nullopt;
+}
+
+std::optional<Expression> AstTransformer::visit(FieldAccess &acc)
+{
+  visit(acc.expr);
+
+  // FieldAccesses will automatically resolve through any number of pointer
+  // dereferences. For now, we inject the `Unop` operator directly, as codegen
+  // stores the underlying structs as pointers anyways. In the future, we will
+  // likely want to do this in a different way if we are tracking l-values.
+  auto type = get_type(&acc.expr.node());
+  while (type.IsPtrTy()) {
+    auto *unop = ast_.make_node<Unop>(acc.expr.node().loc,
+                                      acc.expr,
+                                      Operator::MUL);
+    unop->result_type = type.GetPointeeTy();
+    if (type.IsCtxAccess())
+      unop->result_type.MarkCtxAccess();
+    unop->result_type.is_internal = type.is_internal;
+    unop->result_type.SetAS(type.GetAS());
+    acc.expr.value = unop;
+    had_transforms_ = true;
+    type = unop->result_type;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Expression> AstTransformer::visit(Offsetof &offof)
+{
+  SizedType cstruct;
+  if (std::holds_alternative<SizedType>(offof.record)) {
+    cstruct = std::get<SizedType>(offof.record);
+  } else {
+    cstruct = get_type(&std::get<Expression>(offof.record).node());
+  }
+
+  if (cstruct.IsNoneTy()) {
+    return std::nullopt;
+  }
+
+  size_t offset = 0;
+  for (const auto &field : offof.field) {
+    if (!cstruct.IsCStructTy() || !cstruct.HasField(field)) {
+      return std::nullopt;
+    }
+    const auto &f = cstruct.GetField(field);
+    offset += f.offset;
+    cstruct = f.type;
+  }
+
+  return ast_.make_node<Integer>(Location(offof.loc), offset);
+}
+
+std::optional<Expression> AstTransformer::visit(Sizeof &szof)
+{
+  size_t size = 0;
+  if (std::holds_alternative<SizedType>(szof.record)) {
+    auto &ty = std::get<SizedType>(szof.record);
+    if (ty.IsNoneTy()) {
+      return std::nullopt;
+    }
+    size = ty.GetSize();
+  } else {
+    const auto &ty = get_type(&std::get<Expression>(szof.record).node());
+    if (ty.IsNoneTy()) {
+      return std::nullopt;
+    }
+    size = ty.GetSize();
+  }
+
+  return ast_.make_node<Integer>(Location(szof.loc), size);
+}
+
+std::optional<Expression> AstTransformer::visit(Typeinfo &typeinfo)
+{
+  const auto &type = get_type(typeinfo.typeof);
+  if (type.IsNoneTy()) {
+    return std::nullopt;
+  }
+
+  // We currently lack a globally-unique enumeration of types. For
+  // simplicity, just use the type string with a placeholder identifier.
+  auto *id = ast_.make_node<Integer>(typeinfo.loc, 0);
+  auto *base_ty = ast_.make_node<String>(typeinfo.loc, to_string(type.GetTy()));
+  auto *full_ty = ast_.make_node<String>(typeinfo.loc, typestr(type));
+
+  std::vector<SizedType> elements = { CreateUInt64(),
+                                      base_ty->type(),
+                                      full_ty->type() };
+  std::vector<std::string_view> names = { "btf_id", "base_type", "full_type" };
+
+  auto record_type = CreateRecord(Struct::CreateRecord(elements, names));
+
+  auto *record = make_record(
+      ast_,
+      typeinfo.loc,
+      { { "btf_id", id }, { "base_type", base_ty }, { "full_type", full_ty } });
+
+  record->record_type = record_type;
+
+  return record;
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/ast_transformer.h
+++ b/src/ast/passes/ast_transformer.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "ast/passes/type_resolver.h"
+#include "ast/visitor.h"
+
+#include <optional>
+
+namespace bpftrace::ast {
+
+class MacroRegistry;
+
+class AstTransformer
+    : public Visitor<AstTransformer, std::optional<Expression>> {
+public:
+  AstTransformer(ASTContext &ast,
+                 const MacroRegistry &macro_registry,
+                 const ResolvedTypes &resolved_types)
+      : ast_(ast),
+        macro_registry_(macro_registry),
+        resolved_types_(resolved_types) {};
+
+  using Visitor<AstTransformer, std::optional<Expression>>::visit;
+
+  std::optional<Expression> visit(Expression &expr);
+  std::optional<Expression> visit(Binop &binop);
+  std::optional<Expression> visit(Offsetof &offof);
+  std::optional<Expression> visit(Sizeof &szof);
+  std::optional<Expression> visit(Typeinfo &typeinfo);
+  std::optional<Expression> visit(FieldAccess &acc);
+
+  bool had_transforms() const
+  {
+    return had_transforms_;
+  }
+
+private:
+  ASTContext &ast_;
+  const MacroRegistry &macro_registry_;
+  const ResolvedTypes &resolved_types_;
+  bool had_transforms_ = false;
+
+  const SizedType &get_type(const TypeVariable &node) const
+  {
+    auto it = resolved_types_.find(node);
+    if (it != resolved_types_.end()) {
+      return it->second;
+    }
+    static SizedType none = CreateNone();
+    return none;
+  }
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/cast_creator.cpp
+++ b/src/ast/passes/cast_creator.cpp
@@ -1,0 +1,481 @@
+#include "ast/passes/cast_creator.h"
+#include "ast/ast.h"
+#include "ast/passes/map_sugar.h"
+#include "bpftrace.h"
+#include "log.h"
+#include "types.h"
+
+#include <functional>
+#include <optional>
+
+namespace bpftrace::ast {
+
+std::optional<SizedType> try_expression_cast(ASTContext &ctx,
+                                             Expression &expr,
+                                             const SizedType &expr_type,
+                                             const SizedType &target_type);
+
+std::optional<SizedType> try_tuple_cast(ASTContext &ctx,
+                                        Expression &exp,
+                                        const SizedType &expr_type,
+                                        const SizedType &target_type)
+{
+  if (auto *block_expr = exp.as<BlockExpr>()) {
+    return try_tuple_cast(ctx, block_expr->expr, expr_type, target_type);
+  }
+
+  if (!exp.is<Variable>() && !exp.is<TupleAccess>() && !exp.is<MapAccess>() &&
+      !exp.is<Tuple>() && !exp.is<FieldAccess>() && !exp.is<Unop>()) {
+    LOG(BUG) << "Unexpected expression kind: try_tuple_cast";
+  }
+
+  ExpressionList expr_list = {};
+  std::vector<SizedType> element_types;
+
+  for (size_t i = 0; i < target_type.GetFields().size(); ++i) {
+    auto &expr_field_ty = expr_type.GetField(i).type;
+    auto &target_field_ty = target_type.GetField(i).type;
+    Expression elem;
+    if (auto *tuple_literal = exp.as<Tuple>()) {
+      elem = clone(ctx,
+                   tuple_literal->elems.at(i).loc(),
+                   tuple_literal->elems.at(i));
+    } else {
+      elem = ctx.make_node<TupleAccess>(Location(exp.loc()),
+                                        clone(ctx, exp.loc(), exp),
+                                        i);
+      elem.as<TupleAccess>()->element_type = expr_field_ty;
+    }
+    auto cast_type = try_expression_cast(
+        ctx, elem, expr_field_ty, target_field_ty);
+    if (!cast_type) {
+      return std::nullopt;
+    }
+    element_types.emplace_back(*cast_type);
+    expr_list.emplace_back(std::move(elem));
+  }
+
+  auto tuple_type = CreateTuple(Struct::CreateTuple(element_types));
+
+  exp = ctx.make_node<Tuple>(Location(exp.loc()), std::move(expr_list));
+  exp.as<Tuple>()->tuple_type = tuple_type;
+
+  return tuple_type;
+}
+
+std::optional<SizedType> try_record_cast(ASTContext &ctx,
+                                         Expression &exp,
+                                         const SizedType &expr_type,
+                                         const SizedType &target_type)
+{
+  if (auto *block_expr = exp.as<BlockExpr>()) {
+    return try_record_cast(ctx, block_expr->expr, expr_type, target_type);
+  }
+
+  if (!exp.is<Variable>() && !exp.is<FieldAccess>() && !exp.is<MapAccess>() &&
+      !exp.is<Record>() && !exp.is<TupleAccess>() && !exp.is<Unop>()) {
+    LOG(BUG) << "Unexpected expression kind: try_record_cast";
+  }
+
+  std::unordered_map<size_t, std::pair<NamedArgument *, SizedType>>
+      named_arg_map;
+
+  for (size_t i = 0; i < expr_type.GetFields().size(); ++i) {
+    const auto &target_field = target_type.GetField(i);
+    const auto &expr_field_ty = expr_type.GetField(target_field.name).type;
+    const auto &target_field_ty = target_field.type;
+    Expression elem;
+    if (auto *record_literal = exp.as<Record>()) {
+      auto field_idx = expr_type.GetFieldIdx(target_field.name);
+      elem = clone(ctx,
+                   record_literal->elems.at(field_idx)->expr.loc(),
+                   record_literal->elems.at(field_idx)->expr);
+    } else {
+      elem = ctx.make_node<FieldAccess>(Location(exp.loc()),
+                                        clone(ctx, exp.loc(), exp),
+                                        target_field.name);
+      elem.as<FieldAccess>()->field_type = expr_field_ty;
+    }
+    auto cast_type = try_expression_cast(
+        ctx, elem, expr_field_ty, target_field_ty);
+    if (!cast_type) {
+      return std::nullopt;
+    }
+    auto *named_arg = ctx.make_node<NamedArgument>(Location(exp.loc()),
+                                                   target_field.name,
+                                                   std::move(elem));
+    named_arg_map[expr_type.GetFieldIdx(target_field.name)] = { named_arg,
+                                                                *cast_type };
+  }
+
+  // Keep the ordering for the current type to maintain evaluation order
+  NamedArgumentList named_args = {};
+  std::vector<SizedType> elements;
+  std::vector<std::string_view> names;
+  for (size_t i = 0; i < expr_type.GetFields().size(); ++i) {
+    named_args.emplace_back(named_arg_map[i].first);
+    names.emplace_back(named_arg_map[i].first->name);
+    elements.emplace_back(named_arg_map[i].second);
+  }
+
+  auto record_type = CreateRecord(Struct::CreateRecord(elements, names));
+
+  exp = ctx.make_node<Record>(Location(exp.loc()), std::move(named_args));
+  exp.as<Record>()->record_type = record_type;
+
+  return record_type;
+}
+
+std::optional<SizedType> try_int_cast(ASTContext &ctx,
+                                      Expression &exp,
+                                      const SizedType &expr_type,
+                                      const SizedType &target_type)
+{
+  // We don't need a cast if it's a literal
+  if (auto *integer = exp.as<Integer>()) {
+    if (target_type.IsSigned()) {
+      auto signed_ty = ast::get_signed_integer_type(integer->value);
+      if (!signed_ty || !signed_ty->FitsInto(target_type)) {
+        // The integer is too large
+        return std::nullopt;
+      }
+    } else {
+      auto unsigned_ty = ast::get_integer_type(integer->value);
+      if (!unsigned_ty.FitsInto(target_type)) {
+        // The integer is too large
+        return std::nullopt;
+      }
+    }
+    exp = ctx.make_node<Integer>(
+        Location(exp.loc()), integer->value, target_type, integer->original);
+    return target_type;
+  } else if (auto *negative_integer = exp.as<NegativeInteger>()) {
+    if (!target_type.IsSigned()) {
+      return std::nullopt;
+    }
+
+    auto signed_ty = ast::get_signed_integer_type(negative_integer->value);
+    if (!signed_ty.FitsInto(target_type)) {
+      // The integer is too large
+      return std::nullopt;
+    }
+
+    exp = ctx.make_node<NegativeInteger>(Location(exp.loc()),
+                                         negative_integer->value,
+                                         target_type);
+    return target_type;
+  }
+
+  if (!expr_type.FitsInto(target_type) && !expr_type.IsCastableMapTy()) {
+    return std::nullopt;
+  }
+
+  auto *typeof_r = ctx.make_node<Typeof>(Location(exp.loc()), target_type);
+  exp = ctx.make_node<Cast>(Location(exp.loc()),
+                            typeof_r,
+                            clone(ctx, exp.loc(), exp));
+
+  return target_type;
+}
+
+std::optional<SizedType> try_string_cast(ASTContext &ctx,
+                                         Expression &exp,
+                                         const SizedType &expr_type,
+                                         const SizedType &target_type)
+{
+  if (exp.type().GetSize() == target_type.GetSize()) {
+    return target_type;
+  }
+
+  if (!expr_type.FitsInto(target_type)) {
+    return std::nullopt;
+  }
+
+  auto *typeof_r = ctx.make_node<Typeof>(Location(exp.loc()), target_type);
+  exp = ctx.make_node<Cast>(Location(exp.loc()),
+                            typeof_r,
+                            clone(ctx, exp.loc(), exp));
+  return target_type;
+}
+
+std::optional<SizedType> try_expression_cast(ASTContext &ctx,
+                                             Expression &expr,
+                                             const SizedType &expr_type,
+                                             const SizedType &target_type)
+{
+  if (expr_type == target_type) {
+    return target_type;
+  }
+
+  // No when both are castable map types
+  if (expr_type.GetTy() == target_type.GetTy() && expr_type.IsCastableMapTy()) {
+    return target_type;
+  }
+
+  if ((expr_type.IsIntegerTy() || expr_type.IsCastableMapTy()) &&
+      (target_type.IsIntegerTy() || target_type.IsCastableMapTy())) {
+    return try_int_cast(ctx, expr, expr_type, target_type);
+  }
+
+  if (expr_type.GetTy() != target_type.GetTy()) {
+    return std::nullopt;
+  }
+
+  if (target_type.IsStringTy()) {
+    return try_string_cast(ctx, expr, expr_type, target_type);
+  } else if (target_type.IsTupleTy()) {
+    return try_tuple_cast(ctx, expr, expr_type, target_type);
+  } else if (target_type.IsRecordTy()) {
+    return try_record_cast(ctx, expr, expr_type, target_type);
+  } else if (target_type.IsPtrTy()) {
+    auto *typeof_r = ctx.make_node<Typeof>(Location(expr.loc()), target_type);
+    expr = ctx.make_node<Cast>(Location(expr.loc()),
+                               typeof_r,
+                               clone(ctx, expr.loc(), expr));
+
+    return target_type;
+  } else if (target_type.IsBufferTy()) {
+    // TODO: make it ok to cast buffer types to larger buffer types
+    return target_type;
+  }
+
+  return std::nullopt;
+}
+
+CastCreator::CastCreator(ASTContext &ast, BPFtrace &bpftrace)
+    : ctx_(ast), bpftrace_(bpftrace)
+{
+}
+
+void CastCreator::visit(AssignMapStatement &assignment)
+{
+  visit(assignment.map_access);
+  visit(assignment.expr);
+
+  const auto &expr_type = assignment.expr.type();
+  const auto &value_type = assignment.map_access->map->value_type;
+
+  if (value_type == expr_type) {
+    return;
+  }
+
+  if (!try_expression_cast(ctx_, assignment.expr, expr_type, value_type)) {
+    assignment.addError() << "Type mismatch for "
+                          << assignment.map_access->map->ident << ": "
+                          << "trying to assign value of type '" << expr_type
+                          << "' when map already has a value type '"
+                          << value_type << "'";
+  }
+}
+
+void CastCreator::visit(AssignVarStatement &assignment)
+{
+  visit(assignment.expr);
+  visit(assignment.var_decl);
+
+  const auto &expr_type = assignment.expr.type();
+  const auto &var_type = assignment.var()->type();
+
+  if (var_type == expr_type) {
+    return;
+  }
+
+  if (!try_expression_cast(ctx_, assignment.expr, expr_type, var_type)) {
+    assignment.addError() << "Type mismatch for " << assignment.var()->ident
+                          << ": "
+                          << "trying to assign value of type '" << expr_type
+                          << "' when variable already has a type '" << var_type
+                          << "'";
+  }
+}
+
+void CastCreator::visit(Binop &binop)
+{
+  visit(binop.left);
+  visit(binop.right);
+
+  const auto &left_type = binop.left.type();
+  const auto &right_type = binop.right.type();
+
+  // N.B. don't upcast strings as there are cases when one size is the max
+  // string size and we don't want to create a cast like (string[1024])"hi"
+  if (left_type.IsStringTy() || right_type.IsStringTy()) {
+    return;
+  }
+
+  if (is_comparison_op(binop.op)) {
+    auto promoted = get_promoted_type(left_type, right_type);
+    if (promoted) {
+      try_expression_cast(ctx_, binop.left, left_type, *promoted);
+      try_expression_cast(ctx_, binop.right, right_type, *promoted);
+    }
+  } else {
+    try_expression_cast(ctx_, binop.left, left_type, binop.result_type);
+    try_expression_cast(ctx_, binop.right, right_type, binop.result_type);
+  }
+}
+
+void CastCreator::visit(BlockExpr &block)
+{
+  visit(block.stmts);
+  visit(block.expr);
+}
+
+void CastCreator::visit(Call &call)
+{
+  for (auto &varg : call.vargs) {
+    visit(varg);
+  }
+
+  if (getAssignRewriteFuncs().contains(call.func)) {
+    if (auto *map = call.vargs.at(0).as<Map>()) {
+      try_expression_cast(
+          ctx_, call.vargs.at(1), call.vargs.at(1).type(), map->key_type);
+    }
+  } else if (call.func == "percpu_kaddr") {
+    if (call.vargs.size() == 2) {
+      auto arg_type = call.vargs.at(1).type();
+      if (arg_type != CreateUInt32() && arg_type.IsIntegerTy()) {
+        auto *typeof_c = ctx_.make_node<Typeof>(
+            Location(call.vargs.at(1).loc()), CreateUInt32());
+        call.vargs.at(1) = ctx_.make_node<Cast>(
+            Location(call.vargs.at(1).loc()),
+            typeof_c,
+            clone(ctx_, call.vargs.at(1).loc(), call.vargs.at(1)));
+      }
+    }
+  } else if (call.func == "usym") {
+    auto arg_type = call.vargs.at(0).type();
+    if (arg_type.IsIntegerTy() && arg_type.GetSize() != 8) {
+      try_expression_cast(
+          ctx_, call.vargs.at(0), call.vargs.at(0).type(), CreateUInt64());
+    }
+  }
+}
+
+void CastCreator::visit(Cast &cast)
+{
+  visit(cast.expr);
+  visit(cast.typeof);
+}
+
+void CastCreator::visit(For &f)
+{
+  visit(f.decl);
+  visit(f.block);
+
+  if (auto *map = f.iterable.as<Map>()) {
+    visit(map);
+  } else if (auto *range = f.iterable.as<Range>()) {
+    visit(range->start);
+    visit(range->end);
+
+    const auto &start_type = range->start.type();
+    const auto &end_type = range->end.type();
+    if (start_type == end_type) {
+      return;
+    }
+    auto larger = start_type.GetSize() > end_type.GetSize() ? start_type
+                                                            : end_type;
+    try_expression_cast(ctx_, range->start, start_type, larger);
+    try_expression_cast(ctx_, range->end, end_type, larger);
+  }
+}
+
+void CastCreator::visit(IfExpr &if_expr)
+{
+  visit(if_expr.cond);
+  visit(if_expr.left);
+  visit(if_expr.right);
+
+  const auto &result_type = if_expr.result_type;
+  const auto &left_type = if_expr.left.type();
+  const auto &right_type = if_expr.right.type();
+
+  if (result_type != left_type) {
+    if (!try_expression_cast(ctx_, if_expr.left, left_type, result_type)) {
+      LOG(BUG) << "IfExpr left should be castable";
+    }
+  }
+
+  if (result_type != right_type) {
+    if (!try_expression_cast(ctx_, if_expr.right, right_type, result_type)) {
+      LOG(BUG) << "IfExpr right should be castable";
+    }
+  }
+}
+
+void CastCreator::visit(Jump &jump)
+{
+  if (jump.ident == JumpType::RETURN) {
+    visit(jump.return_value);
+    if (std::holds_alternative<Probe *>(top_level_node_)) {
+      if (jump.return_value.has_value()) {
+        const auto &ty = jump.return_value->type();
+        if (ty.IsIntegerTy() && ty.GetSize() != 8) {
+          // Probes always return 64 bit ints
+          try_expression_cast(ctx_, *jump.return_value, ty, CreateInt64());
+        }
+      }
+    } else if (auto **subprog_ptr = std::get_if<Subprog *>(&top_level_node_)) {
+      auto *subprog = *subprog_ptr;
+      if (!jump.return_value.has_value()) {
+        if (!subprog->return_type->type().IsVoidTy()) {
+          jump.addError() << "Function " << subprog->name << " is of type "
+                          << subprog->return_type->type() << ", cannot return "
+                          << CreateVoid();
+          return;
+        }
+        return;
+      }
+      if (!try_expression_cast(ctx_,
+                               *jump.return_value,
+                               jump.return_value->type(),
+                               subprog->return_type->type())) {
+        jump.addError() << "Function " << subprog->name << " is of type "
+                        << subprog->return_type->type() << ", cannot return "
+                        << jump.return_value->type();
+        return;
+      }
+    }
+  }
+}
+
+void CastCreator::visit(MapAccess &acc)
+{
+  visit(acc.key);
+  visit(acc.map);
+  const auto &expr_type = acc.key.type();
+  const auto &key_type = acc.map->key_type;
+
+  if (key_type.IsNoneTy() || expr_type.IsNoneTy()) {
+    return;
+  }
+
+  if (!try_expression_cast(ctx_, acc.key, expr_type, key_type)) {
+    acc.addError() << "Type mismatch for " << acc.map->ident << ": "
+                   << "trying to assign key of type '" << expr_type
+                   << "' when map already has a key type '" << key_type << "'";
+  }
+}
+
+void CastCreator::visit(Probe &probe)
+{
+  top_level_node_ = &probe;
+  visit(probe.attach_points);
+  visit(probe.block);
+}
+
+void CastCreator::visit(Subprog &subprog)
+{
+  top_level_node_ = &subprog;
+
+  for (SubprogArg *arg : subprog.args) {
+    visit(arg->var);
+  }
+
+  visit(subprog.block);
+  visit(subprog.return_type);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/cast_creator.h
+++ b/src/ast/passes/cast_creator.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+#include "ast/visitor.h"
+
+#include <optional>
+#include <variant>
+
+namespace bpftrace {
+class BPFtrace;
+} // namespace bpftrace
+
+namespace bpftrace::ast {
+
+std::optional<SizedType> try_tuple_cast(ASTContext &ctx,
+                                        Expression &exp,
+                                        const SizedType &expr_type,
+                                        const SizedType &target_type);
+
+std::optional<SizedType> try_record_cast(ASTContext &ctx,
+                                         Expression &exp,
+                                         const SizedType &expr_type,
+                                         const SizedType &target_type);
+
+class CastCreator : public Visitor<CastCreator> {
+public:
+  explicit CastCreator(ASTContext &ast, BPFtrace &bpftrace);
+
+  using Visitor<CastCreator>::visit;
+  void visit(AssignMapStatement &assignment);
+  void visit(AssignVarStatement &assignment);
+  void visit(Binop &binop);
+  void visit(BlockExpr &block);
+  void visit(Call &call);
+  void visit(Cast &cast);
+  void visit(For &f);
+  void visit(IfExpr &if_expr);
+  void visit(Jump &jump);
+  void visit(MapAccess &acc);
+  void visit(Probe &probe);
+  void visit(Subprog &subprog);
+
+private:
+  ASTContext &ctx_;
+  BPFtrace &bpftrace_;
+  std::variant<std::monostate, Probe *, Subprog *> top_level_node_;
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2225,9 +2225,9 @@ ScopedExpr CodegenLLVM::binop_ptr(Binop &binop)
   if (compare) {
     // The only other type pointers can be compared to is ints
     if (!binop.left.type().IsPtrTy()) {
-      rhs = b_.CreatePtrToInt(rhs, b_.GetType(binop.left.type()));
+      lhs = b_.CreateIntToPtr(lhs, rhs->getType());
     } else if (!binop.right.type().IsPtrTy()) {
-      lhs = b_.CreatePtrToInt(lhs, b_.GetType(binop.right.type()));
+      rhs = b_.CreateIntToPtr(rhs, lhs->getType());
     }
     switch (binop.op) {
       case Operator::EQ:

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -946,6 +946,12 @@ void fold(ASTContext &ast, Expression &expr)
   folder.visit(expr);
 }
 
+void fold(ASTContext &ast)
+{
+  LiteralFolder folder(ast);
+  folder.visit(ast.root);
+}
+
 Pass CreateFoldLiteralsPass()
 {
   auto fn = [](ASTContext &ast, BPFtrace &b) {

--- a/src/ast/passes/fold_literals.h
+++ b/src/ast/passes/fold_literals.h
@@ -11,6 +11,8 @@ namespace bpftrace::ast {
 // literals. Note however, that it is up to the pass to ensure that the full
 // expression is recursively folded.
 void fold(ASTContext &ast, Expression &expr);
+// Re-visit the whole ast and re-fold
+void fold(ASTContext &ast);
 
 // Fold all nodes.
 Pass CreateFoldLiteralsPass();

--- a/src/ast/passes/type_applicator.cpp
+++ b/src/ast/passes/type_applicator.cpp
@@ -1,0 +1,122 @@
+#include "ast/passes/type_applicator.h"
+#include "ast/ast.h"
+
+namespace bpftrace::ast {
+
+void TypeApplicator::visit(ArrayAccess &arr)
+{
+  Visitor<TypeApplicator>::visit(arr);
+  apply(arr, arr.element_type);
+}
+
+void TypeApplicator::visit(Binop &binop)
+{
+  Visitor<TypeApplicator>::visit(binop);
+  apply(binop, binop.result_type);
+}
+
+void TypeApplicator::visit(Builtin &builtin)
+{
+  apply(builtin, builtin.builtin_type);
+}
+
+void TypeApplicator::visit(Call &call)
+{
+  Visitor<TypeApplicator>::visit(call);
+  apply(call, call.return_type);
+}
+
+void TypeApplicator::visit(Cast &cast)
+{
+  // N.B. this can mutate the AST. Consider this example: `$a = (uint8)1 ==
+  // (int8)-1;`. Both casts are holding a SizedType as the record (not an
+  // expression) so when the left and right types get promoted to an int16 these
+  // two casts change to `$a = (int16)1 == (int16)-1;`. However a cast will be
+  // inserted by CastCreator if the initial casts were expressions, e.g. `$a =
+  // (typeof)1 == (int8)-1;`
+  Visitor<TypeApplicator>::visit(cast);
+  if (std::holds_alternative<SizedType>(cast.typeof->record)) {
+    apply(cast, std::get<SizedType>(cast.typeof->record));
+  }
+}
+
+void TypeApplicator::visit(FieldAccess &acc)
+{
+  Visitor<TypeApplicator>::visit(acc);
+  apply(acc, acc.field_type);
+}
+
+void TypeApplicator::visit(IfExpr &if_expr)
+{
+  Visitor<TypeApplicator>::visit(if_expr);
+  apply(if_expr, if_expr.result_type);
+}
+
+void TypeApplicator::visit(Identifier &identifier)
+{
+  apply(identifier, identifier.ident_type);
+}
+
+void TypeApplicator::visit(Map &map)
+{
+  auto key_it = resolved_types_.find(get_map_key_name(map.ident));
+  if (key_it != resolved_types_.end()) {
+    map.key_type = key_it->second;
+  }
+  if (map.key_type.IsNoneTy()) {
+    map.addError() << "Undefined map: " + map.ident;
+  }
+  auto val_it = resolved_types_.find(get_map_value_name(map.ident));
+  if (val_it != resolved_types_.end()) {
+    map.value_type = val_it->second;
+  }
+  if (map.value_type.IsNoneTy()) {
+    map.addError() << "Undefined map: " + map.ident;
+  }
+}
+
+void TypeApplicator::visit(MapAddr &map_addr)
+{
+  Visitor<TypeApplicator>::visit(map_addr);
+  apply(map_addr, map_addr.map_addr_type);
+}
+
+void TypeApplicator::visit(Record &record)
+{
+  Visitor<TypeApplicator>::visit(record);
+  apply(record, record.record_type);
+}
+
+void TypeApplicator::visit(Tuple &tuple)
+{
+  Visitor<TypeApplicator>::visit(tuple);
+  apply(tuple, tuple.tuple_type);
+}
+
+void TypeApplicator::visit(TupleAccess &acc)
+{
+  Visitor<TypeApplicator>::visit(acc);
+  apply(acc, acc.element_type);
+}
+
+void TypeApplicator::visit(Unop &unop)
+{
+  Visitor<TypeApplicator>::visit(unop);
+  apply(unop, unop.result_type);
+}
+
+void TypeApplicator::visit(Variable &var)
+{
+  apply(var, var.var_type);
+  if (var.var_type.IsNoneTy()) {
+    var.addError() << "Could not resolve the type of this variable";
+  }
+}
+
+void TypeApplicator::visit(VariableAddr &var_addr)
+{
+  Visitor<TypeApplicator>::visit(var_addr);
+  apply(var_addr, var_addr.var_addr_type);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/type_applicator.h
+++ b/src/ast/passes/type_applicator.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "ast/passes/type_resolver.h"
+#include "ast/visitor.h"
+
+namespace bpftrace::ast {
+
+class TypeApplicator : public Visitor<TypeApplicator> {
+public:
+  explicit TypeApplicator(const ResolvedTypes &resolved_types)
+      : resolved_types_(resolved_types) {};
+
+  using Visitor<TypeApplicator>::visit;
+
+  void visit(ArrayAccess &arr);
+  void visit(Binop &binop);
+  void visit(Builtin &builtin);
+  void visit(Call &call);
+  void visit(Cast &cast);
+  void visit(FieldAccess &acc);
+  void visit(Identifier &identifier);
+  void visit(IfExpr &if_expr);
+  void visit(Map &map);
+  void visit(MapAddr &map_addr);
+  void visit(Record &record);
+  void visit(Tuple &tuple);
+  void visit(TupleAccess &acc);
+  void visit(Unop &unop);
+  void visit(Variable &var);
+  void visit(VariableAddr &var_addr);
+
+private:
+  const ResolvedTypes &resolved_types_;
+
+  void apply(Node &node, SizedType &target)
+  {
+    auto it = resolved_types_.find(&node);
+    if (it != resolved_types_.end()) {
+      target = it->second;
+    }
+  }
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/type_resolver.cpp
+++ b/src/ast/passes/type_resolver.cpp
@@ -1,350 +1,78 @@
-#include <algorithm>
-#include <arpa/inet.h>
-#include <bpf/bpf.h>
-#include <cstring>
-#include <optional>
-#include <regex>
-#include <string>
-#include <sys/stat.h>
-
-#include "arch/arch.h"
+#include "ast/passes/type_resolver.h"
 #include "ast/ast.h"
 #include "ast/async_event_types.h"
-#include "ast/context.h"
-#include "ast/helpers.h"
-#include "ast/integer_types.h"
+#include "ast/passes/ast_transformer.h"
+#include "ast/passes/cast_creator.h"
+#include "ast/passes/clang_parser.h"
 #include "ast/passes/fold_literals.h"
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
-#include "ast/passes/type_resolver.h"
+#include "ast/passes/type_applicator.h"
 #include "ast/passes/type_system.h"
+#include "ast/visitor.h"
 #include "bpftrace.h"
 #include "btf/compat.h"
 #include "collect_nodes.h"
 #include "config.h"
+#include "config_parser.h"
 #include "log.h"
-#include "probe_matcher.h"
 #include "probe_types.h"
+#include "struct.h"
 #include "types.h"
-#include "util/paths.h"
-#include "util/strings.h"
-#include "util/system.h"
-#include "util/type_name.h"
-#include "util/wildcard.h"
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <functional>
+#include <queue>
 
 namespace bpftrace::ast {
 
 namespace {
 
-struct variable {
-  SizedType type;
-  bool can_resize;
-};
-
-class PassTracker {
-public:
-  void mark_final_pass()
-  {
-    assert(state_ == SecondChance);
-    state_ = FinalPass;
-  }
-  void mark_second_chance()
-  {
-    assert(state_ == Converging);
-    state_ = SecondChance;
-  }
-  void clear_second_chance()
-  {
-    assert(state_ == SecondChance);
-    state_ = Converging;
-  }
-  bool is_final_pass() const
-  {
-    return state_ == FinalPass;
-  }
-  bool is_second_chance() const
-  {
-    return state_ == SecondChance;
-  }
-  void inc_num_unresolved()
-  {
-    num_unresolved_++;
-  }
-  void add_unresolved_branch(IfExpr &if_expr)
-  {
-    unresolved_branches_.push_back(&if_expr);
-  }
-  void reset_num_unresolved()
-  {
-    num_unresolved_ = 0;
-    unresolved_branches_.clear();
-  }
-  int get_num_unresolved() const
-  {
-    return num_unresolved_;
-  }
-  const std::vector<IfExpr *> &get_unresolved_branches()
-  {
-    return unresolved_branches_;
-  }
-  int get_num_passes() const
-  {
-    return num_passes_;
-  }
-  void inc_num_passes()
-  {
-    num_passes_++;
-  }
-
-private:
-  enum State {
-    Converging,
-    SecondChance,
-    FinalPass,
-  };
-  State state_ = Converging;
-  int num_unresolved_ = 0;
-  std::vector<IfExpr *> unresolved_branches_;
-  int num_passes_ = 1;
-};
-
-template <util::TypeName name>
-class AssignMapDisallowed : public Visitor<AssignMapDisallowed<name>> {
-public:
-  explicit AssignMapDisallowed() = default;
-  using Visitor<AssignMapDisallowed>::visit;
-  void visit(AssignMapStatement &assignment)
-  {
-    assignment.addError() << "Map assignments not allowed inside of "
-                          << name.str();
-  }
-};
-
-class TypeResolver : public Visitor<TypeResolver> {
-public:
-  explicit TypeResolver(ASTContext &ctx,
-                        BPFtrace &bpftrace,
-                        CDefinitions &c_definitions,
-                        MapMetadata &map_metadata,
-                        NamedParamDefaults &named_param_defaults,
-                        TypeMetadata &type_metadata,
-                        MacroRegistry &macro_registry)
-      : ctx_(ctx),
-        bpftrace_(bpftrace),
-        c_definitions_(c_definitions),
-        map_metadata_(map_metadata),
-        named_param_defaults_(named_param_defaults),
-        type_metadata_(type_metadata),
-        macro_registry_(macro_registry)
-  {
-  }
-
-  int analyse();
-
-  using Visitor<TypeResolver>::visit;
-  void visit(String &string);
-  void visit(StackMode &mode);
-  void visit(Identifier &identifier);
-  void visit(Builtin &builtin);
-  void visit(Call &call);
-  void visit(Sizeof &szof);
-  void visit(Offsetof &offof);
-  void visit(Typeof &typeof);
-  void visit(Typeinfo &typeinfo);
-  void visit(Map &map);
-  void visit(MapAddr &map_addr);
-  void visit(Variable &var);
-  void visit(VariableAddr &var_addr);
-  void visit(Binop &binop);
-  void visit(Unop &unop);
-  void visit(While &while_block);
-  void visit(For &f);
-  void visit(Jump &jump);
-  void visit(IfExpr &if_expr);
-  void visit(FieldAccess &acc);
-  void visit(ArrayAccess &arr);
-  void visit(TupleAccess &acc);
-  void visit(MapAccess &acc);
-  void visit(Cast &cast);
-  void visit(Tuple &tuple);
-  void visit(Record &record);
-  void visit(Expression &expr);
-  void visit(ExprStatement &expr);
-  void visit(AssignMapStatement &assignment);
-  void visit(AssignVarStatement &assignment);
-  void visit(VarDeclStatement &decl);
-  void visit(Unroll &unroll);
-  void visit(Probe &probe);
-  void visit(BlockExpr &block);
-  void visit(Subprog &subprog);
-  void visit(Comptime &comptime);
-
-private:
-  ASTContext &ctx_;
-  PassTracker pass_tracker_;
-  BPFtrace &bpftrace_;
-  CDefinitions &c_definitions_;
-  MapMetadata &map_metadata_;
-  NamedParamDefaults &named_param_defaults_;
-  TypeMetadata &type_metadata_;
-  const MacroRegistry &macro_registry_;
-
-  bool is_final_pass() const;
-  bool is_first_pass() const;
-  bool is_second_chance() const;
-
-  std::optional<size_t> check(Sizeof &szof);
-  std::optional<size_t> check(Offsetof &offof);
-
-  void check_map_value(Map &map, Call &call, SizedType type);
-
-  bool check_symbol(const Call &call);
-  void check_stack_call(Call &call, bool kernel);
-
-  Probe *get_probe(Node &node, std::string name = "");
-
-  bool is_valid_assignment(const Expression &expr,
-                           bool map_without_type = false);
-  SizedType *get_map_type(const Map &map);
-  SizedType *get_map_key_type(const Map &map);
-  void assign_map_type(Map &map,
-                       const SizedType &type,
-                       const Node *loc_node,
-                       AssignMapStatement *assignment = nullptr);
-  SizedType create_key_type(const SizedType &expr_type, Node &node);
-  void reconcile_map_key(Map *map, Expression &key_expr);
-  std::optional<SizedType> get_promoted_int(
-      const SizedType &leftTy,
-      const SizedType &rightTy,
-      const std::optional<Expression> &leftExpr = std::nullopt,
-      const std::optional<Expression> &rightExpr = std::nullopt);
-  std::optional<SizedType> get_promoted_tuple(const SizedType &leftTy,
-                                              const SizedType &rightTy);
-  std::optional<SizedType> get_promoted_record(const SizedType &storedTy,
-                                               const SizedType &assignTy);
-  std::optional<SizedType> update_int_type(
-      const SizedType &rightTy,
-      Expression &rightExpr,
-      const SizedType &leftTy,
-      std::optional<std::reference_wrapper<Expression>> leftExpr = {});
-  void resolve_struct_type(SizedType &type, Node &node);
-
-  AddrSpace find_addrspace(ProbeType pt);
-
-  void binop_ptr(Binop &op);
-  void binop_int(Binop &op);
-
-  void create_int_cast(Expression &exp, const SizedType &target_type);
-  void create_string_cast(Expression &exp, const SizedType &target_type);
-  void create_tuple_cast(Expression &exp,
-                         const SizedType &curr_type,
-                         const SizedType &target_type);
-  void create_record_cast(Expression &exp,
-                          const SizedType &curr_type,
-                          const SizedType &target_type);
-  void apply_element_cast(Expression &elem,
-                          const SizedType &curr_type,
-                          const SizedType &target_type);
-
-  bool has_error() const;
-
-  // At the moment we iterate over the stack from top to
-  // bottom as variable shadowing is not supported.
-  std::vector<Node *> scope_stack_;
-  Node *top_level_node_ = nullptr;
-
-  // Holds the function currently being visited by this TypeResolver.
-  std::string func_;
-  // This is specifically for visiting Identifiers
-  // in typeof, sizeof, cast, and offsetof expressions
-  // as the ident is treated like a type name, e.g.
-  // `print(sizeof(uint64_t));`
-  bool is_type_name_ = false;
-
-  variable *find_variable(const std::string &var_ident);
-  Node *find_variable_scope(const std::string &var_ident, bool safe = false);
-
-  std::map<Node *, std::map<std::string, variable>> variables_;
-  std::map<Node *, std::map<std::string, VarDeclStatement &>> variable_decls_;
-  std::map<Node *, CollectNodes<Variable>> for_vars_referenced_;
-  std::map<std::string, SizedType> map_val_;
-  std::map<std::string, SizedType> map_key_;
-  std::map<std::string, SizedType> agg_map_val_;
-};
-
-} // namespace
-
-static std::unordered_set<std::string> VOID_RETURNING_FUNCS = {
+std::unordered_set<std::string> VOID_RETURNING_FUNCS = {
   "join", "printf", "errorf", "warnf", "system", "cat",     "debugf",
   "exit", "print",  "clear",  "zero",  "time",   "unwatch", "fail"
 };
 
-// These are special map aggregation types that cannot be assigned
-// to scratch variables or from one map to another e.g. these are both invalid:
-// `@a = hist(10); let $b = @a;`
-// `@a = count(); @b = @a;`
-// However, if the assigned map already contains integers, we implicitly cast
-// the aggregation into an integer to retrieve its value, so this is valid:
-// `@a = count(); @b = 0; @b = @a`
-bool TypeResolver::is_valid_assignment(const Expression &expr,
-                                       bool map_without_type)
-{
-  // Prevent assigning aggregations to another map.
-  if (expr.type().IsMultiKeyMapTy()) {
-    return false;
-  } else if (expr.type().NeedsPercpuMap() && !expr.type().IsCastableMapTy()) {
-    return false;
-  } else if (expr.type().IsCastableMapTy() && map_without_type) {
-    return false;
-  } else if (is_final_pass() &&
-             (expr.type().IsNoneTy() || expr.type().IsVoidTy())) {
-    return false;
-  }
-  return true;
-}
+std::unordered_map<std::string, SizedType (*)()> SIMPLE_BUILTIN_TYPES = {
+  { "pid", CreateUInt32 },
+  { "tid", CreateUInt32 },
+  { "nsecs", CreateUInt64 },
+  { "__builtin_elapsed", CreateUInt64 },
+  { "__builtin_cgroup", CreateUInt64 },
+  { "__builtin_uid", CreateUInt64 },
+  { "__builtin_gid", CreateUInt64 },
+  { "__builtin_cpu", CreateUInt64 },
+  { "__builtin_rand", CreateUInt64 },
+  { "__builtin_jiffies", CreateUInt64 },
+  { "__builtin_ncpus", CreateUInt64 },
+  { "__builtin_username", CreateUsername },
+  { "__builtin_usermode", CreateUInt8 },
+  { "__builtin_cpid", CreateUInt64 },
+};
 
-void TypeResolver::visit(String &string)
-{
-  // Some strings are not part of bpf bytecode, like printf args
-  // so this address space will be ignored
-  string.string_type.SetAS(AddrSpace::kernel);
-}
+std::unordered_map<std::string, SizedType (*)()> SIMPLE_CALL_TYPES = {
+  { "ksym", CreateKSym },          { "usym", CreateUSym },
+  { "cgroupid", CreateUInt64 },    { "cgroup_path", CreateCgroupPath },
+  { "stack_len", CreateInt64 },    { "strftime", CreateTimestamp },
+  { "macaddr", CreateMacAddress }, { "skboutput", CreateUInt32 },
+  { "strncmp", CreateUInt64 },     { "socket_cookie", CreateUInt64 },
+};
 
-void TypeResolver::visit(Identifier &identifier)
-{
-  if (c_definitions_.enums.contains(identifier.ident)) {
-    const auto &enum_name = std::get<1>(c_definitions_.enums[identifier.ident]);
-    identifier.ident_type = CreateEnum(64, enum_name);
-  } else if (bpftrace_.structs.Has(identifier.ident)) {
-    identifier.ident_type = CreateCStruct(
-        identifier.ident, bpftrace_.structs.Lookup(identifier.ident));
-  } else if (func_ == "nsecs") {
-    identifier.ident_type = CreateTimestampMode();
-    if (identifier.ident == "monotonic") {
-      identifier.ident_type.ts_mode = TimestampMode::monotonic;
-    } else if (identifier.ident == "boot") {
-      identifier.ident_type.ts_mode = TimestampMode::boot;
-    } else if (identifier.ident == "tai") {
-      identifier.ident_type.ts_mode = TimestampMode::tai;
-    } else if (identifier.ident == "sw_tai") {
-      identifier.ident_type.ts_mode = TimestampMode::sw_tai;
-    } else {
-      identifier.addError() << "Invalid timestamp mode: " << identifier.ident;
-    }
-  } else {
-    ConfigParser<StackMode> parser;
-    StackMode mode;
-    auto ok = parser.parse(func_, &mode, identifier.ident);
-    if (ok) {
-      identifier.ident_type = CreateStack(true, StackType{ .mode = mode });
-    } else if (is_type_name_) {
-      identifier.ident_type = bpftrace_.btf_->get_stype(identifier.ident);
-    }
-  }
-}
+const std::unordered_map<Type, std::string_view> AGGREGATE_HINTS{
+  { Type::count_t, "count()" },
+  { Type::sum_t, "sum(retval)" },
+  { Type::min_t, "min(retval)" },
+  { Type::max_t, "max(retval)" },
+  { Type::avg_t, "avg(retval)" },
+  { Type::hist_t, "hist(retval)" },
+  { Type::lhist_t, "lhist(rand %10, 0, 10, 1)" },
+  { Type::tseries_t, "tseries(rand %10, 10s, 1)" },
+  { Type::stats_t, "stats(arg2)" },
+};
 
-AddrSpace TypeResolver::find_addrspace(ProbeType pt)
+AddrSpace find_addrspace(ProbeType pt)
 {
   switch (pt) {
     case ProbeType::kprobe:
@@ -359,9 +87,6 @@ AddrSpace TypeResolver::find_addrspace(ProbeType pt)
     case ProbeType::uretprobe:
     case ProbeType::usdt:
       return AddrSpace::user;
-    // case : i:ms:1 (struct x*)ctx)->x
-    // Cannot decide the addrspace. Provide backward compatibility,
-    // if addrspace cannot be detected.
     case ProbeType::invalid:
     case ProbeType::special:
     case ProbeType::test:
@@ -371,69 +96,750 @@ AddrSpace TypeResolver::find_addrspace(ProbeType pt)
     case ProbeType::software:
     case ProbeType::hardware:
     case ProbeType::watchpoint:
-      // Will trigger a warning in selectProbeReadHelper.
       return AddrSpace::none;
   }
   return {}; // unreached
 }
 
-void TypeResolver::visit(Builtin &builtin)
+struct TypeRule {
+  TypeVariable output;
+  std::vector<TypeVariable> inputs;
+  std::function<SizedType(const std::vector<SizedType> &)> resolve;
+};
+
+class TypeResolver {
+public:
+  void set_type(const TypeVariable &node, const SizedType &type)
+  {
+    if (type.IsNoneTy()) {
+      return;
+    }
+    types_[node] = type;
+    seeded_nodes_.push_back(node);
+  }
+
+  const SizedType &get_type(const TypeVariable &node) const
+  {
+    static const SizedType none_type = CreateNone();
+    auto it = types_.find(node);
+    return it != types_.end() ? it->second : none_type;
+  }
+
+  void add_type_rule(TypeRule type_rule)
+  {
+    size_t idx = type_rules_.size();
+    for (const auto &input : type_rule.inputs) {
+      dependents_[input].push_back(idx);
+    }
+    type_rules_.push_back(std::move(type_rule));
+  }
+
+  void add_pass_through(const TypeVariable &source, const TypeVariable &target)
+  {
+    add_type_rule({
+        .output = target,
+        .inputs = { source },
+        .resolve = [](const std::vector<SizedType> &inputs) -> SizedType {
+          return inputs[0];
+        },
+    });
+  }
+
+  void resolve(const std::unordered_set<std::string> &map_value_names)
+  {
+    // Seed worklist from nodes that were set during the visit phase,
+    // in the order they were set (preserves AST visitation order).
+    for (const auto &node : seeded_nodes_) {
+      enqueue_dependents(node);
+    }
+
+    while (!worklist_.empty()) {
+      auto idx = worklist_.front();
+      worklist_.pop();
+      in_worklist_.erase(idx);
+
+      auto &type_rule = type_rules_[idx];
+
+      // Check all inputs are resolved
+      std::vector<SizedType> input_types;
+      input_types.reserve(type_rule.inputs.size());
+      bool all_resolved = true;
+      for (const auto &input : type_rule.inputs) {
+        const auto &t = get_type(input);
+        if (t.IsNoneTy()) {
+          all_resolved = false;
+          break;
+        }
+        input_types.push_back(t);
+      }
+      if (!all_resolved) {
+        continue;
+      }
+
+      auto result_type = type_rule.resolve(input_types);
+      if (result_type.IsNoneTy()) {
+        continue;
+      }
+
+      // N.B. this is ok because nothing lists AST Map nodes as a dependent. AST
+      // Map nodes have two types (key type and value type) so storing and
+      // referencing a single type for an AST Map node is not correct
+      const auto &current_type = types_[type_rule.output];
+
+      // TODO: further investigate and fix this weirdness with address space and
+      // ctx access
+      if (current_type == result_type &&
+          current_type.IsCtxAccess() == result_type.IsCtxAccess() &&
+          (current_type.GetAS() == result_type.GetAS() ||
+           current_type.GetAS() != AddrSpace::none)) {
+        continue;
+      }
+
+      types_[type_rule.output] = result_type;
+      enqueue_dependents(type_rule.output);
+    }
+
+    // There are some map expressions that self initialize, e.g. `@a++` or `@a
+    // +=1` and there are no other assignments to them. Treat these as holding
+    // an int64 value type and try again to resolve them
+    bool had_unresolved_map_values = false;
+    for (const auto &name : map_value_names) {
+      const auto &current_type = get_type(name);
+      if (current_type.IsNoneTy()) {
+        had_unresolved_map_values = true;
+        set_type(name, CreateInt64());
+      }
+    }
+    if (had_unresolved_map_values) {
+      // Re-run the solve
+      resolve(map_value_names);
+    }
+  }
+
+  const ResolvedTypes &get_resolved_types() const
+  {
+    return types_;
+  }
+
+private:
+  ResolvedTypes types_;
+  std::vector<TypeVariable> seeded_nodes_;
+  std::vector<TypeRule> type_rules_;
+  std::unordered_map<TypeVariable, std::vector<size_t>, TypeVariableHash>
+      dependents_;
+  std::queue<size_t> worklist_;
+  std::unordered_set<size_t> in_worklist_;
+
+  void enqueue_dependents(const TypeVariable &node)
+  {
+    auto it = dependents_.find(node);
+    if (it == dependents_.end())
+      return;
+    for (auto idx : it->second) {
+      if (in_worklist_.insert(idx).second) {
+        worklist_.push(idx);
+      }
+    }
+  }
+};
+
+using LockedNodes =
+    std::unordered_map<TypeVariable, SizedType, TypeVariableHash>;
+
+class TypeRuleCollector : public Visitor<TypeRuleCollector> {
+public:
+  explicit TypeRuleCollector(ASTContext &ast,
+                             BPFtrace &bpftrace,
+                             MapMetadata &map_metadata,
+                             CDefinitions &c_definitions,
+                             NamedParamDefaults &named_param_defaults,
+                             TypeMetadata &type_metadata,
+                             const MacroRegistry &macro_registry,
+                             TypeResolver &resolver,
+                             LockedNodes locked_nodes = {})
+      : ast_(ast),
+        bpftrace_(bpftrace),
+        map_metadata_(map_metadata),
+        c_definitions_(c_definitions),
+        named_param_defaults_(named_param_defaults),
+        type_metadata_(type_metadata),
+        macro_registry_(macro_registry),
+        resolver_(resolver),
+        locked_nodes_(std::move(locked_nodes))
+  {
+  }
+
+  using Visitor<TypeRuleCollector>::visit;
+  void visit(ArrayAccess &arr);
+  void visit(AssignMapStatement &assignment);
+  void visit(AssignVarStatement &assignment);
+  void visit(Binop &binop);
+  void visit(BlockExpr &block);
+  void visit(Boolean &boolean);
+  void visit(Builtin &builtin);
+  void visit(Call &call);
+  void visit(Cast &cast);
+  void visit(Comptime &comptime);
+  void visit(ExprStatement &expr);
+  void visit(FieldAccess &acc);
+  void visit(For &f);
+  void visit(Identifier &identifier);
+  void visit(IfExpr &if_expr);
+  void visit(Integer &integer);
+  void visit(Jump &jump);
+  void visit(Map &map);
+  void visit(MapAccess &acc);
+  void visit(MapAddr &map_addr);
+  void visit(NegativeInteger &integer);
+  void visit(Offsetof &offof);
+  void visit(PositionalParameter &param);
+  void visit(PositionalParameterCount &param);
+  void visit(Probe &probe);
+  void visit(Record &record);
+  void visit(Sizeof &szof);
+  void visit(String &str);
+  void visit(Subprog &subprog);
+  void visit(Tuple &tuple);
+  void visit(TupleAccess &acc);
+  void visit(Typeof &typeof);
+  void visit(Typeinfo &typeinfo);
+  void visit(Unop &unop);
+  void visit(VarDeclStatement &decl);
+  void visit(Variable &var);
+  void visit(VariableAddr &var_addr);
+
+  LockedNodes get_locked_nodes();
+
+  const std::vector<Comptime *> &get_unresolved_comptimes() const
+  {
+    return unresolved_comptimes_;
+  }
+
+  const std::unordered_set<std::string> &get_map_value_names() const
+  {
+    return map_value_names_;
+  }
+
+private:
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+  MapMetadata &map_metadata_;
+  CDefinitions &c_definitions_;
+  NamedParamDefaults &named_param_defaults_;
+  TypeMetadata &type_metadata_;
+  const MacroRegistry &macro_registry_;
+  TypeResolver &resolver_;
+  const LockedNodes locked_nodes_;
+  std::unordered_map<Node *, std::unordered_map<std::string, SizedType>>
+      variables_;
+  std::unordered_set<std::string> map_value_names_;
+  std::map<Node *, CollectNodes<Variable>> for_vars_referenced_;
+  // These are variables that have a declaration with a type with a SIZE
+  // let $a: uint16; // type with a size
+  // let $a; // no type no size
+  // let $a: string // type but no size
+  std::unordered_set<ScopedVariable, ScopedVariableHash> sized_decl_vars_;
+  std::vector<Node *> scope_stack_;
+  Probe *probe_ = nullptr;
+  std::string func_; // tracks Call context for Identifier resolution
+  int introspection_level_ = 0;
+  // Only includes ScopedVariables and map keys/value strings
+  std::unordered_set<TypeVariable, TypeVariableHash> introspected_nodes_;
+
+  std::vector<Comptime *> unresolved_comptimes_;
+
+  // This is for tracking type compatibilty for the arguments passed to map
+  // aggregate functions, e.g. `sum`, `avg`, etc.
+  // `sum((uint64)1)` is not compatible with `sum((int64)-1)`
+  std::unordered_map<std::string, SizedType> agg_map_args_;
+
+  // Cached map name strings to avoid repeated allocations
+  std::unordered_map<std::string, std::string> map_key_name_cache_;
+  std::unordered_map<std::string, std::string> map_value_name_cache_;
+
+  const std::string &map_key_name(const std::string &ident)
+  {
+    auto [it, inserted] = map_key_name_cache_.try_emplace(ident);
+    if (inserted) {
+      it->second = get_map_key_name(ident);
+    }
+    return it->second;
+  }
+
+  const std::string &map_value_name(const std::string &ident)
+  {
+    auto [it, inserted] = map_value_name_cache_.try_emplace(ident);
+    if (inserted) {
+      it->second = get_map_value_name(ident);
+    }
+    return it->second;
+  }
+
+  bool resolve_struct_type(SizedType &type, Node &node);
+  bool check_offsetof_type(Offsetof &offof, SizedType cstruct);
+
+  SizedType get_var_type(const ScopedVariable &scoped_var,
+                         const SizedType &type,
+                         Node &error_node);
+  SizedType get_map_value_type(const std::string &map_name,
+                               const SizedType &type,
+                               Node &error_node);
+  SizedType get_agg_map_type(const std::string &map_name,
+                             const SizedType &type,
+                             Call &call);
+  SizedType get_map_key_type(const std::string &map_name,
+                             const SizedType &type,
+                             Node &error_node);
+  void check_unresolved_maps();
+  Node *find_variable_scope(const std::string &var_ident, bool safe = true);
+  SizedType get_locked_node(const TypeVariable &node,
+                            const SizedType &type,
+                            Node &error_node,
+                            const std::string &name);
+  Probe *get_probe();
+  Probe *get_probe(Node &node, std::string name = "");
+  void check_stack_call(Call &call, bool kernel);
+};
+
+SizedType binop_ptr(Binop &binop, const SizedType &lht, const SizedType &rht)
 {
-  if (builtin.ident == "ctx") {
+  bool left_is_ptr = lht.IsPtrTy();
+  const auto &ptr = left_is_ptr ? lht : rht;
+  const auto &other = left_is_ptr ? rht : lht;
+
+  bool compare = is_comparison_op(binop.op);
+  bool logical = binop.op == Operator::LAND || binop.op == Operator::LOR;
+
+  auto invalid_op = [&binop, &lht, &rht]() -> SizedType {
+    binop.addError() << "The " << opstr(binop)
+                     << " operator can not be used on expressions of types "
+                     << lht << ", " << rht;
+    return CreateNone();
+  };
+
+  // Binop on two pointers
+  if (other.IsPtrTy()) {
+    if (compare) {
+      const auto le = lht.GetPointeeTy();
+      const auto re = rht.GetPointeeTy();
+      if (le != re) {
+        auto &warn = binop.addWarning();
+        warn << "comparison of distinct pointer types: " << le << ", " << re;
+        warn.addContext(binop.left.loc()) << "left (" << le << ")";
+        warn.addContext(binop.right.loc()) << "right (" << re << ")";
+      }
+      return CreateBool();
+    } else if (!logical) {
+      return invalid_op();
+    } else {
+      return CreateBool();
+    }
+  }
+  // Binop on a pointer and (int or bool)
+  else if (other.IsIntTy() || other.IsBoolTy()) {
+    // sum is associative but minus only works with pointer on the left hand
+    // side
+    if (binop.op == Operator::MINUS && !left_is_ptr)
+      return invalid_op();
+    else if (binop.op == Operator::PLUS || binop.op == Operator::MINUS)
+      return CreatePointer(ptr.GetPointeeTy(), ptr.GetAS());
+    else if (!compare && !logical)
+      return invalid_op();
+
+    if (compare) {
+      return CreateBool();
+    } else {
+      return invalid_op();
+    }
+  }
+  // Binop on a pointer and something else
+  else {
+    return invalid_op();
+  }
+}
+
+SizedType binop_int(Binop &binop, const SizedType &lht, const SizedType &rht)
+{
+  auto is_comparison = is_comparison_op(binop.op);
+  if (lht == rht) {
+    if (is_comparison) {
+      return CreateBool();
+    } else {
+      if (lht.IsSigned()) {
+        return CreateInt64();
+      }
+      return CreateUInt64();
+    }
+  }
+
+  bool show_warning = false;
+  bool mismatched_sign = rht.IsSigned() != lht.IsSigned();
+  // N.B. all castable map values are 64 bits
+  if (lht.IsCastableMapTy()) {
+    if (rht.IsCastableMapTy()) {
+      show_warning = mismatched_sign;
+    } else {
+      if (!get_promoted_type(rht, CreateInteger(64, lht.IsSigned()))) {
+        show_warning = true;
+      }
+    }
+  } else if (rht.IsCastableMapTy()) {
+    if (!get_promoted_type(lht, CreateInteger(64, rht.IsSigned()))) {
+      show_warning = true;
+    }
+  } else if (!get_promoted_type(lht, rht)) {
+    show_warning = true;
+  }
+
+  if (show_warning) {
+    switch (binop.op) {
+      case Operator::EQ:
+      case Operator::NE:
+      case Operator::LE:
+      case Operator::GE:
+      case Operator::LT:
+      case Operator::GT:
+        binop.addWarning() << "comparison of integers of different signs: '"
+                           << lht << "' and '" << rht << "'"
+                           << " can lead to undefined behavior";
+        break;
+      case Operator::PLUS:
+      case Operator::MINUS:
+      case Operator::MUL:
+      case Operator::DIV:
+      case Operator::MOD:
+        binop.addWarning() << "arithmetic on integers of different signs: '"
+                           << lht << "' and '" << rht << "'"
+                           << " can lead to undefined behavior";
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (is_comparison) {
+    return CreateBool();
+  }
+
+  // Next, warn on any operations that require signed division.
+  //
+  // SDIV is not implemented for bpf. See Documentation/bpf/bpf_design_QA
+  // in kernel sources
+  if (binop.op == Operator::DIV || binop.op == Operator::MOD) {
+    // If they're still signed, we have to warn
+    if (lht.IsSigned() || rht.IsSigned()) {
+      binop.addWarning() << "signed operands for '" << opstr(binop)
+                         << "' can lead to undefined behavior "
+                         << "(cast to unsigned to silence warning)";
+    }
+  }
+  if (lht.IsSigned() || rht.IsSigned()) {
+    return CreateInt64();
+  }
+
+  return CreateUInt64();
+}
+
+SizedType get_binop_type(Binop &binop,
+                         const SizedType &lht,
+                         const SizedType &rht)
+{
+  bool is_comparison = is_comparison_op(binop.op);
+
+  if (lht.IsBoolTy() && rht.IsBoolTy()) {
+    return CreateBool();
+  }
+
+  bool lsign = lht.IsSigned();
+  bool rsign = rht.IsSigned();
+  bool is_int_binop = (lht.IsCastableMapTy() || lht.IsIntTy() ||
+                       lht.IsBoolTy()) &&
+                      (rht.IsCastableMapTy() || rht.IsIntTy() ||
+                       rht.IsBoolTy());
+
+  bool is_signed = lsign || rsign;
+  switch (binop.op) {
+    case Operator::LEFT:
+    case Operator::RIGHT:
+      is_signed = lsign;
+      break;
+    default:
+      break;
+  }
+
+  if (lht.IsPtrTy() || rht.IsPtrTy()) {
+    return binop_ptr(binop, lht, rht);
+  }
+
+  auto result_type = is_comparison ? CreateBool()
+                                   : CreateInteger(64, is_signed);
+  auto addr_lhs = lht.GetAS();
+  auto addr_rhs = rht.GetAS();
+
+  // if lhs or rhs has different addrspace (not none), then set the
+  // addrspace to none. This preserves the behaviour for x86.
+  if (addr_lhs != addr_rhs && addr_lhs != AddrSpace::none &&
+      addr_rhs != AddrSpace::none) {
+    binop.addWarning() << "Addrspace mismatch";
+    result_type.SetAS(AddrSpace::none);
+  }
+  // Associativity from left to right for binary operator
+  else if (addr_lhs != AddrSpace::none) {
+    result_type.SetAS(addr_lhs);
+  } else {
+    // In case rhs is none, then this triggers warning in
+    // selectProbeReadHelper.
+    result_type.SetAS(addr_rhs);
+  }
+
+  if (is_int_binop) {
+    auto int_type = binop_int(binop, lht, rht);
+    int_type.SetAS(result_type.GetAS());
+    return int_type;
+  }
+
+  return result_type;
+}
+
+bool TypeRuleCollector::check_offsetof_type(Offsetof &offof, SizedType cstruct)
+{
+  // Check if all sub-fields are present.
+  for (const auto &field : offof.field) {
+    if (!cstruct.IsCStructTy()) {
+      offof.addError() << "'" << cstruct << "' " << "is not a c_struct type.";
+      return false;
+    } else if (!bpftrace_.structs.Has(cstruct.GetName())) {
+      offof.addError() << "'" << cstruct.GetName() << "' does not exist.";
+      return false;
+    } else if (!cstruct.HasField(field)) {
+      offof.addError() << "'" << cstruct.GetName() << "' "
+                       << "has no field named " << "'" << field << "'";
+      return false;
+    } else {
+      // Get next sub-field
+      const auto &f = cstruct.GetField(field);
+      cstruct = f.type;
+    }
+  }
+  return true;
+}
+
+// These are special map aggregation types that cannot be assigned
+// to scratch variables and map values/keys:
+// @a = count();                  // OK
+// @a = 1; @b = count(); @a = @b; // OK
+// @a = 1; @b = hist(); @a = @b;  // NOK
+// @b = count(); @a = @b;         // NOK
+// @a = 1; @a = count();          // NOK
+// @a = count(); @a = 1;          // NOK
+// @a = count(); @a = sum(5);     // NOK
+bool is_valid_assignment(const SizedType &type,
+                         const SizedType &current_type,
+                         bool is_map_assignment = false)
+{
+  if (type.IsVoidTy()) {
+    return false;
+  } else if (type.NeedsPercpuMap() && !type.IsCastableMapTy()) {
+    return false;
+  } else if (!current_type.IsIntegerTy() && type.IsCastableMapTy()) {
+    // Assigning to maps with no value type yet is not allowed (mostly to
+    // prevent user confusion)
+    // @b = count(); @a = @b;
+    // But assigning to scratch variables or map keys is OK
+    if (is_map_assignment) {
+      return false;
+    } else if (!current_type.IsNoneTy()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+void TypeRuleCollector::visit(ArrayAccess &arr)
+{
+  visit(arr.expr);
+  visit(arr.indexpr);
+
+  resolver_.add_type_rule({
+      .output = &arr,
+      .inputs = { &arr.expr.node() },
+      .resolve = [&arr](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        SizedType elem;
+        if (type.IsArrayTy()) {
+          elem = type.GetElementTy();
+        } else if (type.IsPtrTy()) {
+          elem = type.GetPointeeTy();
+        } else if (type.IsStringTy()) {
+          elem = CreateInt8();
+        } else if (type.IsTupleTy()) {
+          if (auto *integer = arr.indexpr.as<Integer>()) {
+            if (static_cast<ssize_t>(integer->value) >= type.GetFieldCount()) {
+              arr.addError()
+                  << "Invalid tuple index: " << integer->value << ". Found "
+                  << type.GetFields().size() << " elements in tuple.";
+            } else {
+              elem = type.GetField(integer->value).type;
+            }
+          }
+        } else {
+          arr.addError() << "The array index operator [] can only be "
+                            "used on arrays, pointers, and tuples, found "
+                         << type << ".";
+        }
+
+        elem.SetAS(type.GetAS());
+
+        // BPF verifier cannot track BTF information for double pointers so we
+        // cannot propagate is_internal for arrays of pointers and we need to
+        // reset it on the array type as well. Indexing a pointer as an array
+        // also can't be verified, so the same applies there.
+        if (elem.IsPtrTy() || type.IsPtrTy()) {
+          elem.is_internal = false;
+        } else {
+          elem.is_internal = type.is_internal;
+        }
+
+        return elem;
+      },
+  });
+}
+
+void TypeRuleCollector::visit(AssignMapStatement &assignment)
+{
+  visit(assignment.map_access);
+  visit(assignment.expr);
+
+  auto map_name = assignment.map_access->map->ident;
+  const auto &value_name = map_value_name(map_name);
+
+  resolver_.add_type_rule({
+      .output = value_name,
+      .inputs = { &assignment.expr.node() },
+      .resolve = [this, &assignment, map_name](
+                     const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        const auto &value_name = map_value_name(map_name);
+        const auto &current_type = resolver_.get_type(value_name);
+
+        if (!is_valid_assignment(type, current_type, true)) {
+          auto &err = assignment.addError();
+          auto hint = AGGREGATE_HINTS.find(type.GetTy());
+          if (hint != AGGREGATE_HINTS.end()) {
+            err << "Map value '" << type
+                << "' cannot be assigned from one map to another. "
+                   "The function that returns this type must be called "
+                   "directly "
+                   "e.g. "
+                   "`"
+                << assignment.map_access->map->ident << " = " << hint->second
+                << ";`.";
+            if (const auto *acc = assignment.expr.as<MapAccess>()) {
+              if (type.IsCastableMapTy()) {
+                err.addHint()
+                    << "Add a cast to integer if you want the value of the "
+                       "aggregate, "
+                    << "e.g. `" << assignment.map_access->map->ident
+                    << " = (int64)" << acc->map->ident << ";`.";
+              }
+            }
+          } else {
+            err << "Value '" << type << "' cannot be assigned to a map.";
+          }
+
+          return CreateNone();
+        }
+
+        return get_map_value_type(map_name, type, assignment);
+      },
+  });
+}
+
+void TypeRuleCollector::visit(AssignVarStatement &assignment)
+{
+  visit(assignment.expr);
+  visit(assignment.var_decl);
+
+  Node *var_scope = find_variable_scope(assignment.var()->ident);
+  ScopedVariable scoped_var = std::make_pair(var_scope,
+                                             assignment.var()->ident);
+
+  // Ignore the RHS to determine the type of this variable and issue errors
+  // later if the RHS type is not compatible or doesn't fit into this sized
+  // declaration type
+  if (sized_decl_vars_.contains(scoped_var)) {
+    return;
+  }
+
+  resolver_.add_type_rule({
+      .output = scoped_var,
+      .inputs = { &assignment.expr.node() },
+      .resolve = [this, &assignment, scoped_var](
+                     const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        if (!is_valid_assignment(type, resolver_.get_type(scoped_var))) {
+          assignment.addError()
+              << "Value '" << type
+              << "' cannot be assigned to a scratch variable.";
+          return CreateNone();
+        }
+
+        return get_var_type(scoped_var, type, assignment);
+      },
+  });
+}
+
+void TypeRuleCollector::visit(Builtin &builtin)
+{
+  SizedType builtin_type = CreateNone();
+  auto simple_it = SIMPLE_BUILTIN_TYPES.find(builtin.ident);
+  if (simple_it != SIMPLE_BUILTIN_TYPES.end()) {
+    builtin_type = simple_it->second();
+  } else if (builtin.ident == "ctx") {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
       return;
     ProbeType pt = probetype(probe->attach_points[0]->provider);
     bpf_prog_type bt = progtype(pt);
     std::string func = probe->attach_points[0]->func;
-    builtin.builtin_type = CreatePointer(CreateNone());
+    builtin_type = CreatePointer(CreateNone());
     switch (bt) {
       case BPF_PROG_TYPE_KPROBE: {
         auto record = bpftrace_.structs.Lookup("struct pt_regs");
         if (!record.expired()) {
-          builtin.builtin_type = CreatePointer(
-              CreateCStruct("struct pt_regs", record), AddrSpace::kernel);
-          builtin.builtin_type.MarkCtxAccess();
+          builtin_type = CreatePointer(CreateCStruct("struct pt_regs", record),
+                                       AddrSpace::kernel);
+          builtin_type.MarkCtxAccess();
         }
         break;
       }
       case BPF_PROG_TYPE_PERF_EVENT:
-        builtin.builtin_type = CreatePointer(
+        builtin_type = CreatePointer(
             CreateCStruct("struct bpf_perf_event_data",
                           bpftrace_.structs.Lookup(
                               "struct bpf_perf_event_data")),
             AddrSpace::kernel);
-        builtin.builtin_type.MarkCtxAccess();
+        builtin_type.MarkCtxAccess();
         break;
       case BPF_PROG_TYPE_TRACING:
         if (pt == ProbeType::iter) {
           std::string type = "struct bpf_iter__" + func;
-          builtin.builtin_type = CreatePointer(
+          builtin_type = CreatePointer(
               CreateCStruct(type, bpftrace_.structs.Lookup(type)),
               AddrSpace::kernel);
-          builtin.builtin_type.MarkCtxAccess();
+          builtin_type.MarkCtxAccess();
         }
         break;
       default:
         break;
     }
-  } else if (builtin.ident == "pid" || builtin.ident == "tid") {
-    builtin.builtin_type = CreateUInt32();
-  } else if (builtin.ident == "nsecs" || builtin.ident == "__builtin_elapsed" ||
-             builtin.ident == "__builtin_cgroup" ||
-             builtin.ident == "__builtin_uid" ||
-             builtin.ident == "__builtin_gid" ||
-             builtin.ident == "__builtin_cpu" ||
-             builtin.ident == "__builtin_rand" ||
-             builtin.ident == "__builtin_jiffies" ||
-             builtin.ident == "__builtin_ncpus") {
-    builtin.builtin_type = CreateUInt64();
   } else if (builtin.ident == "__builtin_curtask") {
-    // Retype curtask to its original type: struct task_struct.
-    builtin.builtin_type = CreatePointer(
-        CreateCStruct("struct task_struct",
-                      bpftrace_.structs.Lookup("struct task_struct")),
-        AddrSpace::kernel);
+    builtin_type = CreatePointer(CreateCStruct("struct task_struct",
+                                               bpftrace_.structs.Lookup(
+                                                   "struct task_struct")),
+                                 AddrSpace::kernel);
   } else if (builtin.ident == "__builtin_retval") {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
@@ -443,57 +849,46 @@ void TypeResolver::visit(Builtin &builtin)
       const auto *arg = bpftrace_.structs.GetProbeArg(*probe,
                                                       RETVAL_FIELD_NAME);
       if (arg) {
-        builtin.builtin_type = arg->type;
+        builtin_type = arg->type;
       } else
         builtin.addError() << "Can't find a field " << RETVAL_FIELD_NAME;
     } else {
-      builtin.builtin_type = CreateUInt64();
+      builtin_type = CreateUInt64();
     }
-    // For kretprobe, fentry, fexit -> AddrSpace::kernel
-    // For uretprobe -> AddrSpace::user
-    builtin.builtin_type.SetAS(find_addrspace(type));
+    builtin_type.SetAS(find_addrspace(type));
   } else if (builtin.ident == "kstack") {
     if (bpftrace_.config_->stack_mode == StackMode::build_id) {
       builtin.addWarning() << "'build_id' stack mode can only be used for "
                               "ustack. Falling back to 'raw' mode.";
-      builtin.builtin_type = CreateStack(true,
-                                         StackType{ .mode = StackMode::raw });
+      builtin_type = CreateStack(true, StackType{ .mode = StackMode::raw });
     } else {
-      builtin.builtin_type = CreateStack(
+      builtin_type = CreateStack(
           true, StackType{ .mode = bpftrace_.config_->stack_mode });
     }
   } else if (builtin.ident == "ustack") {
-    builtin.builtin_type = CreateStack(
+    builtin_type = CreateStack(
         false, StackType{ .mode = bpftrace_.config_->stack_mode });
   } else if (builtin.ident == "__builtin_comm") {
     constexpr int COMM_SIZE = 16;
-    builtin.builtin_type = CreateString(COMM_SIZE);
-    // comm allocated in the bpf stack. See codegen
-    // Case: @=comm and strncmp(@, "name")
-    builtin.builtin_type.SetAS(AddrSpace::kernel);
+    builtin_type = CreateString(COMM_SIZE);
+    builtin_type.SetAS(AddrSpace::kernel);
   } else if (builtin.ident == "__builtin_func") {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
       return;
     ProbeType type = probe->get_probetype();
     if (type == ProbeType::uprobe || type == ProbeType::uretprobe) {
-      builtin.builtin_type = CreateUSym();
+      builtin_type = CreateUSym();
     } else {
-      builtin.builtin_type = CreateKSym();
+      builtin_type = CreateKSym();
     }
   } else if (builtin.is_argx()) {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
       return;
-    builtin.builtin_type = CreateUInt64();
-    builtin.builtin_type.SetAS(
+    builtin_type = CreateUInt64();
+    builtin_type.SetAS(
         find_addrspace(probetype(probe->attach_points[0]->provider)));
-  } else if (builtin.ident == "__builtin_username") {
-    builtin.builtin_type = CreateUsername();
-  } else if (builtin.ident == "__builtin_usermode") {
-    builtin.builtin_type = CreateUInt8();
-  } else if (builtin.ident == "__builtin_cpid") {
-    builtin.builtin_type = CreateUInt64();
   } else if (builtin.ident == "args") {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
@@ -508,48 +903,48 @@ void TypeResolver::visit(Builtin &builtin)
 
     if (type == ProbeType::fentry || type == ProbeType::fexit ||
         type == ProbeType::uprobe || type == ProbeType::rawtracepoint) {
-      builtin.builtin_type = CreateCStruct(
-          *type_name, bpftrace_.structs.Lookup(*type_name));
-      if (builtin.builtin_type.GetFieldCount() == 0)
+      builtin_type = CreateCStruct(*type_name,
+                                   bpftrace_.structs.Lookup(*type_name));
+      if (builtin_type.GetFieldCount() == 0)
         builtin.addError() << "Cannot read function parameters";
 
-      builtin.builtin_type.MarkCtxAccess();
-      builtin.builtin_type.is_funcarg = true;
-      builtin.builtin_type.SetAS(type == ProbeType::uprobe ? AddrSpace::user
-                                                           : AddrSpace::kernel);
-      // We'll build uprobe args struct on stack
+      builtin_type.MarkCtxAccess();
+      builtin_type.is_funcarg = true;
+      builtin_type.SetAS(type == ProbeType::uprobe ? AddrSpace::user
+                                                   : AddrSpace::kernel);
       if (type == ProbeType::uprobe)
-        builtin.builtin_type.is_internal = true;
+        builtin_type.is_internal = true;
     } else if (type == ProbeType::tracepoint) {
-      builtin.builtin_type = CreateCStruct(
-          *type_name, bpftrace_.structs.Lookup(*type_name));
-      builtin.builtin_type.SetAS(probe->attach_points.front()->target ==
-                                         "syscalls"
-                                     ? AddrSpace::user
-                                     : AddrSpace::kernel);
-      builtin.builtin_type.MarkCtxAccess();
+      builtin_type = CreateCStruct(*type_name,
+                                   bpftrace_.structs.Lookup(*type_name));
+      builtin_type.SetAS(probe->attach_points.front()->target == "syscalls"
+                             ? AddrSpace::user
+                             : AddrSpace::kernel);
+      builtin_type.MarkCtxAccess();
     }
   } else {
     LOG(BUG) << "Unknown builtin variable: '" << builtin.ident << "'";
   }
+  resolver_.set_type(&builtin, builtin_type);
 }
 
-void TypeResolver::visit(Call &call)
+void TypeRuleCollector::visit(Call &call)
 {
+  // RAII setter for func_ context (used by Identifier resolution)
   struct func_setter {
-    func_setter(TypeResolver &analyser, const std::string &s)
-        : analyser_(analyser), old_func_(analyser_.func_)
+    func_setter(TypeRuleCollector &pass, const std::string &s)
+        : pass_(pass), old_func_(pass_.func_)
     {
-      analyser_.func_ = s;
+      pass_.func_ = s;
     }
 
     ~func_setter()
     {
-      analyser_.func_ = old_func_;
+      pass_.func_ = old_func_;
     }
 
   private:
-    TypeResolver &analyser_;
+    TypeRuleCollector &pass_;
     std::string old_func_;
   };
 
@@ -559,207 +954,227 @@ void TypeResolver::visit(Call &call)
     visit(varg);
   }
 
+  // These map aggregate functions are the only ones that can set the map value
+  // types to the corresponding aggregate types. For example `@a = count();`
+  // gets desuggared to `count(@a, 0)` However some of these aggregation types
+  // are castable to ints so this is ok:
+  // `@a = count(); @b = 1; @b = @a;` but the value type of `@b` remains an
+  // integer not `count_t`.
   if (getAssignRewriteFuncs().contains(call.func)) {
     if (auto *map = call.vargs.at(0).as<Map>()) {
-      if (call.func == "sum" || call.func == "min" || call.func == "max" ||
-          call.func == "avg" || call.func == "stats") {
-        if (call.vargs.size() != 3) {
-          // This is an error in a later pass.
-          return;
-        }
+      auto map_name = map->ident;
+
+      if (call.func == "count" || call.func == "hist" || call.func == "lhist" ||
+          call.func == "tseries") {
+        resolver_.add_type_rule({
+            .output = map_value_name(map_name),
+            .inputs = { &call },
+            .resolve = [this, &call, map_name](
+                           const std::vector<SizedType> &) -> SizedType {
+              SizedType agg_type;
+              if (call.func == "count") {
+                agg_type = CreateCount();
+              } else if (call.func == "hist") {
+                agg_type = CreateHist();
+              } else if (call.func == "lhist") {
+                agg_type = CreateLhist();
+              } else if (call.func == "tseries") {
+                agg_type = CreateTSeries();
+              }
+
+              return get_agg_map_type(map_name, agg_type, call);
+            },
+        });
+      } else {
+        // N.B. @a = sum(5); gets desugared to _ = sum(@x, 0, 5); so we have to
+        // set the consumer of this map aggregate function to be the map value
+        // name directly and also add the resolved call type in the callback
+        resolver_.add_type_rule({
+            .output = map_value_name(map_name),
+            .inputs = { &call.vargs.at(2).node() },
+            .resolve = [this, &call, map_name](
+                           const std::vector<SizedType> &inputs) -> SizedType {
+              const auto &type = inputs[0];
+              if (!type.IsIntegerTy()) {
+                call.addError()
+                    << call.func << "() only supports integer arguments ("
+                    << type << " provided)";
+                return CreateNone();
+              }
+
+              SizedType agg_type;
+              if (call.func == "avg") {
+                agg_type = CreateAvg(type.IsSigned());
+              } else if (call.func == "max") {
+                agg_type = CreateMax(type.IsSigned());
+              } else if (call.func == "min") {
+                agg_type = CreateMin(type.IsSigned());
+              } else if (call.func == "stats") {
+                agg_type = CreateStats(type.IsSigned());
+              } else if (call.func == "sum") {
+                agg_type = CreateSum(type.IsSigned());
+              }
+
+              // Check if the arguments passed are compatible with each other
+              auto found = agg_map_args_.find(map_name);
+              if (found == agg_map_args_.end()) {
+                agg_map_args_[map_name] = type;
+              } else {
+                auto promoted = get_promoted_type(found->second, type);
+                if (!promoted) {
+                  call.addError() << "Type mismatch for " << call.func << ": "
+                                  << "trying to call function with type '"
+                                  << type << "' when it already has a type '"
+                                  << found->second << "'";
+                  return CreateNone();
+                } else {
+                  found->second = *promoted;
+                }
+              }
+
+              return get_agg_map_type(map_name, agg_type, call);
+            },
+        });
       }
-      if (call.func == "avg") {
-        check_map_value(*map,
-                        call,
-                        CreateAvg(call.vargs.at(2).type().IsSigned()));
-      } else if (call.func == "count") {
-        check_map_value(*map, call, CreateCount());
-      } else if (call.func == "hist") {
-        check_map_value(*map, call, CreateHist());
-      } else if (call.func == "lhist") {
-        check_map_value(*map, call, CreateLhist());
-      } else if (call.func == "tseries") {
-        check_map_value(*map, call, CreateTSeries());
-      } else if (call.func == "max") {
-        check_map_value(*map,
-                        call,
-                        CreateMax(call.vargs.at(2).type().IsSigned()));
-      } else if (call.func == "min") {
-        check_map_value(*map,
-                        call,
-                        CreateMin(call.vargs.at(2).type().IsSigned()));
-      } else if (call.func == "stats") {
-        check_map_value(*map,
-                        call,
-                        CreateStats(call.vargs.at(2).type().IsSigned()));
-      } else if (call.func == "sum") {
-        check_map_value(*map,
-                        call,
-                        CreateSum(call.vargs.at(2).type().IsSigned()));
-      }
-      // This reconciles the argument if the other one is a map, but otherwise
-      // we don't specifically emit an error. `map_type_spec` above does that.
-      reconcile_map_key(map, call.vargs.at(1));
+
+      // 2nd arg is the key
+      resolver_.add_type_rule({
+          .output = map_key_name(map_name),
+          .inputs = { &call.vargs.at(1).node() },
+          .resolve = [this, &call, map_name](
+                         const std::vector<SizedType> &inputs) -> SizedType {
+            return get_map_key_type(map_name, inputs[0], call);
+          },
+      });
+
+      resolver_.set_type(&call, CreateVoid());
     } else {
       call.vargs.at(0).node().addError()
           << call.func << "() expects a map argument";
     }
-  }
+  } else {
+    SizedType return_type = CreateNone();
+    if (VOID_RETURNING_FUNCS.contains(call.func)) {
+      return_type = CreateVoid();
+    } else if (auto it = SIMPLE_CALL_TYPES.find(call.func);
+               it != SIMPLE_CALL_TYPES.end()) {
+      return_type = it->second();
+    } else if (call.func == "str") {
+      auto strlen = bpftrace_.config_->max_strlen;
+      if (call.vargs.size() == 2) {
+        if (auto *integer = call.vargs.at(1).as<Integer>()) {
+          if (integer->value + 1 > strlen) {
+            call.addWarning() << "length param (" << integer->value
+                              << ") is too long and will be shortened to "
+                              << strlen << " bytes (see BPFTRACE_MAX_STRLEN)";
+          } else {
+            strlen = integer->value + 1;
+          }
+        }
 
-  if (getRawMapArgFuncs().contains(call.func) && !call.vargs.empty()) {
-    if (auto *map = call.vargs.at(0).as<Map>()) {
-      if (!get_map_type(*map) && !is_first_pass()) {
-        map->addError() << "Undefined map: " + map->ident;
+        if (auto *integer = dynamic_cast<NegativeInteger *>(
+                call.vargs.at(1).as<NegativeInteger>())) {
+          call.addError() << call.func << "cannot use negative length ("
+                          << integer->value << ")";
+        }
       }
-    } else if (call.func != "print") {
-      call.vargs.at(0).node().addError()
-          << call.func << "() expects a map argument";
-    }
-  }
+      return_type = CreateString(strlen);
+      return_type.SetAS(AddrSpace::kernel);
+    } else if (call.func == "buf") {
+      const uint64_t max_strlen = bpftrace_.config_->max_strlen;
+      uint32_t max_buffer_size = max_strlen - sizeof(AsyncEvent::Buf);
+      uint32_t buffer_size = max_buffer_size;
 
-  if (getAssignRewriteFuncs().contains(call.func) ||
-      VOID_RETURNING_FUNCS.contains(call.func)) {
-    call.return_type = CreateVoid();
-  } else if (call.func == "str") {
-    auto strlen = bpftrace_.config_->max_strlen;
-    if (call.vargs.size() == 2) {
-      if (auto *integer = call.vargs.at(1).as<Integer>()) {
-        if (integer->value + 1 > strlen) {
-          call.addWarning() << "length param (" << integer->value
-                            << ") is too long and will be shortened to "
-                            << strlen << " bytes (see BPFTRACE_MAX_STRLEN)";
-        } else {
-          strlen = integer->value + 1; // Storage for NUL byte.
+      if (call.vargs.size() == 1) {
+        resolver_.add_type_rule({
+            .output = &call,
+            .inputs = { &call.vargs.at(0).node() },
+            .resolve = [this, &call, max_buffer_size](
+                           const std::vector<SizedType> &inputs) -> SizedType {
+              const auto &type = inputs[0];
+              uint32_t buffer_size = max_buffer_size;
+              if (type.IsArrayTy()) {
+                buffer_size = type.GetNumElements() *
+                              type.GetElementTy().GetSize();
+              }
+              buffer_size = std::min(buffer_size, max_buffer_size);
+
+              auto return_type = CreateBuffer(buffer_size);
+              return_type.SetAS(AddrSpace::kernel);
+              return return_type;
+            },
+        });
+        return;
+      } else if (call.vargs.size() == 2) {
+        if (auto *integer = call.vargs.at(1).as<Integer>()) {
+          buffer_size = integer->value;
         }
       }
 
-      if (auto *integer = dynamic_cast<NegativeInteger *>(
-              call.vargs.at(1).as<NegativeInteger>())) {
-        call.addError() << call.func << "cannot use negative length ("
-                        << integer->value << ")";
-      } else {
-        // In codegen we compare against the BPFTRACE_MAX_STRLEN
-        // which is set as a 64 bit int
-        create_int_cast(call.vargs.at(1), CreateUInt64());
-      }
-    }
-    call.return_type = CreateString(strlen);
-    call.return_type.SetAS(AddrSpace::kernel);
-  } else if (call.func == "buf") {
-    const uint64_t max_strlen = bpftrace_.config_->max_strlen;
-    // Subtract out metadata headroom
-    uint32_t max_buffer_size = max_strlen - sizeof(AsyncEvent::Buf);
-    uint32_t buffer_size = max_buffer_size;
+      buffer_size = std::min(buffer_size, max_buffer_size);
 
-    if (call.vargs.size() == 1) {
-      auto &arg = call.vargs.at(0);
-      if (arg.type().IsArrayTy()) {
-        buffer_size = arg.type().GetNumElements() *
-                      arg.type().GetElementTy().GetSize();
-      }
-    } else if (call.vargs.size() == 2) {
-      if (auto *integer = call.vargs.at(1).as<Integer>()) {
-        buffer_size = integer->value;
-      }
-    }
-
-    if (buffer_size > max_buffer_size) {
-      if (is_final_pass())
-        call.addWarning() << call.func
-                          << "() length is too long and will be shortened to "
-                          << std::to_string(max_strlen)
-                          << " bytes (see BPFTRACE_MAX_STRLEN)";
-
-      buffer_size = max_buffer_size;
-    }
-
-    call.return_type = CreateBuffer(buffer_size);
-    // Consider case : $a = buf("hi", 2); $b = buf("bye", 3);  $a == $b
-    // The result of buf is copied to bpf stack. Hence kernel probe read
-    call.return_type.SetAS(AddrSpace::kernel);
-  } else if (call.func == "ksym" || call.func == "usym") {
-    // allow symbol lookups on casts (eg, function pointers)
-    if (!call.vargs.empty()) {
-      auto &arg = call.vargs.at(0);
-      const auto &type = arg.type();
-      if (type.IsIntegerTy() && type.GetSize() != 8) {
-        create_int_cast(call.vargs.at(0), CreateInt64());
-      }
-    }
-
-    if (call.func == "ksym")
-      call.return_type = CreateKSym();
-    else if (call.func == "usym")
-      call.return_type = CreateUSym();
-  } else if (call.func == "ntop") {
-    int buffer_size = 24;
-    call.return_type = CreateInet(buffer_size);
-  } else if (call.func == "pton") {
-    int af_type = 0, addr_size = 0;
-    std::string addr;
-    if (call.vargs.size() == 1) {
-      if (auto *str = call.vargs.at(0).as<String>()) {
-        addr = str->value;
-        // use '.' and ':' to determine the address family
-        if (addr.find(".") != std::string::npos) {
-          af_type = AF_INET;
-          addr_size = 4;
-        } else if (addr.find(":") != std::string::npos) {
-          af_type = AF_INET6;
-          addr_size = 16;
+      return_type = CreateBuffer(buffer_size);
+      return_type.SetAS(AddrSpace::kernel);
+    } else if (call.func == "ntop") {
+      int buffer_size = 24;
+      return_type = CreateInet(buffer_size);
+    } else if (call.func == "pton") {
+      int af_type = 0, addr_size = 0;
+      std::string addr;
+      if (call.vargs.size() == 1) {
+        if (auto *str = call.vargs.at(0).as<String>()) {
+          addr = str->value;
+          if (addr.find(".") != std::string::npos) {
+            af_type = AF_INET;
+            addr_size = 4;
+          } else if (addr.find(":") != std::string::npos) {
+            af_type = AF_INET6;
+            addr_size = 16;
+          } else {
+            call.addError()
+                << call.func
+                << "() expects an string argument of an IPv4/IPv6 address, got "
+                << addr;
+            return;
+          }
         } else {
           call.addError()
               << call.func
-              << "() expects an string argument of an IPv4/IPv6 address, got "
-              << addr;
+              << "() expects an string literal at the first argument";
           return;
         }
-      } else {
-        call.addError() << call.func << "() expects an string literal, got "
-                        << call.vargs.at(0).type();
+      }
+
+      std::vector<char> dst(addr_size);
+      auto ret = inet_pton(af_type, addr.c_str(), dst.data());
+      if (ret != 1) {
+        call.addError() << call.func
+                        << "() expects a valid IPv4/IPv6 address, got " << addr;
         return;
       }
-    }
 
-    std::vector<char> dst(addr_size);
-    auto ret = inet_pton(af_type, addr.c_str(), dst.data());
-    if (ret != 1) {
-      call.addError() << call.func
-                      << "() expects a valid IPv4/IPv6 address, got " << addr;
-      return;
-    }
+      return_type = CreateArray(addr_size, CreateUInt8());
+      return_type.SetAS(AddrSpace::kernel);
+      return_type.is_internal = true;
+    } else if (call.func == "reg") {
+      return_type = CreateUInt64();
+      if (probe_) {
+        ProbeType pt = probe_->get_probetype();
+        return_type.SetAS(find_addrspace(pt));
+      } else {
+        return_type.SetAS(AddrSpace::kernel);
+      }
+    } else if (call.func == "kaddr" || call.func == "percpu_kaddr") {
+      return_type = CreateUInt64();
+      return_type.SetAS(AddrSpace::kernel);
+    } else if (call.func == "__builtin_uaddr") {
+      auto *probe = get_probe(call, call.func);
+      if (probe == nullptr)
+        return;
 
-    call.return_type = CreateArray(addr_size, CreateUInt8());
-    call.return_type.SetAS(AddrSpace::kernel);
-    call.return_type.is_internal = true;
-  } else if (call.func == "reg") {
-    call.return_type = CreateUInt64();
-    if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
-      ProbeType pt = probe->get_probetype();
-      // In case of different attach_points, Set the addrspace to none.
-      call.return_type.SetAS(find_addrspace(pt));
-    } else {
-      // Assume kernel space for data in subprogs
-      call.return_type.SetAS(AddrSpace::kernel);
-    }
-  } else if (call.func == "kaddr") {
-    call.return_type = CreateUInt64();
-    call.return_type.SetAS(AddrSpace::kernel);
-  } else if (call.func == "percpu_kaddr") {
-    if (call.vargs.size() == 2 && call.vargs.at(1).type() != CreateUInt32()) {
-      create_int_cast(call.vargs.at(1), CreateUInt32());
-    }
-    call.return_type = CreateUInt64();
-    call.return_type.SetAS(AddrSpace::kernel);
-  } else if (call.func == "__builtin_uaddr") {
-    auto *probe = get_probe(call, call.func);
-    if (probe == nullptr)
-      return;
+      struct symbol sym = {};
 
-    struct symbol sym = {};
-
-    if (!call.vargs.empty() && call.vargs.at(0).is<String>()) {
-      if (check_symbol(call)) {
+      if (!call.vargs.empty() && call.vargs.at(0).is<String>()) {
         auto name = call.vargs.at(0).as<String>()->value;
         const auto &target = probe->attach_points[0]->target;
 
@@ -769,287 +1184,1370 @@ void TypeResolver::visit(Call &call)
                           << name;
         }
       }
+
+      size_t pointee_size = 0;
+      switch (sym.size) {
+        case 1:
+        case 2:
+        case 4:
+          pointee_size = sym.size * 8;
+          break;
+        default:
+          pointee_size = 64;
+      }
+
+      return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
+    } else if (call.func == "kstack") {
+      check_stack_call(call, true);
+      return_type = call.return_type;
+    } else if (call.func == "ustack") {
+      check_stack_call(call, false);
+      return_type = call.return_type;
+    } else if (call.func == "path") {
+      auto call_type_size = bpftrace_.config_->max_strlen;
+      if (call.vargs.size() == 2) {
+        if (auto *size = call.vargs.at(1).as<Integer>()) {
+          call_type_size = size->value;
+        }
+      }
+      return_type = SizedType(Type::string, call_type_size);
+    } else if (call.func == "kptr" || call.func == "uptr") {
+      resolver_.add_type_rule({
+          .output = &call,
+          .inputs = { &call.vargs.at(0).node() },
+          .resolve =
+              [this, &call](const std::vector<SizedType> &inputs) -> SizedType {
+            auto result = inputs[0];
+            result.SetAS(call.func == "kptr" ? AddrSpace::kernel
+                                             : AddrSpace::user);
+            return result;
+          },
+      });
+      return;
+    } else if (call.func == "bswap") {
+      resolver_.add_type_rule({
+          .output = &call,
+          .inputs = { &call.vargs.at(0).node() },
+          .resolve =
+              [this, &call](const std::vector<SizedType> &inputs) -> SizedType {
+            const auto &type = inputs[0];
+            auto int_bit_width = 1;
+            if (!type.IsIntTy()) {
+              call.addError()
+                  << call.func << "() only supports integer arguments ("
+                  << type.GetTy() << " provided)";
+              return CreateNone();
+            }
+            int_bit_width = type.GetIntBitWidth();
+            return CreateUInt(int_bit_width);
+          },
+      });
+      return;
+    } else if (call.func == "nsecs") {
+      if (call.vargs.size() == 1) {
+        resolver_.add_type_rule({
+            .output = &call,
+            .inputs = { &call.vargs.at(0).node() },
+            .resolve = [this, &call](
+                           const std::vector<SizedType> &inputs) -> SizedType {
+              auto ret_type = CreateUInt64();
+              ret_type.ts_mode = inputs[0].ts_mode;
+              return ret_type;
+            },
+        });
+        return;
+      } else {
+        return_type = CreateUInt64();
+        return_type.ts_mode = TimestampMode::boot;
+      }
+    } else if (auto bit = SIMPLE_BUILTIN_TYPES.find(call.func);
+               bit != SIMPLE_BUILTIN_TYPES.end()) {
+      return_type = bit->second();
     }
 
-    size_t pointee_size = 0;
-    switch (sym.size) {
-      case 1:
-      case 2:
-      case 4:
-        pointee_size = sym.size * 8;
-        break;
-      default:
-        pointee_size = 64;
-    }
-    call.return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
-  } else if (call.func == "cgroupid") {
-    call.return_type = CreateUInt64();
-  } else if (call.func == "cgroup_path") {
-    call.return_type = CreateCgroupPath();
-  } else if (call.func == "stack_len") {
-    call.return_type = CreateInt64();
-  } else if (call.func == "strftime") {
-    call.return_type = CreateTimestamp();
-  } else if (call.func == "kstack") {
-    check_stack_call(call, true);
-  } else if (call.func == "ustack") {
-    check_stack_call(call, false);
-  } else if (call.func == "path") {
-    auto call_type_size = bpftrace_.config_->max_strlen;
-    if (call.vargs.size() == 2) {
-      if (auto *size = call.vargs.at(1).as<Integer>()) {
-        call_type_size = size->value;
-      }
-    }
-    call.return_type = SizedType(Type::string, call_type_size);
-  } else if (call.func == "strncmp") {
-    call.return_type = CreateUInt64();
-  } else if (call.func == "kptr" || call.func == "uptr") {
-    auto as = (call.func == "kptr" ? AddrSpace::kernel : AddrSpace::user);
-    call.return_type = call.vargs.front().type();
-    call.return_type.SetAS(as);
-  } else if (call.func == "macaddr") {
-    call.return_type = CreateMacAddress();
-  } else if (call.func == "bswap") {
-    auto int_bit_width = 1;
-    if (!call.vargs.empty()) {
-      auto &arg = call.vargs.at(0);
-      if (!arg.type().IsIntTy()) {
-        call.addError() << call.func << "() only supports integer arguments ("
-                        << arg.type().GetTy() << " provided)";
+    if (!return_type.IsNoneTy()) {
+      resolver_.set_type(&call, return_type);
+    } else {
+      // BTF function lookup
+      auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
+      if (!maybe_func) {
+        call.addError() << "Unknown function: '" << call.func << "'";
         return;
       }
-      int_bit_width = arg.type().GetIntBitWidth();
-    }
-    call.return_type = CreateUInt(int_bit_width);
-  } else if (call.func == "skboutput") {
-    call.return_type = CreateUInt32();
-  } else if (call.func == "nsecs") {
-    call.return_type = CreateUInt64();
-    call.return_type.ts_mode = TimestampMode::boot;
-    if (call.vargs.size() == 1) {
-      call.return_type.ts_mode = call.vargs.at(0).type().ts_mode;
-    }
-  } else if (call.func == "pid" || call.func == "tid") {
-    call.return_type = CreateUInt32();
-  } else if (call.func == "socket_cookie") {
-    call.return_type = CreateUInt64();
-  } else {
-    auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
-    if (!maybe_func) {
-      call.addError() << "Unknown function: '" << call.func << "'";
-      return;
-    }
 
-    const auto &func = *maybe_func;
+      const auto &func = *maybe_func;
 
-    if (func.linkage() != btf::Function::Linkage::Global &&
-        func.linkage() != btf::Function::Linkage::Extern) {
-      call.addError() << "Unsupported function linkage: '" << call.func << "'";
-      return;
-    }
+      if (func.linkage() != btf::Function::Linkage::Global &&
+          func.linkage() != btf::Function::Linkage::Extern) {
+        call.addError() << "Unsupported function linkage: '" << call.func
+                        << "'";
+        return;
+      }
 
-    auto proto = func.type();
-    if (!proto) {
-      call.addError() << "Unable to find function proto: " << proto.takeError();
-      return;
+      auto proto = func.type();
+      if (!proto) {
+        call.addError() << "Unable to find function proto: "
+                        << proto.takeError();
+        return;
+      }
+      // Extract our return type.
+      auto btf_return_type = proto->return_type();
+      if (!btf_return_type) {
+        call.addError() << "Unable to read return type: "
+                        << btf_return_type.takeError();
+        return;
+      }
+      auto compat_return_type = getCompatType(*btf_return_type);
+      if (!compat_return_type) {
+        call.addError() << "Unable to convert return type: "
+                        << compat_return_type.takeError();
+        return;
+      }
+      resolver_.set_type(&call, *compat_return_type);
     }
-    // Extract our return type.
-    auto return_type = proto->return_type();
-    if (!return_type) {
-      call.addError() << "Unable to read return type: "
-                      << return_type.takeError();
-      return;
-    }
-    auto compat_return_type = getCompatType(*return_type);
-    if (!compat_return_type) {
-      call.addError() << "Unable to convert return type: "
-                      << compat_return_type.takeError();
-      return;
-    }
-    call.return_type = *compat_return_type;
   }
 }
 
-std::optional<size_t> TypeResolver::check(Sizeof &szof)
+void TypeRuleCollector::visit(Binop &op)
 {
-  is_type_name_ = true;
-  Visitor<TypeResolver>::visit(szof);
-  is_type_name_ = false;
+  visit(op.left);
+  visit(op.right);
 
-  if (std::holds_alternative<SizedType>(szof.record)) {
-    auto &ty = std::get<SizedType>(szof.record);
-    resolve_struct_type(ty, szof);
-    if (!ty.IsNoneTy()) {
-      return ty.GetSize();
-    }
-  } else {
-    const auto &ty = std::get<Expression>(szof.record).type();
-    if (!ty.IsNoneTy()) {
-      return ty.GetSize();
-    }
-  }
-
-  return std::nullopt;
+  resolver_.add_type_rule({
+      .output = &op,
+      .inputs = { &op.left.node(), &op.right.node() },
+      .resolve = [&op](const std::vector<SizedType> &inputs) -> SizedType {
+        return get_binop_type(op, inputs[0], inputs[1]);
+      },
+  });
 }
 
-void TypeResolver::visit(Sizeof &szof)
+void TypeRuleCollector::visit(BlockExpr &block)
 {
-  AssignMapDisallowed<"sizeof">().visit(szof.record);
+  scope_stack_.push_back(&block);
+  visit(block.stmts);
+  visit(block.expr);
 
-  const auto v = check(szof);
-  if (!v && is_final_pass()) {
-    szof.addError() << "sizeof not resolved, is type complete?";
-  }
+  resolver_.add_pass_through(&block.expr.node(), &block);
+  scope_stack_.pop_back();
 }
 
-std::optional<size_t> TypeResolver::check(Offsetof &offof)
+void TypeRuleCollector::visit(Boolean &boolean)
 {
-  is_type_name_ = true;
-  Visitor<TypeResolver>::visit(offof);
-  is_type_name_ = false;
+  resolver_.set_type(&boolean, boolean.type());
+}
 
-  auto check_type = [&](SizedType cstruct) -> std::optional<size_t> {
-    size_t offset = 0;
-    // Check if all sub-fields are present.
-    for (const auto &field : offof.field) {
-      if (!cstruct.IsCStructTy()) {
-        offof.addError() << "'" << cstruct << "' " << "is not a c_struct type.";
-        return std::nullopt;
-      } else if (!bpftrace_.structs.Has(cstruct.GetName())) {
-        offof.addError() << "'" << cstruct.GetName() << "' does not exist.";
-        return std::nullopt;
-      } else if (!cstruct.HasField(field)) {
-        offof.addError() << "'" << cstruct.GetName() << "' "
-                         << "has no field named " << "'" << field << "'";
-        return std::nullopt;
-      } else {
-        // Get next sub-field
-        const auto &f = cstruct.GetField(field);
-        offset += f.offset;
-        cstruct = f.type;
+SizedType update_cast_expr(const SizedType &cast_ty,
+                           const SizedType &expr_ty,
+                           Probe *probe)
+{
+  auto updated_ty = cast_ty;
+  if (updated_ty.IsArrayTy()) {
+    if (updated_ty.GetNumElements() == 0) {
+      if (updated_ty.GetElementTy().GetSize() != 0) {
+        if (expr_ty.GetSize() % updated_ty.GetElementTy().GetSize() == 0) {
+          // casts to unsized arrays (e.g. int8[]) need to determine size from
+          // RHS
+          auto num_elems = expr_ty.GetSize() /
+                           updated_ty.GetElementTy().GetSize();
+          updated_ty = CreateArray(num_elems, updated_ty.GetElementTy());
+        }
       }
     }
-    return offset;
-  };
 
-  std::optional<size_t> offset;
+    if (expr_ty.IsIntTy() || expr_ty.IsBoolTy())
+      updated_ty.is_internal = true;
+  }
+
+  if (expr_ty.IsCtxAccess() && !updated_ty.IsIntTy()) {
+    updated_ty.MarkCtxAccess();
+  }
+  updated_ty.SetAS(expr_ty.GetAS());
+  // case : begin { @foo = (struct Foo)0; }
+  // case : profile:hz:99 $task = (struct task_struct *)curtask.
+  if (updated_ty.GetAS() == AddrSpace::none) {
+    if (probe) {
+      ProbeType type = probe->get_probetype();
+      updated_ty.SetAS(find_addrspace(type));
+    } else {
+      // Assume kernel space for data in subprogs.
+      updated_ty.SetAS(AddrSpace::kernel);
+    }
+  }
+  return updated_ty;
+}
+
+void TypeRuleCollector::visit(Cast &cast)
+{
+  visit(cast.expr);
+
+  // Account for the race condition whereby the expression type may resolve
+  // before the cast type even though they both need resolution to determine the
+  // final cast type, e.g. `@ = (int8[])"hello"`
+  resolver_.add_type_rule({
+      .output = &cast,
+      .inputs = { &cast.expr.node() },
+      .resolve = [this,
+                  &cast](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &expr_ty = inputs[0];
+        const auto &cast_ty = resolver_.get_type(&cast);
+        return update_cast_expr(cast_ty, expr_ty, probe_);
+      },
+  });
+
+  if (std::holds_alternative<SizedType>(cast.typeof->record)) {
+    auto &ty = std::get<SizedType>(cast.typeof->record);
+    if (!resolve_struct_type(ty, *cast.typeof)) {
+      return;
+    }
+    const auto &expr_ty = resolver_.get_type(&cast.expr.node());
+    if (!expr_ty.IsNoneTy()) {
+      ty = update_cast_expr(ty, expr_ty, probe_);
+    }
+    resolver_.set_type(&cast, ty);
+  } else {
+    visit(cast.typeof);
+    resolver_.add_type_rule({
+        .output = &cast,
+        .inputs = { cast.typeof },
+        .resolve = [this,
+                    &cast](const std::vector<SizedType> &inputs) -> SizedType {
+          const auto &cast_ty = inputs[0];
+          const auto &expr_ty = resolver_.get_type(&cast.expr.node());
+
+          if (!expr_ty.IsNoneTy()) {
+            return update_cast_expr(cast_ty, expr_ty, probe_);
+          }
+          return cast_ty;
+        },
+    });
+  }
+}
+
+void TypeRuleCollector::visit(Comptime &comptime)
+{
+  visit(comptime.expr);
+  unresolved_comptimes_.emplace_back(&comptime);
+}
+
+void TypeRuleCollector::visit(ExprStatement &expr)
+{
+  visit(expr.expr);
+}
+
+void TypeRuleCollector::visit(FieldAccess &acc)
+{
+  visit(acc.expr);
+
+  resolver_.add_type_rule({
+      .output = &acc,
+      .inputs = { &acc.expr.node() },
+      .resolve = [this,
+                  &acc](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &expr_type_in = inputs[0];
+        // FieldAccesses will automatically resolve through any number of
+        // pointer dereferences. For now, we inject the `Unop` operator
+        // in AstTransformer, as codegen stores the underlying structs as
+        // pointers anyways. In the future, we will likely want to do this in a
+        // different way if we are tracking l-values.
+        bool is_ctx = expr_type_in.IsCtxAccess();
+        bool is_internal = expr_type_in.is_internal;
+        auto expr_type = expr_type_in;
+        while (expr_type.IsPtrTy()) {
+          expr_type = expr_type.GetPointeeTy();
+        }
+
+        SizedType result_type = CreateNone();
+
+        if (!expr_type.IsCStructTy() && !expr_type.IsRecordTy()) {
+          acc.addError() << "Can not access field '" << acc.field
+                         << "' on expression of type '" << expr_type << "'";
+          return CreateNone();
+        }
+
+        if (expr_type.is_funcarg) {
+          auto *probe = get_probe();
+          if (probe == nullptr) {
+            return CreateNone();
+          }
+          const auto *arg = bpftrace_.structs.GetProbeArg(*probe, acc.field);
+          if (arg) {
+            result_type = arg->type;
+            result_type.SetAS(expr_type.GetAS());
+
+            if (result_type.IsNoneTy()) {
+              acc.addError() << acc.field << " has unsupported type";
+            }
+          } else {
+            acc.addError() << "Can't find function parameter " << acc.field;
+          }
+          return result_type;
+        }
+
+        if (!expr_type.IsRecordTy() &&
+            !bpftrace_.structs.Has(expr_type.GetName())) {
+          acc.addError() << "Unknown struct/union: '" << expr_type.GetName()
+                         << "'";
+          return CreateNone();
+        }
+
+        const auto &record = expr_type.GetStruct();
+
+        if (!record->HasField(acc.field)) {
+          if (expr_type.IsRecordTy()) {
+            acc.addError() << "Record does not contain " << "a field named '"
+                           << acc.field << "'";
+          } else {
+            acc.addError() << "Struct/union of type '" << expr_type.GetName()
+                           << "' does not contain " << "a field named '"
+                           << acc.field << "'";
+          }
+          return CreateNone();
+        } else {
+          const auto &field = record->GetField(acc.field);
+
+          if (field.type.IsPtrTy()) {
+            const auto &tags = field.type.GetBtfTypeTags();
+            // Currently only "rcu" is safe. "percpu", for example, requires
+            // special unwrapping with `bpf_per_cpu_ptr` which is not yet
+            // supported.
+            static const std::string_view allowed_tag = "rcu";
+            for (const auto &tag : tags) {
+              if (tag != allowed_tag) {
+                acc.addError()
+                    << "Attempting to access pointer field '" << acc.field
+                    << "' with unsupported tag attribute: " << tag;
+              }
+            }
+          }
+
+          result_type = field.type;
+          if (is_ctx &&
+              (result_type.IsArrayTy() || result_type.IsCStructTy())) {
+            // e.g., ((struct bpf_perf_event_data*)ctx)->regs.ax
+            result_type.MarkCtxAccess();
+          }
+          result_type.is_internal = is_internal;
+          result_type.SetAS(expr_type.GetAS());
+
+          return result_type;
+        }
+      },
+  });
+}
+
+SizedType get_range_type(const SizedType &start_type,
+                         const SizedType &end_type,
+                         Range *range)
+{
+  if (!start_type.IsIntTy()) {
+    range->addError() << "Loop range requires an integer for the start value";
+  }
+  if (!end_type.IsIntTy()) {
+    range->addError() << "Loop range requires an integer for the end value";
+  }
+
+  auto range_type = start_type;
+  if (start_type.IsIntTy() && end_type.IsIntTy()) {
+    if (start_type.GetSize() > end_type.GetSize() ||
+        start_type.GetSize() < end_type.GetSize()) {
+      auto promoted = get_promoted_type(start_type, end_type);
+      if (promoted) {
+        range_type = *promoted;
+      }
+    }
+  }
+
+  return range_type;
+}
+
+void TypeRuleCollector::visit(For &f)
+{
+  if (auto *map = f.iterable.as<Map>()) {
+    if (map_metadata_.bad_iterator.contains(map)) {
+      map->addError() << map->ident
+                      << " has no explicit keys (scalar map), and "
+                         "cannot be used for iteration";
+    }
+  }
+
+  const auto &decl_name = f.decl->ident;
+
+  // Collect a list of unique variables which are referenced in the loop's
+  // body and declared before the loop. These will be passed into the loop
+  // callback function as the context parameter.
+  std::unordered_set<std::string> found_vars;
+  auto [iter, _] = for_vars_referenced_.try_emplace(&f);
+  auto &collector = iter->second;
+  collector.visit(f.block, [this, &found_vars, &decl_name](const auto &var) {
+    if (found_vars.contains(var.ident) || var.ident == decl_name)
+      return false;
+
+    Node *scope = find_variable_scope(var.ident, false);
+    if (scope && variables_[scope].contains(var.ident)) {
+      found_vars.insert(var.ident);
+      return true;
+    }
+
+    return false;
+  });
+
+  visit(f.decl);
+
+  ScopedVariable scoped_var = std::make_pair(scope_stack_.back(), decl_name);
+
+  if (auto *map = f.iterable.as<Map>()) {
+    visit(map);
+    const auto &key_name = map_key_name(map->ident);
+    const auto &value_name = map_value_name(map->ident);
+    resolver_.add_type_rule({
+        .output = scoped_var,
+        .inputs = { key_name, value_name },
+        .resolve = [map](const std::vector<SizedType> &inputs) -> SizedType {
+          const auto &key_type = inputs[0];
+          const auto &value_type = inputs[1];
+          if (!value_type.IsMapIterableTy()) {
+            map->addError()
+                << "Loop expression does not support type: " << value_type;
+          }
+          return CreateTuple(Struct::CreateTuple({ key_type, value_type }));
+        },
+    });
+
+  } else if (auto *range = f.iterable.as<Range>()) {
+    visit(range->start);
+    visit(range->end);
+    resolver_.add_type_rule({
+        .output = scoped_var,
+        .inputs = { &range->start.node(), &range->end.node() },
+        .resolve = [range](const std::vector<SizedType> &inputs) -> SizedType {
+          return get_range_type(inputs[0], inputs[1], range);
+        },
+    });
+  }
+
+  scope_stack_.push_back(&f);
+
+  visit(f.block);
+
+  scope_stack_.pop_back();
+
+  {
+    std::vector<TypeVariable> ctx_inputs;
+    for (Variable &var : collector.nodes()) {
+      ctx_inputs.emplace_back(&var);
+    }
+    if (!ctx_inputs.empty()) {
+      resolver_.add_type_rule({
+          .output = &f,
+          .inputs = std::move(ctx_inputs),
+          .resolve = [this, &f](const std::vector<SizedType> &) -> SizedType {
+            // Finally, create the context tuple now that all variables
+            // inside the loop have been resolved.
+            std::vector<SizedType> ctx_types;
+            std::vector<std::string_view> ctx_idents;
+            auto [iter, _] = for_vars_referenced_.try_emplace(&f);
+            auto &collector = iter->second;
+            for (const Variable &var : collector.nodes()) {
+              const auto &var_type = resolver_.get_type(
+                  const_cast<Node *>(static_cast<const Node *>(&var)));
+              ctx_types.push_back(CreatePointer(var_type, AddrSpace::none));
+              ctx_idents.push_back(var.ident);
+            }
+
+            f.ctx_type = CreateCStruct(
+                Struct::CreateRecord(ctx_types, ctx_idents));
+            // Nothing should be dependent upon this for loop
+            return CreateNone();
+          },
+      });
+    }
+  }
+
+  // Create an empty ctx struct in case there are no referenced vars in the loop
+  // body
+  std::vector<SizedType> ctx_types;
+  std::vector<std::string_view> ctx_idents;
+  f.ctx_type = CreateCStruct(Struct::CreateRecord(ctx_types, ctx_idents));
+}
+
+void TypeRuleCollector::visit(Identifier &identifier)
+{
+  SizedType ident_type = CreateNone();
+  if (c_definitions_.enums.contains(identifier.ident)) {
+    const auto &enum_name = std::get<1>(c_definitions_.enums[identifier.ident]);
+    ident_type = CreateEnum(64, enum_name);
+  } else if (bpftrace_.structs.Has(identifier.ident)) {
+    ident_type = CreateCStruct(identifier.ident,
+                               bpftrace_.structs.Lookup(identifier.ident));
+  } else if (func_ == "nsecs") {
+    ident_type = CreateTimestampMode();
+    if (identifier.ident == "monotonic") {
+      ident_type.ts_mode = TimestampMode::monotonic;
+    } else if (identifier.ident == "boot") {
+      ident_type.ts_mode = TimestampMode::boot;
+    } else if (identifier.ident == "tai") {
+      ident_type.ts_mode = TimestampMode::tai;
+    } else if (identifier.ident == "sw_tai") {
+      ident_type.ts_mode = TimestampMode::sw_tai;
+    } else {
+      identifier.addError() << "Invalid timestamp mode: " << identifier.ident;
+    }
+  } else {
+    ConfigParser<StackMode> parser;
+    StackMode mode;
+    auto ok = parser.parse(func_, &mode, identifier.ident);
+    if (ok) {
+      ident_type = CreateStack(true, StackType{ .mode = mode });
+    }
+  }
+
+  if (ident_type.IsNoneTy() && introspection_level_ > 0) {
+    ident_type = bpftrace_.btf_->get_stype(identifier.ident);
+  }
+
+  resolver_.set_type(&identifier, ident_type);
+}
+
+void TypeRuleCollector::visit(IfExpr &if_expr)
+{
+  if (auto *comptime = if_expr.cond.as<Comptime>()) {
+    visit(comptime->expr);
+    unresolved_comptimes_.emplace_back(comptime);
+    return; // Skip visiting this `if` for now.
+  }
+
+  visit(if_expr.cond);
+  visit(if_expr.left);
+  visit(if_expr.right);
+
+  resolver_.add_type_rule({
+      .output = &if_expr,
+      .inputs = { &if_expr.left.node() },
+      .resolve = [&if_expr,
+                  this](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &left_type = inputs[0];
+        const auto &current = resolver_.get_type(&if_expr);
+        auto promoted = get_promoted_type(current, left_type);
+        if (!promoted) {
+          if_expr.addError()
+              << "Branches must return the same type or compatible types: "
+              << "have '" << left_type << "' and '" << current << "'";
+          return CreateNone();
+        }
+        return *promoted;
+      },
+  });
+
+  resolver_.add_type_rule({
+      .output = &if_expr,
+      .inputs = { &if_expr.right.node() },
+      .resolve = [&if_expr,
+                  this](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &right_type = inputs[0];
+        const auto &current = resolver_.get_type(&if_expr);
+        auto promoted = get_promoted_type(current, right_type);
+        if (!promoted) {
+          if_expr.addError()
+              << "Branches must return the same type or compatible types: "
+              << "have '" << current << "' and '" << right_type << "'";
+          return CreateNone();
+        }
+        return *promoted;
+      },
+  });
+}
+
+void TypeRuleCollector::visit(Integer &integer)
+{
+  resolver_.set_type(&integer, integer.type());
+}
+
+void TypeRuleCollector::visit(Jump &jump)
+{
+  if (jump.ident == JumpType::RETURN) {
+    visit(jump.return_value);
+  }
+}
+
+void TypeRuleCollector::visit(Map &map)
+{
+  if (map_metadata_.bad_indexed_access.contains(&map)) {
+    map.addError()
+        << map.ident
+        << " used as a map without an explicit key (scalar map), previously "
+           "used with an explicit key (non-scalar map)";
+    return;
+  }
+
+  const auto &key_name = map_key_name(map.ident);
+  const auto &value_name = map_value_name(map.ident);
+
+  // N.B. No pass throughs or TypeRules are added for AST map nodes. This is
+  // because consumers should only ever depend on the map key name or the map
+  // value name. Functions like `print` and `clear` that use AST Map nodes
+  // (instead of map access) don't actually require the value or key types.
+
+  map_value_names_.insert(value_name);
+
+  // Named param maps (from getopt()) are read-only and have their types pre-set
+  // by the NamedParamsPass.
+  // TODO: consider passing these values in NamedParamDefaults instead of
+  // setting them on the AST
+  if (named_param_defaults_.defaults.contains(map.ident) &&
+      !map.value_type.IsNoneTy()) {
+    resolver_.set_type(value_name, map.value_type);
+    resolver_.set_type(key_name, map.key_type);
+  }
+
+  if (introspection_level_ > 0) {
+    introspected_nodes_.insert(map.ident);
+  }
+}
+
+void TypeRuleCollector::visit(MapAccess &acc)
+{
+  visit(acc.map);
+  visit(acc.key);
+
+  if (map_metadata_.bad_scalar_access.contains(acc.map)) {
+    acc.addError() << acc.map->ident
+                   << " used as a map with an explicit key (non-scalar map), "
+                      "previously used without an explicit key (scalar map)";
+    return;
+  }
+
+  const auto &key_name = map_key_name(acc.map->ident);
+
+  resolver_.add_type_rule({
+      .output = key_name,
+      .inputs = { &acc.key.node() },
+      .resolve = [this, &acc, key_name](
+                     const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        if (!is_valid_assignment(type, resolver_.get_type(key_name))) {
+          acc.addError() << "Value '" << type
+                         << "' cannot be used as a map key.";
+          return CreateNone();
+        }
+
+        return get_map_key_type(acc.map->ident, type, acc);
+      },
+  });
+
+  resolver_.add_pass_through(map_value_name(acc.map->ident), &acc);
+}
+
+void TypeRuleCollector::visit(MapAddr &map_addr)
+{
+  visit(map_addr.map);
+
+  // This needs to be fixed as neither the map value or map key are the actual
+  // map's type
+  resolver_.add_type_rule({
+      .output = &map_addr,
+      .inputs = { map_value_name(map_addr.map->ident) },
+      .resolve = [](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        return CreatePointer(type, type.GetAS());
+      },
+  });
+}
+
+void TypeRuleCollector::visit(NegativeInteger &integer)
+{
+  resolver_.set_type(&integer, integer.type());
+}
+
+void TypeRuleCollector::visit(PositionalParameter &param)
+{
+  resolver_.set_type(&param, CreateInt64());
+}
+
+void TypeRuleCollector::visit(PositionalParameterCount &param)
+{
+  resolver_.set_type(&param, CreateUInt64());
+}
+
+void TypeRuleCollector::visit(Offsetof &offof)
+{
+  // This type will change later depending on what integer literal it resolves
+  // to in AstTransformer but for now set it to the smallest uint
   if (std::holds_alternative<SizedType>(offof.record)) {
     auto &ty = std::get<SizedType>(offof.record);
     resolve_struct_type(ty, offof);
-    offset = check_type(ty);
+    if (!check_offsetof_type(offof, ty)) {
+      return;
+    }
+    resolver_.set_type(&offof, CreateUInt8());
   } else {
-    const auto &ty = std::get<Expression>(offof.record).type();
-    offset = check_type(ty);
+    auto &expr = std::get<Expression>(offof.record);
+    ++introspection_level_;
+    visit(expr);
+    --introspection_level_;
+    resolver_.add_type_rule({
+        .output = &offof,
+        .inputs = { &expr.node() },
+        .resolve = [this,
+                    &offof](const std::vector<SizedType> &inputs) -> SizedType {
+          auto local_type = inputs[0];
+          resolve_struct_type(local_type, offof);
+          if (!check_offsetof_type(offof, local_type)) {
+            return CreateNone();
+          }
+          return CreateUInt8();
+        },
+    });
   }
-  if (offset) {
-    return offset.value();
-  }
-
-  return std::nullopt;
 }
 
-void TypeResolver::visit(Offsetof &offof)
+void TypeRuleCollector::visit(Probe &probe)
 {
-  AssignMapDisallowed<"offsetof">().visit(offof.record);
+  probe_ = &probe;
+  visit(probe.attach_points);
+  visit(probe.block);
+}
 
-  const auto v = check(offof);
-  if (!v && is_final_pass()) {
-    offof.addError() << "offsetof not resolved, is type complete?";
+void TypeRuleCollector::visit(Record &record)
+{
+  std::vector<TypeVariable> inputs;
+  for (auto *named_arg : record.elems) {
+    visit(named_arg->expr);
+    inputs.emplace_back(&named_arg->expr.node());
+  }
+
+  resolver_.add_type_rule({
+      .output = &record,
+      .inputs = std::move(inputs),
+      .resolve = [&record](const std::vector<SizedType> &inputs) -> SizedType {
+        std::vector<SizedType> elements;
+        std::vector<std::string_view> names;
+        for (size_t i = 0; i < record.elems.size(); ++i) {
+          elements.emplace_back(inputs[i]);
+          names.emplace_back(record.elems[i]->name);
+        }
+        return CreateRecord(Struct::CreateRecord(elements, names));
+      },
+  });
+}
+
+void TypeRuleCollector::visit(Sizeof &szof)
+{
+  if (std::holds_alternative<SizedType>(szof.record)) {
+    auto &ty = std::get<SizedType>(szof.record);
+    resolve_struct_type(ty, szof);
+    resolver_.set_type(&szof, ty);
+  } else {
+    auto &expr = std::get<Expression>(szof.record);
+    ++introspection_level_;
+    visit(expr);
+    --introspection_level_;
+    resolver_.add_type_rule({
+        .output = &szof,
+        .inputs = { &expr.node() },
+        .resolve = [&szof](const std::vector<SizedType> &) -> SizedType {
+          // This will change later depending on
+          // what integer literal it resolves to
+          // for now set it to the smallest uint
+          return CreateUInt8();
+        },
+    });
   }
 }
 
-void TypeResolver::visit(Typeof &typeof)
+void TypeRuleCollector::visit(String &str)
 {
-  AssignMapDisallowed<"typeof or typeinfo">().visit(typeof.record);
+  auto type = str.type();
+  type.SetAS(AddrSpace::kernel);
+  resolver_.set_type(&str, type);
+}
 
-  if (std::holds_alternative<SizedType>(typeof.record)) {
-    resolve_struct_type(std::get<SizedType>(typeof.record), typeof);
-  } else {
-    const auto &expr = std::get<Expression>(typeof.record);
-    if (auto *ident = expr.as<Identifier>()) {
-      auto stype = bpftrace_.btf_->get_stype(ident->ident);
-      if (!stype.IsNoneTy()) {
-        typeof.record = stype;
+void TypeRuleCollector::visit(Subprog &subprog)
+{
+  // Note that we visit the subprogram and process arguments *after*
+  // constructing the stack with the variable states. This is because the
+  // arguments, etc. may have types defined in terms of the arguments
+  // themselves. We already handle detecting circular dependencies.
+  scope_stack_.push_back(&subprog);
+  probe_ = nullptr;
+
+  for (SubprogArg *arg : subprog.args) {
+    ScopedVariable scoped_var = std::make_pair(&subprog, arg->var->ident);
+
+    if (std::holds_alternative<SizedType>(arg->typeof->record)) {
+      auto &ty = std::get<SizedType>(arg->typeof->record);
+      if (resolve_struct_type(ty, *arg->typeof)) {
+        resolver_.set_type(scoped_var, ty);
+        if (ty.GetSize() != 0) {
+          sized_decl_vars_.insert(scoped_var);
+        }
       }
+    } else {
+      sized_decl_vars_.insert(scoped_var);
+      visit(arg->typeof);
+      resolver_.add_pass_through(arg->typeof, scoped_var);
+    }
+
+    visit(arg->var);
+  }
+
+  visit(subprog.block);
+  visit(subprog.return_type);
+
+  scope_stack_.pop_back();
+}
+
+void TypeRuleCollector::visit(Typeof &typeof)
+{
+  if (std::holds_alternative<SizedType>(typeof.record)) {
+    auto &ty = std::get<SizedType>(typeof.record);
+    resolve_struct_type(ty, typeof);
+    resolver_.set_type(&typeof, ty);
+  } else {
+    auto &expr = std::get<Expression>(typeof.record);
+    ++introspection_level_;
+    visit(expr);
+    --introspection_level_;
+
+    if (auto *map = expr.as<Map>()) {
+      // Typeof for a raw (scalar) map returns the key type.
+      // Subscribe directly to the map's key name to avoid getting the
+      // value type (both propagate through the Map node).
+      resolver_.add_pass_through(map_key_name(map->ident), &typeof);
+    } else {
+      resolver_.add_pass_through(&expr.node(), &typeof);
+    }
+  }
+}
+
+void TypeRuleCollector::visit(Tuple &tuple)
+{
+  std::vector<TypeVariable> inputs;
+  for (auto &elem : tuple.elems) {
+    visit(elem);
+    inputs.emplace_back(&elem.node());
+  }
+
+  resolver_.add_type_rule({
+      .output = &tuple,
+      .inputs = std::move(inputs),
+      .resolve = [&tuple](const std::vector<SizedType> &inputs) -> SizedType {
+        return CreateTuple(Struct::CreateTuple(
+            std::vector<SizedType>(inputs.begin(), inputs.end())));
+      },
+  });
+}
+
+void TypeRuleCollector::visit(TupleAccess &acc)
+{
+  visit(acc.expr);
+
+  resolver_.add_type_rule({
+      .output = &acc,
+      .inputs = { &acc.expr.node() },
+      .resolve = [&acc](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        if (!type.IsTupleTy()) {
+          return CreateNone();
+        }
+
+        if (acc.index >= type.GetFields().size()) {
+          return CreateNone();
+        }
+
+        return type.GetField(acc.index).type;
+      },
+  });
+}
+
+void TypeRuleCollector::visit(Typeinfo &typeinfo)
+{
+  ++introspection_level_;
+  visit(typeinfo.typeof);
+  --introspection_level_;
+  resolver_.add_type_rule({
+      .output = &typeinfo,
+      .inputs = { typeinfo.typeof },
+      .resolve = [](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        auto base_ty_str = to_string(type.GetTy());
+        auto full_ty_str = typestr(type);
+        std::vector<SizedType> elements = {
+          CreateUInt64(),
+          CreateString(base_ty_str.size() + 1),
+          CreateString(full_ty_str.size() + 1)
+        };
+        std::vector<std::string_view> names = { "btf_id",
+                                                "base_type",
+                                                "full_type" };
+        return CreateRecord(Struct::CreateRecord(elements, names));
+      },
+  });
+}
+
+void TypeRuleCollector::visit(Unop &unop)
+{
+  visit(unop.expr);
+
+  bool is_inc_dec_op = false;
+
+  switch (unop.op) {
+    case Operator::PRE_INCREMENT:
+    case Operator::PRE_DECREMENT:
+    case Operator::POST_INCREMENT:
+    case Operator::POST_DECREMENT:
+      is_inc_dec_op = true;
+      break;
+    default:;
+  }
+
+  // Unops are special in that they can be both assignments and expressions. If
+  // we're dealing with a map access or variable then treat these like
+  // assignments whereby we set the type of the unop expression and create a
+  // chain that attemps to assign this integer type to the stored map value or
+  // variable. This enables us to get error messages on the correct node if we
+  // attempt to increment a string or some other invalid type.
+  if (is_inc_dec_op) {
+    if (auto *acc = unop.expr.as<MapAccess>()) {
+      auto map_name = acc->map->ident;
+
+      resolver_.add_type_rule({
+          .output = map_value_name(map_name),
+          .inputs = { &unop },
+          .resolve = [this, &unop, map_name](
+                         const std::vector<SizedType> &inputs) -> SizedType {
+            const auto &type = inputs[0];
+            const auto &current_type = resolver_.get_type(
+                map_value_name(map_name));
+            if (current_type.IsPtrTy()) {
+              return current_type;
+            }
+            return get_map_value_type(map_name, type, unop);
+          },
+      });
+
+      resolver_.add_type_rule({
+          .output = &unop,
+          .inputs = { &unop.expr.node() },
+          .resolve =
+              [&unop](const std::vector<SizedType> &inputs) -> SizedType {
+            return inputs[0].IsSigned() ? CreateInt64() : CreateUInt64();
+          },
+      });
+
+      return;
+    } else if (auto *var = unop.expr.as<Variable>()) {
+      Node *scope = find_variable_scope(var->ident);
+      ScopedVariable scoped_var = std::make_pair(scope, var->ident);
+
+      resolver_.add_type_rule({
+          .output = scoped_var,
+          .inputs = { &unop },
+          .resolve = [this, &unop, scoped_var](
+                         const std::vector<SizedType> &inputs) -> SizedType {
+            const auto &type = inputs[0];
+            if (sized_decl_vars_.contains(scoped_var)) {
+              return CreateNone();
+            }
+
+            const auto &current_type = resolver_.get_type(scoped_var);
+            if (current_type.IsPtrTy()) {
+              return current_type;
+            }
+
+            return get_var_type(scoped_var, type, unop);
+          },
+      });
+
+      resolver_.add_type_rule({
+          .output = &unop,
+          .inputs = { &unop.expr.node() },
+          .resolve = [this, &unop, scoped_var](
+                         const std::vector<SizedType> &inputs) -> SizedType {
+            const auto &type = inputs[0];
+            const auto &current_type = resolver_.get_type(scoped_var);
+            if (sized_decl_vars_.contains(scoped_var) ||
+                current_type.IsPtrTy()) {
+              return current_type;
+            }
+
+            return type.IsSigned() ? CreateInt64() : CreateUInt64();
+          },
+      });
+
+      return;
+    } else {
+      unop.addError() << "The " << opstr(unop)
+                      << " operator must be applied to a map or variable";
     }
   }
 
-  is_type_name_ = true;
-  Visitor<TypeResolver>::visit(typeof);
-  is_type_name_ = false;
+  auto valid_ptr_op = unop.op == Operator::MUL;
+
+  resolver_.add_type_rule({
+      .output = &unop,
+      .inputs = { &unop.expr.node() },
+      .resolve = [&unop, valid_ptr_op](
+                     const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        bool invalid = false;
+        // Unops are only allowed on ints (e.g. ~$x), dereference only on
+        // pointers and context (we allow args->field for backwards
+        // compatibility)
+        if (type.IsBoolTy()) {
+          invalid = unop.op != Operator::LNOT;
+        } else if (!type.IsIntegerTy() &&
+                   !((type.IsPtrTy() || type.IsCtxAccess()) && valid_ptr_op)) {
+          invalid = true;
+        }
+        if (invalid) {
+          unop.addError()
+              << "The " << opstr(unop)
+              << " operator can not be used on expressions of type '" << type
+              << "'";
+          return CreateNone();
+        }
+
+        SizedType result = CreateNone();
+        if (unop.op == Operator::MUL) {
+          if (type.IsPtrTy()) {
+            result = type.GetPointeeTy();
+            if (type.IsCtxAccess())
+              result.MarkCtxAccess();
+            result.is_internal = type.is_internal;
+            result.SetAS(type.GetAS());
+          } else if (type.IsCStructTy()) {
+            // We allow dereferencing "args" with no effect (for backwards
+            // compat)
+            if (type.IsCtxAccess())
+              result = type;
+            else {
+              unop.addError() << "Can not dereference struct/union of type '"
+                              << type.GetName() << "'. It is not a pointer.";
+            }
+          } else if (type.IsIntTy()) {
+            result = CreateUInt64();
+          } else {
+            unop.addError() << "Can not dereference type '" << type
+                            << "'. It is not a pointer.";
+          }
+        } else if (unop.op == Operator::LNOT) {
+          result = CreateBool();
+        } else if (type.IsPtrTy() && valid_ptr_op) {
+          result = type;
+        } else {
+          result = type.IsSigned() ? CreateInt64() : CreateUInt64();
+        }
+
+        return result;
+      },
+  });
 }
 
-void TypeResolver::visit(Typeinfo &typeinfo)
+void TypeRuleCollector::visit(VarDeclStatement &decl)
 {
-  Visitor<TypeResolver>::visit(typeinfo);
+  if (find_variable_scope(decl.var->ident, false) != nullptr) {
+    LOG(BUG) << "Variable shadowing should have been caught by now";
+  }
+
+  if (!decl.typeof) {
+    // If the declaration has no type then we can rely on the assignments to
+    // this variable to determine the type.
+    visit(decl.var);
+    return;
+  }
+
+  auto *scope = scope_stack_.back();
+  ScopedVariable scoped_var = std::make_pair(scope, decl.var->ident);
+
+  if (std::holds_alternative<SizedType>(decl.typeof->record)) {
+    auto &ty = std::get<SizedType>(decl.typeof->record);
+    if (!resolve_struct_type(ty, *decl.typeof)) {
+      return;
+    }
+    resolver_.set_type(scoped_var, ty);
+    // Some declared types like 'string' have no size so we can factor in the
+    // size of the assignment
+    if (ty.GetSize() != 0) {
+      sized_decl_vars_.insert(scoped_var);
+    }
+  } else {
+    sized_decl_vars_.insert(scoped_var);
+    visit(decl.typeof);
+    resolver_.add_pass_through(decl.typeof, scoped_var);
+  }
+
+  visit(decl.var);
 }
 
-bool TypeResolver::check_symbol(const Call &call)
+void TypeRuleCollector::visit(Variable &var)
 {
-  auto *arg = call.vargs.at(0).as<String>();
-  if (!arg) {
-    call.addError() << call.func
-                    << "() expects a string literal as the first argument";
-    return false;
+  Node *scope = find_variable_scope(var.ident, false);
+  if (scope == nullptr) {
+    scope = scope_stack_.back();
+  }
+  variables_[scope].insert({ var.ident, CreateNone() });
+
+  ScopedVariable scoped_var = std::make_pair(scope, var.ident);
+
+  resolver_.add_pass_through(scoped_var, &var);
+
+  if (introspection_level_ > 0) {
+    introspected_nodes_.insert(scoped_var);
+  }
+}
+
+void TypeRuleCollector::visit(VariableAddr &var_addr)
+{
+  visit(var_addr.var);
+  resolver_.add_type_rule({
+      .output = &var_addr,
+      .inputs = { var_addr.var },
+      .resolve = [](const std::vector<SizedType> &inputs) -> SizedType {
+        const auto &type = inputs[0];
+        return CreatePointer(type, type.GetAS());
+      },
+  });
+}
+
+bool TypeRuleCollector::resolve_struct_type(SizedType &type, Node &node)
+{
+  SizedType inner_type = type;
+  int pointer_level = 0;
+  while (inner_type.IsPtrTy()) {
+    inner_type = inner_type.GetPointeeTy();
+    pointer_level++;
   }
 
-  std::string re = "^[a-zA-Z0-9./_-]+$";
-  bool is_valid = std::regex_match(arg->value, std::regex(re));
-  if (!is_valid) {
-    call.addError() << call.func
-                    << "() expects a string that is a valid symbol (" << re
-                    << ") as input (\"" << arg << "\" provided)";
-    return false;
+  bool is_array = false;
+  size_t num_elements = 0;
+  if (inner_type.IsArrayTy()) {
+    num_elements = inner_type.GetNumElements();
+    inner_type = inner_type.GetElementTy();
+    is_array = true;
   }
 
+  if (inner_type.IsCStructTy() && !inner_type.GetStruct()) {
+    auto struct_type = bpftrace_.structs.Lookup(inner_type.GetName()).lock();
+    if (!struct_type) {
+      // Try to find the type as something other than a struct, e.g. 'char' or
+      // 'uint64_t'
+      auto stype = bpftrace_.btf_->get_stype(inner_type.GetName());
+      if (stype.IsNoneTy()) {
+        node.addError() << "Cannot resolve unknown type \""
+                        << inner_type.GetName() << "\"\n";
+        return false;
+      } else {
+        type = stype;
+      }
+    } else {
+      type = CreateCStruct(inner_type.GetName(), struct_type);
+    }
+    if (is_array) {
+      type = CreateArray(num_elements, type);
+    }
+    while (pointer_level > 0) {
+      type = CreatePointer(type);
+      pointer_level--;
+    }
+  }
   return true;
 }
 
-void TypeResolver::check_stack_call(Call &call, bool kernel)
+SizedType TypeRuleCollector::get_var_type(const ScopedVariable &scoped_var,
+                                          const SizedType &type,
+                                          Node &error_node)
+{
+  const auto &var = scoped_var.second;
+
+  auto locked_type = get_locked_node(scoped_var, type, error_node, var);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  const auto &current_type = resolver_.get_type(scoped_var);
+  auto promoted = get_promoted_type(current_type, type);
+  if (promoted) {
+    return *promoted;
+  }
+
+  error_node.addError() << "Type mismatch for " << var << ": "
+                        << "trying to assign value of type '" << type
+                        << "' when variable already has a type '"
+                        << current_type << "'";
+  return CreateNone();
+}
+
+SizedType TypeRuleCollector::get_map_value_type(const std::string &map_name,
+                                                const SizedType &type,
+                                                Node &error_node)
+{
+  const auto &value_name = map_value_name(map_name);
+
+  auto locked_type = get_locked_node(value_name, type, error_node, map_name);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  const auto &current_type = resolver_.get_type(value_name);
+
+  auto add_error = [&]() {
+    error_node.addError() << "Type mismatch for " << map_name << ": "
+                          << "trying to assign value of type '" << type
+                          << "' when map already has a type '" << current_type
+                          << "'";
+  };
+
+  if (current_type.IsCastableMapTy()) {
+    add_error();
+    return CreateNone();
+  }
+
+  auto promoted = get_promoted_type(current_type, type);
+  if (promoted) {
+    // Data stored in a BPF map is internal (managed by BPF runtime), so
+    // structs and arrays should be marked as such.
+    if (promoted->IsCStructTy() || promoted->IsArrayTy()) {
+      promoted->is_internal = true;
+    }
+
+    return *promoted;
+  }
+
+  add_error();
+  return CreateNone();
+}
+
+SizedType TypeRuleCollector::get_agg_map_type(const std::string &map_name,
+                                              const SizedType &type,
+                                              Call &call)
+{
+  const auto &value_name = map_value_name(map_name);
+
+  auto locked_type = get_locked_node(value_name, type, call, map_name);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  const auto &current_type = resolver_.get_type(value_name);
+  if (current_type.IsNoneTy()) {
+    return type;
+  }
+
+  if (current_type.GetTy() == type.GetTy()) {
+    auto promoted = get_promoted_type(current_type, type);
+    if (promoted) {
+      return *promoted;
+    }
+  }
+
+  call.addError() << "Type mismatch for " << map_name << ": "
+                  << "trying to assign value of type '" << type
+                  << "' when map already has a type '" << current_type << "'";
+  return CreateNone();
+}
+
+SizedType TypeRuleCollector::get_map_key_type(const std::string &map_name,
+                                              const SizedType &type,
+                                              Node &error_node)
+{
+  auto val = map_metadata_.scalar.find(map_name);
+  if (val != map_metadata_.scalar.end() && val->second) {
+    // N.B. all scalar map keys are int64
+    return CreateInt64();
+  }
+
+  const auto &key_name = map_key_name(map_name);
+
+  auto locked_type = get_locked_node(key_name, type, error_node, map_name);
+  if (!locked_type.IsNoneTy()) {
+    return locked_type;
+  }
+
+  const auto &current_type = resolver_.get_type(key_name);
+  auto promoted = get_promoted_type(current_type, type);
+  if (promoted) {
+    return *promoted;
+  }
+
+  error_node.addError() << "Argument mismatch for " << map_name << ": "
+                        << "trying to access with arguments: '" << type
+                        << "' when map expects arguments: '" << current_type
+                        << "'";
+  return CreateNone();
+}
+
+SizedType TypeRuleCollector::get_locked_node(const TypeVariable &node,
+                                             const SizedType &type,
+                                             Node &error_node,
+                                             const std::string &name)
+{
+  if (auto found_locked = locked_nodes_.find(node);
+      found_locked != locked_nodes_.end()) {
+    if (!type.FitsInto(found_locked->second)) {
+      error_node.addError()
+          << "Type mismatch for " << name << ": "
+          << "this type has been locked because it was used "
+             "in another part of the type graph that was already "
+             "resolved (e.g. `sizeof`, `typeinfo`, etc.). The new type '"
+          << type << "' doesn't fit into the locked type '"
+          << found_locked->second << "'";
+    }
+    return found_locked->second;
+  }
+  return CreateNone();
+}
+
+Probe *TypeRuleCollector::get_probe()
+{
+  return probe_;
+}
+
+Probe *TypeRuleCollector::get_probe(Node &node, std::string name)
+{
+  if (probe_ == nullptr) {
+    if (name.empty()) {
+      node.addError() << "Feature not supported outside probe";
+    } else {
+      node.addError() << "Builtin " << name << " not supported outside probe";
+    }
+  }
+  return probe_;
+}
+
+void TypeRuleCollector::check_stack_call(Call &call, bool kernel)
 {
   call.return_type = CreateStack(kernel);
   StackType stack_type;
   stack_type.mode = bpftrace_.config_->stack_mode;
 
-  switch (call.vargs.size()) {
-    case 0:
-      break;
-    case 1: {
+  auto nargs = call.vargs.size();
+  if (nargs > 2) {
+    call.addError() << "Invalid number of arguments";
+  } else {
+    // First arg can be a stack mode identifier or an integer limit
+    size_t limit_arg = 0;
+    if (nargs >= 1) {
       if (auto *ident = call.vargs.at(0).as<Identifier>()) {
         ConfigParser<StackMode> parser;
         auto ok = parser.parse(call.func, &stack_type.mode, ident->ident);
         if (!ok) {
           ident->addError() << "Error parsing stack mode: " << ok.takeError();
         }
-      } else if (auto *limit = call.vargs.at(0).as<Integer>()) {
-        stack_type.limit = limit->value;
-      } else {
-        call.addError() << call.func << ": invalid limit value";
-      }
-      break;
-    }
-    case 2: {
-      if (auto *ident = call.vargs.at(0).as<Identifier>()) {
-        ConfigParser<StackMode> parser;
-        auto ok = parser.parse(call.func, &stack_type.mode, ident->ident);
-        if (!ok) {
-          ident->addError() << "Error parsing stack mode: " << ok.takeError();
-        }
-      } else {
-        // If two arguments are provided, then the first must be a stack mode.
+        limit_arg = 1;
+      } else if (nargs == 2) {
         call.addError() << "Expected stack mode as first argument";
+        limit_arg = 1;
       }
-      if (auto *limit = call.vargs.at(1).as<Integer>()) {
+    }
+    // Parse the limit from whichever arg position it's at
+    if (limit_arg < nargs) {
+      if (auto *limit = call.vargs.at(limit_arg).as<Integer>()) {
         stack_type.limit = limit->value;
       } else {
         call.addError() << call.func << ": invalid limit value";
       }
-      break;
     }
-    default:
-      call.addError() << "Invalid number of arguments";
-      break;
   }
   constexpr int MAX_STACK_SIZE = 1024;
   if (stack_type.limit > MAX_STACK_SIZE) {
@@ -1062,2130 +2560,31 @@ void TypeResolver::check_stack_call(Call &call, bool kernel)
   call.return_type = CreateStack(kernel, stack_type);
 }
 
-Probe *TypeResolver::get_probe(Node &node, std::string name)
+LockedNodes TypeRuleCollector::get_locked_nodes()
 {
-  auto *probe = dynamic_cast<Probe *>(top_level_node_);
-  if (probe == nullptr) {
-    // Attempting to use probe-specific feature in non-probe context
-    if (name.empty()) {
-      node.addError() << "Feature not supported outside probe";
-    } else {
-      node.addError() << "Builtin " << name << " not supported outside probe";
+  LockedNodes locked_nodes = locked_nodes_;
+  for (const auto &node : introspected_nodes_) {
+    if (const auto *scoped_var = std::get_if<ScopedVariable>(&node)) {
+      const auto &type = resolver_.get_type(*scoped_var);
+      if (!type.IsNoneTy()) {
+        locked_nodes.insert({ *scoped_var, type });
+      }
+    } else if (const auto *map_ident = std::get_if<std::string>(&node)) {
+      const auto &key_type = resolver_.get_type(map_key_name(*map_ident));
+      if (!key_type.IsNoneTy()) {
+        locked_nodes.insert({ map_key_name(*map_ident), key_type });
+      }
+      const auto &value_type = resolver_.get_type(map_value_name(*map_ident));
+      if (!value_type.IsNoneTy()) {
+        locked_nodes.insert({ map_value_name(*map_ident), value_type });
+      }
     }
   }
-
-  return probe;
+  return locked_nodes;
 }
 
-void TypeResolver::visit(Map &map)
-{
-  if (map_metadata_.bad_indexed_access.contains(&map)) {
-    map.addError()
-        << map.ident
-        << " used as a map without an explicit key (scalar map), previously "
-           "used with an explicit key (non-scalar map)";
-    return;
-  }
-
-  auto val = map_val_.find(map.ident);
-  if (val != map_val_.end()) {
-    map.value_type = val->second;
-  }
-  auto key = map_key_.find(map.ident);
-  if (key != map_key_.end()) {
-    map.key_type = key->second;
-  }
-}
-void TypeResolver::visit(MapAddr &map_addr)
-{
-  if (!map_val_.contains(map_addr.map->ident)) {
-    if (!is_first_pass()) {
-      map_addr.addError() << "Undefined map: " << map_addr.map->ident;
-    }
-    pass_tracker_.inc_num_unresolved();
-  } else {
-    visit(map_addr.map);
-    map_addr.map_addr_type = CreatePointer(map_addr.map->type(),
-                                           map_addr.map->type().GetAS());
-  }
-}
-
-void TypeResolver::visit(Variable &var)
-{
-  if (auto *found = find_variable(var.ident)) {
-    var.var_type = found->type;
-  }
-}
-
-void TypeResolver::visit(VariableAddr &var_addr)
-{
-  if (auto *found = find_variable(var_addr.var->ident)) {
-    var_addr.var->var_type = found->type;
-    if (!found->type.IsNoneTy()) {
-      var_addr.var_addr_type = CreatePointer(found->type, found->type.GetAS());
-    }
-  }
-  if (is_final_pass() && var_addr.var_addr_type.IsNoneTy()) {
-    var_addr.addError() << "No type available for variable "
-                        << var_addr.var->ident;
-  }
-}
-
-void TypeResolver::visit(ArrayAccess &arr)
-{
-  visit(arr.expr);
-  visit(arr.indexpr);
-
-  const SizedType &type = arr.expr.type();
-
-  if (type.IsArrayTy())
-    arr.element_type = type.GetElementTy();
-  else if (type.IsPtrTy())
-    arr.element_type = type.GetPointeeTy();
-  else if (type.IsStringTy())
-    arr.element_type = CreateInt8();
-  arr.element_type.SetAS(type.GetAS());
-
-  // BPF verifier cannot track BTF information for double pointers so we
-  // cannot propagate is_internal for arrays of pointers and we need to reset
-  // it on the array type as well. Indexing a pointer as an array also can't
-  // be verified, so the same applies there.
-  if (arr.element_type.IsPtrTy() || type.IsPtrTy()) {
-    arr.element_type.is_internal = false;
-  } else {
-    arr.element_type.is_internal = type.is_internal;
-  }
-}
-
-void TypeResolver::visit(TupleAccess &acc)
-{
-  visit(acc.expr);
-  const SizedType &type = acc.expr.type();
-
-  if (!type.IsTupleTy()) {
-    return;
-  }
-
-  if (acc.index < type.GetFields().size()) {
-    acc.element_type = type.GetField(acc.index).type;
-  }
-}
-
-void TypeResolver::binop_int(Binop &binop)
-{
-  SizedType leftTy = binop.left.type();
-  SizedType rightTy = binop.right.type();
-
-  if (leftTy.IsEqual(rightTy)) {
-    return;
-  }
-
-  if (leftTy.IsBoolTy()) {
-    auto *typeof = ctx_.make_node<Typeof>(Location(binop.right.loc()), leftTy);
-    binop.right = ctx_.make_node<Cast>(
-        Location(binop.right.loc()),
-        typeof,
-        clone(ctx_, binop.right.loc(), binop.right));
-    visit(binop.right);
-    return;
-  } else if (rightTy.IsBoolTy()) {
-    auto *typeof = ctx_.make_node<Typeof>(Location(binop.left.loc()), rightTy);
-    binop.left = ctx_.make_node<Cast>(
-        Location(binop.left.loc()),
-        typeof,
-        clone(ctx_, binop.left.loc(), binop.left));
-    visit(binop.left);
-    return;
-  }
-
-  bool show_warning = false;
-  bool mismatched_sign = rightTy.IsSigned() != leftTy.IsSigned();
-  // N.B. all castable map values are 64 bits
-  if (leftTy.IsCastableMapTy()) {
-    if (rightTy.IsCastableMapTy()) {
-      show_warning = mismatched_sign;
-    } else {
-      if (!update_int_type(rightTy,
-                           binop.right,
-                           CreateInteger(64, leftTy.IsSigned()))) {
-        show_warning = true;
-      }
-    }
-  } else if (rightTy.IsCastableMapTy()) {
-    if (!update_int_type(leftTy,
-                         binop.left,
-                         CreateInteger(64, rightTy.IsSigned()))) {
-      show_warning = true;
-    }
-  } else if (!update_int_type(rightTy, binop.right, leftTy, binop.left)) {
-    show_warning = true;
-  }
-
-  if (show_warning) {
-    switch (binop.op) {
-      case Operator::EQ:
-      case Operator::NE:
-      case Operator::LE:
-      case Operator::GE:
-      case Operator::LT:
-      case Operator::GT:
-        binop.addWarning() << "comparison of integers of different signs: '"
-                           << leftTy << "' and '" << rightTy << "'"
-                           << " can lead to undefined behavior";
-        break;
-      case Operator::PLUS:
-      case Operator::MINUS:
-      case Operator::MUL:
-      case Operator::DIV:
-      case Operator::MOD:
-        binop.addWarning() << "arithmetic on integers of different signs: '"
-                           << leftTy << "' and '" << rightTy << "'"
-                           << " can lead to undefined behavior";
-        break;
-      default:
-        break;
-    }
-  }
-
-  // Next, warn on any operations that require signed division.
-  //
-  // SDIV is not implemented for bpf. See Documentation/bpf/bpf_design_QA
-  // in kernel sources
-  if (binop.op == Operator::DIV || binop.op == Operator::MOD) {
-    // If they're still signed, we have to warn
-    if (leftTy.IsSigned() || rightTy.IsSigned()) {
-      binop.addWarning() << "signed operands for '" << opstr(binop)
-                         << "' can lead to undefined behavior "
-                         << "(cast to unsigned to silence warning)";
-    } else {
-      binop.result_type = CreateUInt64();
-    }
-  } else if ((binop.op == Operator::MUL || binop.op == Operator::PLUS) &&
-             !leftTy.IsSigned() && !rightTy.IsSigned()) {
-    binop.result_type = CreateUInt64();
-  }
-}
-
-void TypeResolver::create_int_cast(Expression &exp,
-                                   const SizedType &target_type)
-{
-  // We don't need a cast if it's a literal
-  if (target_type.IsIntegerTy()) {
-    if (auto *integer = exp.as<Integer>()) {
-      exp = ctx_.make_node<Integer>(
-          Location(exp.loc()), integer->value, target_type, integer->original);
-      return;
-    } else if (auto *negative_integer = exp.as<NegativeInteger>()) {
-      exp = ctx_.make_node<NegativeInteger>(Location(exp.loc()),
-                                            negative_integer->value,
-                                            target_type);
-      return;
-    }
-  }
-
-  auto *typeof_r = ctx_.make_node<Typeof>(Location(exp.loc()), target_type);
-  exp = ctx_.make_node<Cast>(Location(exp.loc()),
-                             typeof_r,
-                             clone(ctx_, exp.loc(), exp));
-  visit(exp);
-}
-
-void TypeResolver::create_string_cast(Expression &exp,
-                                      const SizedType &target_type)
-{
-  if (exp.type().GetSize() == target_type.GetSize()) {
-    return;
-  }
-
-  auto *typeof_r = ctx_.make_node<Typeof>(Location(exp.loc()), target_type);
-  exp = ctx_.make_node<Cast>(Location(exp.loc()),
-                             typeof_r,
-                             clone(ctx_, exp.loc(), exp));
-  visit(exp);
-}
-
-void TypeResolver::apply_element_cast(Expression &elem,
-                                      const SizedType &curr_type,
-                                      const SizedType &target_type)
-{
-  if (target_type.IsIntTy() && curr_type != target_type) {
-    create_int_cast(elem, target_type);
-  } else if (target_type.IsStringTy()) {
-    create_string_cast(elem, target_type);
-  } else if (target_type.IsTupleTy()) {
-    create_tuple_cast(elem, curr_type, target_type);
-  } else if (target_type.IsRecordTy()) {
-    create_record_cast(elem, curr_type, target_type);
-  }
-}
-
-void TypeResolver::create_tuple_cast(Expression &exp,
-                                     const SizedType &curr_type,
-                                     const SizedType &target_type)
-{
-  if (auto *block_expr = exp.as<BlockExpr>()) {
-    create_tuple_cast(block_expr->expr, curr_type, target_type);
-    return;
-  }
-
-  if (!exp.is<Variable>() && !exp.is<TupleAccess>() && !exp.is<MapAccess>() &&
-      !exp.is<Tuple>() && !exp.is<FieldAccess>() && !exp.is<Unop>()) {
-    LOG(BUG) << "Unexpected expression kind: create_tuple_cast";
-  }
-
-  ExpressionList expr_list = {};
-
-  for (size_t i = 0; i < target_type.GetFields().size(); ++i) {
-    auto &c_ty = curr_type.GetField(i).type;
-    auto &t_ty = target_type.GetField(i).type;
-    Expression elem;
-    if (auto *tuple_literal = exp.as<Tuple>()) {
-      elem = clone(ctx_,
-                   tuple_literal->elems.at(i).loc(),
-                   tuple_literal->elems.at(i));
-    } else {
-      elem = ctx_.make_node<TupleAccess>(Location(exp.loc()),
-                                         clone(ctx_, exp.loc(), exp),
-                                         i);
-      elem.as<TupleAccess>()->element_type = c_ty;
-    }
-    apply_element_cast(elem, c_ty, t_ty);
-    expr_list.emplace_back(std::move(elem));
-  }
-
-  exp = ctx_.make_node<Tuple>(Location(exp.loc()), std::move(expr_list));
-  exp.as<Tuple>()->tuple_type = target_type;
-  visit(exp);
-}
-
-void TypeResolver::create_record_cast(Expression &exp,
-                                      const SizedType &curr_type,
-                                      const SizedType &target_type)
-{
-  if (auto *block_expr = exp.as<BlockExpr>()) {
-    create_record_cast(block_expr->expr, curr_type, target_type);
-    return;
-  }
-
-  if (!exp.is<Variable>() && !exp.is<FieldAccess>() && !exp.is<MapAccess>() &&
-      !exp.is<Record>() && !exp.is<TupleAccess>() && !exp.is<Unop>()) {
-    LOG(BUG) << "Unexpected expression kind: create_record_cast";
-  }
-
-  std::unordered_map<size_t, NamedArgument *> named_arg_map;
-
-  for (size_t i = 0; i < curr_type.GetFields().size(); ++i) {
-    const auto &target_field = target_type.GetField(i);
-    const auto &c_ty = curr_type.GetField(target_field.name).type;
-    const auto &t_ty = target_field.type;
-    Expression elem;
-    if (auto *record_literal = exp.as<Record>()) {
-      auto field_idx = curr_type.GetFieldIdx(target_field.name);
-      elem = clone(ctx_,
-                   record_literal->elems.at(field_idx)->expr.loc(),
-                   record_literal->elems.at(field_idx)->expr);
-    } else {
-      elem = ctx_.make_node<FieldAccess>(Location(exp.loc()),
-                                         clone(ctx_, exp.loc(), exp),
-                                         target_field.name);
-      elem.as<FieldAccess>()->field_type = c_ty;
-    }
-    apply_element_cast(elem, c_ty, t_ty);
-    auto *named_arg = ctx_.make_node<NamedArgument>(Location(exp.loc()),
-                                                    target_field.name,
-                                                    std::move(elem));
-    named_arg_map[curr_type.GetFieldIdx(target_field.name)] = named_arg;
-  }
-
-  // Maintain the ordering for the current type
-  NamedArgumentList named_args = {};
-  for (size_t i = 0; i < curr_type.GetFields().size(); ++i) {
-    named_args.emplace_back(named_arg_map[i]);
-  }
-
-  exp = ctx_.make_node<Record>(Location(exp.loc()), std::move(named_args));
-  visit(exp);
-}
-
-void TypeResolver::binop_ptr(Binop &binop)
-{
-  const auto &lht = binop.left.type();
-  const auto &rht = binop.right.type();
-
-  bool left_is_ptr = lht.IsPtrTy();
-  const auto &ptr = left_is_ptr ? lht : rht;
-  const auto &other = left_is_ptr ? rht : lht;
-
-  bool compare = false;
-  bool logical = false;
-
-  // Do what C does
-  switch (binop.op) {
-    case Operator::EQ:
-    case Operator::NE:
-    case Operator::LE:
-    case Operator::GE:
-    case Operator::LT:
-    case Operator::GT:
-      compare = true;
-      break;
-    case Operator::LAND:
-    case Operator::LOR:
-      logical = true;
-      break;
-    default:;
-  }
-
-  auto invalid_op = [&binop, &lht, &rht]() {
-    binop.addError() << "The " << opstr(binop)
-                     << " operator can not be used on expressions of types "
-                     << lht << ", " << rht;
-  };
-
-  // Binop on two pointers
-  if (other.IsPtrTy()) {
-    if (compare) {
-      if (is_final_pass()) {
-        const auto le = lht.GetPointeeTy();
-        const auto re = rht.GetPointeeTy();
-        if (le != re) {
-          auto &warn = binop.addWarning();
-          warn << "comparison of distinct pointer types: " << le << ", " << re;
-          warn.addContext(binop.left.loc()) << "left (" << le << ")";
-          warn.addContext(binop.right.loc()) << "right (" << re << ")";
-        }
-      }
-    } else if (!logical) {
-      invalid_op();
-    }
-  }
-  // Binop on a pointer and (int or bool)
-  else if (other.IsIntTy() || other.IsBoolTy()) {
-    // sum is associative but minus only works with pointer on the left hand
-    // side
-    if (binop.op == Operator::MINUS && !left_is_ptr)
-      invalid_op();
-    else if (binop.op == Operator::PLUS || binop.op == Operator::MINUS)
-      binop.result_type = CreatePointer(ptr.GetPointeeTy(), ptr.GetAS());
-    else if (!compare && !logical)
-      invalid_op();
-
-    if (compare && other.IsIntTy() && other.GetSize() != 8) {
-      if (other == rht) {
-        create_int_cast(binop.right, CreateUInt64());
-      } else {
-        create_int_cast(binop.left, CreateUInt64());
-      }
-    }
-  }
-  // Might need an additional pass to resolve the type
-  else if (other.IsNoneTy()) {
-    if (is_final_pass()) {
-      invalid_op();
-    }
-  }
-  // Binop on a pointer and something else
-  else {
-    invalid_op();
-  }
-}
-
-void TypeResolver::visit(Binop &binop)
-{
-  visit(binop.left);
-  visit(binop.right);
-
-  const auto &lht = binop.left.type();
-  const auto &rht = binop.right.type();
-  bool lsign = binop.left.type().IsSigned();
-  bool rsign = binop.right.type().IsSigned();
-  bool is_int_binop = (lht.IsCastableMapTy() || lht.IsIntTy() ||
-                       lht.IsBoolTy()) &&
-                      (rht.IsCastableMapTy() || rht.IsIntTy() ||
-                       rht.IsBoolTy());
-
-  bool is_signed = lsign || rsign;
-  bool is_comparison = is_comparison_op(binop.op);
-  switch (binop.op) {
-    case Operator::LEFT:
-    case Operator::RIGHT:
-      is_signed = lsign;
-      break;
-    default:
-      break;
-  }
-
-  if (is_comparison) {
-    binop.result_type = CreateBool();
-  }
-
-  if (lht.IsBoolTy() && rht.IsBoolTy()) {
-    binop.result_type = CreateBool();
-    return;
-  }
-
-  if (lht.IsPtrTy() || rht.IsPtrTy()) {
-    binop_ptr(binop);
-    return;
-  }
-
-  if (!is_comparison) {
-    // Default type - will be overriden below as necessary
-    binop.result_type = CreateInteger(64, is_signed);
-  }
-
-  auto addr_lhs = binop.left.type().GetAS();
-  auto addr_rhs = binop.right.type().GetAS();
-
-  // if lhs or rhs has different addrspace (not none), then set the
-  // addrspace to none. This preserves the behaviour for x86.
-  if (addr_lhs != addr_rhs && addr_lhs != AddrSpace::none &&
-      addr_rhs != AddrSpace::none) {
-    if (is_final_pass())
-      binop.addWarning() << "Addrspace mismatch";
-    binop.result_type.SetAS(AddrSpace::none);
-  }
-  // Associativity from left to right for binary operator
-  else if (addr_lhs != AddrSpace::none) {
-    binop.result_type.SetAS(addr_lhs);
-  } else {
-    // In case rhs is none, then this triggers warning in
-    // selectProbeReadHelper.
-    binop.result_type.SetAS(addr_rhs);
-  }
-
-  if (!is_final_pass()) {
-    return;
-  }
-
-  if (is_int_binop) {
-    binop_int(binop);
-  }
-}
-
-void TypeResolver::visit(Unop &unop)
-{
-  if (unop.op == Operator::PRE_INCREMENT ||
-      unop.op == Operator::PRE_DECREMENT ||
-      unop.op == Operator::POST_INCREMENT ||
-      unop.op == Operator::POST_DECREMENT) {
-    // Handle ++ and -- before visiting unop.expr, because these
-    // operators should be able to work with undefined maps.
-    if (auto *acc = unop.expr.as<MapAccess>()) {
-      // Doing increments or decrements on the map type implements that
-      // it is done on an integer. Maps are always coerced into larger
-      // integers, so this should not conflict with different assignments.
-      assign_map_type(*acc->map, CreateInt64(), acc->map);
-    }
-  }
-
-  visit(unop.expr);
-
-  auto valid_ptr_op = false;
-  switch (unop.op) {
-    case Operator::PRE_INCREMENT:
-    case Operator::PRE_DECREMENT:
-    case Operator::POST_INCREMENT:
-    case Operator::POST_DECREMENT:
-    case Operator::MUL:
-      valid_ptr_op = true;
-      break;
-    default:;
-  }
-
-  const SizedType &type = unop.expr.type();
-
-  if (unop.op == Operator::MUL) {
-    if (type.IsPtrTy()) {
-      unop.result_type = type.GetPointeeTy();
-      if (type.IsCtxAccess())
-        unop.result_type.MarkCtxAccess();
-      unop.result_type.is_internal = type.is_internal;
-      unop.result_type.SetAS(type.GetAS());
-    } else if (type.IsCStructTy()) {
-      // We allow dereferencing "args" with no effect (for backwards compat)
-      if (type.IsCtxAccess())
-        unop.result_type = type;
-      else {
-        unop.addError() << "Can not dereference struct/union of type '"
-                        << type.GetName() << "'. It is not a pointer.";
-      }
-    } else if (type.IsIntTy()) {
-      unop.result_type = CreateUInt64();
-    }
-  } else if (unop.op == Operator::LNOT) {
-    unop.result_type = CreateBool();
-  } else if (type.IsPtrTy() && valid_ptr_op) {
-    unop.result_type = unop.expr.type();
-  } else {
-    unop.result_type = CreateInteger(64, type.IsSigned());
-  }
-
-  if (unop.expr.is<Variable>() && unop.expr.type().IsIntegerTy()) {
-    auto *variable = unop.expr.as<Variable>();
-    if (auto *scope = find_variable_scope(variable->ident)) {
-      auto &foundVar = variables_[scope][variable->ident];
-      if (foundVar.can_resize) {
-        // We don't know how many times this operation will be called
-        // so just make it the largest possible int
-        foundVar.type.SetSize(8);
-      }
-    }
-  }
-}
-
-void TypeResolver::visit(IfExpr &if_expr)
-{
-  // In order to evaluate literals and resolved type operators, we need to fold
-  // the condition. This is handled in the `Expression` visitor. Branches that
-  // are always `false` are exempted from semantic checks. If after folding the
-  // condition still has unresolved `comptime` operators, then we are not able
-  // to visit yet. These branches are also not allowed to contain information
-  // necessary to resolve types, that is a cycle in the dependency graph, the
-  // `if` condition must be resolvable first. If the condition *is* resolvable
-  // and is a constant, then we prune the dead code paths and will never use
-  // them.
-  if (auto *comptime = if_expr.cond.as<Comptime>()) {
-    visit(comptime->expr);
-    if (is_final_pass()) {
-      comptime->addError() << "Unable to resolve comptime expression";
-    } else {
-      pass_tracker_.add_unresolved_branch(if_expr);
-    }
-    return; // Skip visiting this `if` for now.
-  }
-
-  visit(if_expr.cond);
-  visit(if_expr.left);
-  visit(if_expr.right);
-
-  const Type &cond = if_expr.cond.type().GetTy();
-  const auto &lhs = if_expr.left.type();
-  const auto &rhs = if_expr.right.type();
-
-  if (!lhs.IsCompatible(rhs)) {
-    if (is_final_pass()) {
-      if_expr.addError() << "Branches must return the same type: " << "have '"
-                         << lhs << "' and '" << rhs << "'";
-    }
-    // This assignment is just temporary to prevent errors
-    // before the final pass
-    if_expr.result_type = lhs;
-    return;
-  }
-
-  if (is_final_pass() && cond != Type::integer && cond != Type::pointer &&
-      cond != Type::boolean) {
-    if_expr.addError() << "Invalid condition: " << cond;
-    return;
-  }
-
-  bool type_mismatch_error = false;
-  if (lhs.IsIntegerTy()) {
-    auto updatedTy = update_int_type(rhs, if_expr.right, lhs, if_expr.left);
-    if (!updatedTy) {
-      type_mismatch_error = true;
-    } else {
-      if_expr.result_type = *updatedTy;
-    }
-  } else if (lhs.IsTupleTy()) {
-    auto updatedTy = get_promoted_tuple(lhs, rhs);
-    if (!updatedTy) {
-      type_mismatch_error = true;
-    } else {
-      if (*updatedTy != lhs) {
-        create_tuple_cast(if_expr.left, lhs, *updatedTy);
-      }
-      if (*updatedTy != rhs) {
-        create_tuple_cast(if_expr.right, rhs, *updatedTy);
-      }
-      if_expr.result_type = *updatedTy;
-    }
-  } else if (lhs.IsRecordTy()) {
-    auto updatedTy = get_promoted_record(lhs, rhs);
-    if (!updatedTy) {
-      type_mismatch_error = true;
-    } else {
-      if (*updatedTy != lhs) {
-        create_record_cast(if_expr.left, lhs, *updatedTy);
-      }
-      if (*updatedTy != rhs) {
-        create_record_cast(if_expr.right, rhs, *updatedTy);
-      }
-      if_expr.result_type = *updatedTy;
-    }
-  } else {
-    auto lsize = lhs.GetSize();
-    auto rsize = rhs.GetSize();
-    if_expr.result_type = lsize > rsize ? lhs : rhs;
-  }
-
-  if (is_final_pass() && type_mismatch_error) {
-    if_expr.addError()
-        << "Branches must return the same type or compatible types: "
-        << "have '" << lhs << "' and '" << rhs << "'";
-  }
-}
-
-void TypeResolver::visit(Unroll &unroll)
-{
-  visit(unroll.expr);
-  visit(unroll.block);
-}
-
-void TypeResolver::visit(Jump &jump)
-{
-  if (jump.ident == JumpType::RETURN) {
-    visit(jump.return_value);
-    if (dynamic_cast<Probe *>(top_level_node_)) {
-      if (jump.return_value.has_value()) {
-        const auto &ty = jump.return_value->type();
-        if (ty.IsIntegerTy()) {
-          // Probes always return 64 bit ints
-          update_int_type(jump.return_value->type(),
-                          *jump.return_value,
-                          CreateInt64());
-        }
-      }
-    } else if (auto *subprog = dynamic_cast<Subprog *>(top_level_node_)) {
-      const auto &ty = subprog->return_type->type();
-      if (is_final_pass() && !ty.IsNoneTy() &&
-          (ty.IsVoidTy() != !jump.return_value.has_value() ||
-           (jump.return_value.has_value() &&
-            jump.return_value->type() != ty))) {
-        if (jump.return_value.has_value() &&
-            jump.return_value->type().IsCompatible(ty)) {
-          // TODO: fix this for other types
-          if (ty.IsIntegerTy()) {
-            auto updatedTy = update_int_type(jump.return_value->type(),
-                                             *jump.return_value,
-                                             ty);
-            if (updatedTy && updatedTy->IsEqual(ty)) {
-              return;
-            }
-          }
-        }
-        jump.addError() << "Function " << subprog->name << " is of type " << ty
-                        << ", cannot return "
-                        << (jump.return_value.has_value()
-                                ? jump.return_value->type()
-                                : CreateVoid());
-      }
-    }
-  }
-}
-
-void TypeResolver::visit(While &while_block)
-{
-  visit(while_block.cond);
-  visit(while_block.block);
-}
-
-void TypeResolver::visit(For &f)
-{
-  if (auto *map = f.iterable.as<Map>()) {
-    if (!is_first_pass() && !map_val_.contains(map->ident)) {
-      map->addError() << "Undefined map: " << map->ident;
-    }
-    if (map_metadata_.bad_iterator.contains(map)) {
-      map->addError() << map->ident
-                      << " has no explicit keys (scalar map), and "
-                         "cannot be used for iteration";
-    }
-  }
-
-  // For-loops are implemented using the bpf_for_each_map_elem or bpf_loop
-  // helper functions, which requires them to be rewritten into a callback
-  // style.
-  //
-  // Pseudo code for the transformation we apply:
-  //
-  // Before:
-  //     PROBE {
-  //       @map[0] = 1;
-  //       for ($kv : @map) {
-  //         [LOOP BODY]
-  //       }
-  //     }
-  //
-  // After:
-  //     PROBE {
-  //       @map[0] = 1;
-  //       bpf_for_each_map_elem(@map, &map_for_each_cb, 0, 0);
-  //     }
-  //     long map_for_each_cb(bpf_map *map,
-  //                          const void *key,
-  //                          void *value,
-  //                          void *ctx) {
-  //       $kv = ((uint64)key, (uint64)value);
-  //       [LOOP BODY]
-  //     }
-  //
-  //
-  // To allow variables to be shared between the loop callback and the main
-  // program, some extra steps are taken:
-  //
-  // 1. Determine which variables need to be shared with the loop callback
-  // 2. Pack pointers to them into a context struct
-  // 3. Pass pointer to the context struct to the callback function
-  // 4. In the callback, override the shared variables so that they read and
-  //    write through the context pointers instead of directly from their
-  //    original addresses
-  //
-  // Example transformation with context:
-  //
-  // Before:
-  //     PROBE {
-  //       $str = "hello";
-  //       $not_shared = 2;
-  //       $len = 0;
-  //       @map[11, 12] = "c";
-  //       for ($kv : @map) {
-  //         print($str);
-  //         $len++;
-  //       }
-  //       print($len);
-  //       print($not_shared);
-  //     }
-  //
-  // After:
-  //     struct ctx_t {
-  //       string *str;
-  //       uint64 *len;
-  //     };
-  //     PROBE {
-  //       $str = "hello";
-  //       $not_shared = 2;
-  //       $len = 0;
-  //       @map[11, 12] = "c";
-  //
-  //       ctx_t ctx { .str = &$str, .len = &$len };
-  //       bpf_for_each_map_elem(@map, &map_for_each_cb, &ctx, 0);
-  //
-  //       print($len);
-  //       print($not_shared);
-  //     }
-  //     long map_for_each_cb(bpf_map *map,
-  //                          const void *key,
-  //                          void *value,
-  //                          void *ctx) {
-  //       $kv = (((uint64, uint64))key, (string)value);
-  //       $str = ((ctx_t*)ctx)->str;
-  //       $len = ((ctx_t*)ctx)->len;
-  //
-  //       print($str);
-  //       $len++;
-  //     }
-
-  // Validate decl.
-  const auto &decl_name = f.decl->ident;
-
-  visit(f.iterable);
-
-  // Validate the iterable.
-  if (auto *map = f.iterable.as<Map>()) {
-    if (!map->type().IsMapIterableTy()) {
-      map->addError() << "Loop expression does not support type: "
-                      << map->type();
-    }
-  }
-
-  if (!ctx_.diagnostics().ok()) {
-    return;
-  }
-
-  // Collect a list of unique variables which are referenced in the loop's
-  // body and declared before the loop. These will be passed into the loop
-  // callback function as the context parameter.
-  std::unordered_set<std::string> found_vars;
-  // Only do this on the first pass because variables declared later
-  // in a script will get added to the outer scope, which these do not
-  // reference e.g.
-  // begin { @a[1] = 1; for ($kv : @a) { $x = 2; } let $x; }
-  if (is_first_pass()) {
-    // We save these for potential use at the end of this function in
-    // subsequent passes in case the map we're iterating over isn't ready
-    // yet and still needs additional passes to resolve its key/value types
-    // e.g. begin { $x = 1; for ($kv : @a) { print(($x)); } @a[1] = 1; }
-    //
-    // This is especially tricky because we need to visit all statements
-    // inside the for loop to get the types of the referenced variables but
-    // only after we have the map's key/value type so we can also check
-    // the usages of the created $kv tuple variable.
-    auto [iter, _] = for_vars_referenced_.try_emplace(&f);
-    auto &collector = iter->second;
-    collector.visit(f.block, [this, &found_vars](const auto &var) {
-      if (found_vars.contains(var.ident))
-        return false;
-
-      if (find_variable(var.ident)) {
-        found_vars.insert(var.ident);
-        return true;
-      }
-      return false;
-    });
-  }
-
-  // Create type for the loop's decl.
-  if (auto *map = f.iterable.as<Map>()) {
-    // Iterating over a map provides a tuple: (map_key, map_val)
-    auto *mapkey = get_map_key_type(*map);
-    auto *mapval = get_map_type(*map);
-
-    if (!mapkey || !mapval)
-      return;
-
-    f.decl->var_type = CreateTuple(Struct::CreateTuple({ *mapkey, *mapval }));
-  } else if (auto *range = f.iterable.as<Range>()) {
-    if (range->start.type().IsIntTy() && range->end.type().IsIntTy()) {
-      if (range->start.type().GetSize() > range->end.type().GetSize()) {
-        create_int_cast(range->end, range->start.type());
-      } else if (range->start.type().GetSize() < range->end.type().GetSize()) {
-        create_int_cast(range->start, range->end.type());
-      }
-    }
-    f.decl->var_type = range->start.type();
-  }
-
-  scope_stack_.push_back(&f);
-
-  variables_[scope_stack_.back()][decl_name] = {
-    .type = f.decl->type(),
-    .can_resize = true,
-  };
-
-  visit(f.block);
-
-  scope_stack_.pop_back();
-
-  // Finally, create the context tuple now that all variables inside the loop
-  // have been visited.
-  std::vector<SizedType> ctx_types;
-  std::vector<std::string_view> ctx_idents;
-  auto [iter, _] = for_vars_referenced_.try_emplace(&f);
-  auto &collector = iter->second;
-  for (const Variable &var : collector.nodes()) {
-    ctx_types.push_back(CreatePointer(var.var_type, AddrSpace::none));
-    ctx_idents.push_back(var.ident);
-  }
-  f.ctx_type = CreateCStruct(Struct::CreateRecord(ctx_types, ctx_idents));
-}
-
-void TypeResolver::visit(FieldAccess &acc)
-{
-  visit(acc.expr);
-
-  // FieldAccesses will automatically resolve through any number of pointer
-  // dereferences. For now, we inject the `Unop` operator directly, as codegen
-  // stores the underlying structs as pointers anyways. In the future, we will
-  // likely want to do this in a different way if we are tracking l-values.
-  while (acc.expr.type().IsPtrTy()) {
-    auto *unop = ctx_.make_node<Unop>(acc.expr.node().loc,
-                                      acc.expr,
-                                      Operator::MUL);
-    acc.expr.value = unop;
-    visit(acc.expr);
-  }
-
-  const SizedType &type = acc.expr.type();
-
-  if (type.IsPtrTy()) {
-    acc.addError() << "Can not access field '" << acc.field << "' on type '"
-                   << type << "'. Try dereferencing it first, or using '->'";
-    return;
-  }
-
-  if (!type.IsCStructTy() && !type.IsRecordTy()) {
-    if (is_final_pass()) {
-      acc.addError() << "Can not access field '" << acc.field
-                     << "' on expression of type '" << type << "'";
-    }
-    return;
-  }
-
-  if (type.is_funcarg) {
-    auto *probe = get_probe(acc);
-    if (probe == nullptr)
-      return;
-    const auto *arg = bpftrace_.structs.GetProbeArg(*probe, acc.field);
-    if (arg) {
-      acc.field_type = arg->type;
-      acc.field_type.SetAS(acc.expr.type().GetAS());
-
-      if (is_final_pass() && acc.field_type.IsNoneTy()) {
-        acc.addError() << acc.field << " has unsupported type";
-      }
-    } else {
-      acc.addError() << "Can't find function parameter " << acc.field;
-    }
-    return;
-  }
-
-  if (!type.IsRecordTy() && !bpftrace_.structs.Has(type.GetName())) {
-    acc.addError() << "Unknown struct/union: '" << type.GetName() << "'";
-    return;
-  }
-
-  const auto &record = type.GetStruct();
-
-  if (!record->HasField(acc.field)) {
-    if (is_final_pass()) {
-      if (type.IsRecordTy()) {
-        acc.addError() << "Record does not contain " << "a field named '"
-                       << acc.field << "'";
-      } else {
-        acc.addError() << "Struct/union of type '" << type.GetName()
-                       << "' does not contain " << "a field named '"
-                       << acc.field << "'";
-      }
-    }
-  } else {
-    const auto &field = record->GetField(acc.field);
-
-    if (field.type.IsPtrTy()) {
-      const auto &tags = field.type.GetBtfTypeTags();
-      // Currently only "rcu" is safe. "percpu", for example, requires
-      // special unwrapping with `bpf_per_cpu_ptr` which is not yet
-      // supported.
-      static const std::string_view allowed_tag = "rcu";
-      for (const auto &tag : tags) {
-        if (tag != allowed_tag) {
-          acc.addError() << "Attempting to access pointer field '" << acc.field
-                         << "' with unsupported tag attribute: " << tag;
-        }
-      }
-    }
-
-    acc.field_type = field.type;
-    if (acc.expr.type().IsCtxAccess() &&
-        (acc.field_type.IsArrayTy() || acc.field_type.IsCStructTy())) {
-      // e.g., ((struct bpf_perf_event_data*)ctx)->regs.ax
-      acc.field_type.MarkCtxAccess();
-    }
-    acc.field_type.is_internal = type.is_internal;
-    acc.field_type.SetAS(acc.expr.type().GetAS());
-  }
-}
-
-void TypeResolver::visit(MapAccess &acc)
-{
-  visit(acc.map);
-  visit(acc.key);
-
-  if (map_metadata_.bad_scalar_access.contains(acc.map)) {
-    acc.addError() << acc.map->ident
-                   << " used as a map with an explicit key (non-scalar map), "
-                      "previously used without an explicit key (scalar map)";
-    return;
-  }
-
-  reconcile_map_key(acc.map, acc.key);
-
-  auto search_val = map_val_.find(acc.map->ident);
-  if (search_val != map_val_.end()) {
-    acc.map->value_type = search_val->second;
-  } else {
-    // If there is no record of any assignment after the first pass
-    // then it's safe to say this map is undefined.
-    bool read_only = named_param_defaults_.defaults.contains(acc.map->ident);
-    if (!is_first_pass() && !read_only) {
-      acc.addError() << "Undefined map: " << acc.map->ident;
-    }
-    pass_tracker_.inc_num_unresolved();
-  }
-}
-
-void TypeResolver::reconcile_map_key(Map *map, Expression &key_expr)
-{
-  SizedType new_key_type = create_key_type(key_expr.type(), key_expr.node());
-
-  if (const auto &key = map_key_.find(map->ident); key != map_key_.end()) {
-    SizedType &storedTy = key->second;
-    bool type_mismatch_error = false;
-    if (!storedTy.IsCompatible(new_key_type)) {
-      type_mismatch_error = true;
-    } else {
-      if (storedTy.IsStringTy()) {
-        if (storedTy.GetSize() > new_key_type.GetSize()) {
-          create_string_cast(key_expr, storedTy);
-        } else {
-          storedTy.SetSize(new_key_type.GetSize());
-        }
-      } else if (storedTy.IsTupleTy()) {
-        auto updatedTy = get_promoted_tuple(storedTy, new_key_type);
-        if (!updatedTy) {
-          type_mismatch_error = true;
-        } else {
-          if (*updatedTy != new_key_type) {
-            create_tuple_cast(key_expr, new_key_type, *updatedTy);
-          }
-          storedTy = *updatedTy;
-        }
-      } else if (storedTy.IsRecordTy()) {
-        auto updatedTy = get_promoted_record(storedTy, new_key_type);
-        if (!updatedTy) {
-          type_mismatch_error = true;
-        } else {
-          if (*updatedTy != new_key_type) {
-            create_record_cast(key_expr, new_key_type, *updatedTy);
-          }
-          storedTy = *updatedTy;
-        }
-      } else if (storedTy.IsIntegerTy()) {
-        auto updatedTy = update_int_type(new_key_type, key_expr, storedTy);
-        if (!updatedTy) {
-          type_mismatch_error = true;
-        } else {
-          storedTy = *updatedTy;
-        }
-      }
-    }
-    if (type_mismatch_error) {
-      if (is_final_pass()) {
-        key_expr.node().addError()
-            << "Argument mismatch for " << map->ident << ": "
-            << "trying to access with arguments: '" << new_key_type
-            << "' when map expects arguments: '" << storedTy << "'";
-      }
-    }
-  } else {
-    if (!new_key_type.IsNoneTy() && !new_key_type.IsVoidTy()) {
-      map_key_.insert({ map->ident, new_key_type });
-      map->key_type = new_key_type;
-    }
-  }
-}
-
-void TypeResolver::visit(Cast &cast)
-{
-  visit(cast.expr);
-  visit(cast.typeof);
-
-  const auto &resolved_ty = cast.type();
-  if (resolved_ty.IsNoneTy()) {
-    pass_tracker_.inc_num_unresolved();
-    return; // Revisit later.
-  }
-
-  auto rhs = cast.expr.type();
-  if (rhs.IsNoneTy()) {
-    return; // Revisit later.
-  }
-
-  // Resolved the type because we may mutate it below, for various reasons.
-  cast.typeof->record = resolved_ty;
-  auto &ty = std::get<SizedType>(cast.typeof->record);
-
-  if (ty.IsArrayTy()) {
-    if (ty.GetNumElements() == 0) {
-      if (ty.GetElementTy().GetSize() != 0) {
-        if (rhs.GetSize() % ty.GetElementTy().GetSize() == 0) {
-          // cast to unsized array (e.g. int8[]), determine size from RHS
-          auto num_elems = rhs.GetSize() / ty.GetElementTy().GetSize();
-          ty = CreateArray(num_elems, ty.GetElementTy());
-        }
-      }
-    }
-
-    if (rhs.IsIntTy() || rhs.IsBoolTy())
-      ty.is_internal = true;
-
-    if (rhs.IsIntTy()) {
-      if ((ty.GetElementTy().IsIntegerTy() || ty.GetElementTy().IsBoolTy())) {
-        if ((ty.GetSize() <= 8) && (ty.GetSize() > rhs.GetSize())) {
-          create_int_cast(cast.expr,
-                          CreateInteger(ty.GetSize() * 8,
-                                        ty.GetElementTy().IsSigned()));
-        }
-      }
-    }
-  }
-
-  if (ty.IsArrayTy() && rhs.IsIntTy() &&
-      (ty.GetElementTy().IsIntegerTy() || ty.GetElementTy().IsBoolTy())) {
-    if ((ty.GetSize() <= 8) && (ty.GetSize() > rhs.GetSize())) {
-      create_int_cast(cast.expr,
-                      CreateInteger(ty.GetSize() * 8,
-                                    ty.GetElementTy().IsSigned()));
-    }
-  }
-
-  if (cast.expr.type().IsCtxAccess() && !ty.IsIntTy()) {
-    ty.MarkCtxAccess();
-  }
-  ty.SetAS(cast.expr.type().GetAS());
-  // case : begin { @foo = (struct Foo)0; }
-  // case : profile:hz:99 $task = (struct task_struct *)curtask.
-  if (ty.GetAS() == AddrSpace::none) {
-    if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
-      ProbeType type = probe->get_probetype();
-      ty.SetAS(find_addrspace(type));
-    } else {
-      // Assume kernel space for data in subprogs.
-      ty.SetAS(AddrSpace::kernel);
-    }
-  }
-}
-
-void TypeResolver::visit(Tuple &tuple)
-{
-  std::vector<SizedType> elements;
-  for (auto &elem : tuple.elems) {
-    visit(elem);
-
-    // If elem type is none that means that the tuple is not yet resolved.
-    if (elem.type().IsNoneTy()) {
-      pass_tracker_.inc_num_unresolved();
-      return;
-    }
-    elements.emplace_back(elem.type());
-  }
-
-  tuple.tuple_type = CreateTuple(Struct::CreateTuple(elements));
-}
-
-void TypeResolver::visit(Record &record)
-{
-  std::vector<SizedType> elements;
-  std::vector<std::string_view> names;
-  for (auto *named_arg : record.elems) {
-    auto &elem = named_arg->expr;
-    visit(elem);
-    names.emplace_back(named_arg->name);
-
-    // If elem type is none that means that the record is not yet resolved.
-    if (elem.type().IsNoneTy()) {
-      pass_tracker_.inc_num_unresolved();
-      return;
-    }
-    elements.emplace_back(elem.type());
-  }
-
-  record.record_type = CreateRecord(Struct::CreateRecord(elements, names));
-}
-
-void TypeResolver::visit(Expression &expr)
-{
-  // Visit and fold all other values.
-  Visitor<TypeResolver>::visit(expr);
-  fold(ctx_, expr);
-
-  // Inline specific constant expressions.
-  if (auto *szof = expr.as<Sizeof>()) {
-    const auto v = check(*szof);
-    if (v) {
-      expr.value = ctx_.make_node<Integer>(Location(szof->loc), *v);
-    }
-  } else if (auto *offof = expr.as<Offsetof>()) {
-    const auto v = check(*offof);
-    if (v) {
-      expr.value = ctx_.make_node<Integer>(Location(offof->loc), *v);
-    }
-  } else if (auto *type_id = expr.as<Typeinfo>()) {
-    const auto &ty = type_id->typeof->type();
-    if (!ty.IsNoneTy()) {
-      // We currently lack a globally-unique enumeration of types. For
-      // simplicity, just use the type string with a placeholder identifier.
-      auto *id = ctx_.make_node<Integer>(type_id->loc, 0);
-      auto *base_type = ctx_.make_node<String>(type_id->loc,
-                                               to_string(ty.GetTy()));
-      auto *full_type = ctx_.make_node<String>(type_id->loc, typestr(ty));
-      expr.value = make_record(ctx_,
-                               type_id->loc,
-                               { { "btf_id", id },
-                                 { "base_type", base_type },
-                                 { "full_type", full_type } });
-    }
-  } else if (auto *binop = expr.as<Binop>()) {
-    if ((binop->left.type().IsTupleTy() || binop->left.type().IsRecordTy()) &&
-        binop->left.type().IsCompatible(binop->right.type()) &&
-        (binop->op == Operator::EQ || binop->op == Operator::NE)) {
-      bool is_tuple = binop->left.type().IsTupleTy();
-      const auto &lht = binop->left.type();
-      const auto &rht = binop->right.type();
-      auto updatedTy = is_tuple ? get_promoted_tuple(lht, rht)
-                                : get_promoted_record(lht, rht);
-      if (!updatedTy) {
-        binop->addError() << "Type mismatch for '" << opstr(*binop)
-                          << "': comparing " << lht << " with " << rht;
-      } else {
-        if (*updatedTy != lht) {
-          if (is_tuple) {
-            create_tuple_cast(binop->left, lht, *updatedTy);
-          } else {
-            create_record_cast(binop->left, lht, *updatedTy);
-          }
-        }
-        if (*updatedTy != rht) {
-          if (is_tuple) {
-            create_tuple_cast(binop->right, rht, *updatedTy);
-          } else {
-            create_record_cast(binop->right, rht, *updatedTy);
-          }
-        }
-
-        bool types_equal = binop->left.type() == binop->right.type();
-
-        auto *size = ctx_.make_node<Integer>(binop->loc,
-                                             updatedTy->GetSize(),
-                                             CreateUInt64());
-        // N.B. if the types aren't equal at this point it means that
-        // we're dealing with record types that are same except for
-        // their fields are in a different order so we need to use a
-        // different memcmp that saves off both the left and right to
-        // variables but sets the type of the right variable to the left
-        // before assignment (e.g. `let $right: typeof($left) = right;`)
-        // as this ensures the temporary `$right` variable has the same
-        // field ordering as the `$left`.
-        auto *call = ctx_.make_node<Call>(
-            binop->loc,
-            types_equal ? "memcmp" : "memcmp_record",
-            ExpressionList{ binop->left, binop->right, size });
-        auto *typeof = ctx_.make_node<Typeof>(binop->loc, CreateBool());
-        auto *cast = ctx_.make_node<Cast>(binop->loc, typeof, call);
-        if (binop->op == Operator::NE) {
-          expr.value = cast;
-        } else {
-          expr.value = ctx_.make_node<Unop>(binop->loc, cast, Operator::LNOT);
-        }
-        expand_macro(ctx_, expr, macro_registry_);
-      }
-    }
-  }
-}
-
-void TypeResolver::visit(ExprStatement &expr)
-{
-  visit(expr.expr);
-}
-
-static const std::unordered_map<Type, std::string_view> AGGREGATE_HINTS{
-  { Type::count_t, "count()" },
-  { Type::sum_t, "sum(retval)" },
-  { Type::min_t, "min(retval)" },
-  { Type::max_t, "max(retval)" },
-  { Type::avg_t, "avg(retval)" },
-  { Type::hist_t, "hist(retval)" },
-  { Type::lhist_t, "lhist(rand %10, 0, 10, 1)" },
-  { Type::tseries_t, "tseries(rand %10, 10s, 1)" },
-  { Type::stats_t, "stats(arg2)" },
-};
-
-void TypeResolver::visit(AssignMapStatement &assignment)
-{
-  visit(assignment.map_access);
-  visit(assignment.expr);
-
-  reconcile_map_key(assignment.map_access->map, assignment.map_access->key);
-  const auto *map_type_before = get_map_type(*assignment.map_access->map);
-
-  // Add an implicit cast when copying the value of an aggregate map to an
-  // existing map of int. Enables the following: `@x = 1; @y = count(); @x =
-  // @y`
-  const bool map_contains_int = map_type_before && map_type_before->IsIntTy();
-  if (map_contains_int && assignment.expr.type().IsCastableMapTy()) {
-    auto *typeof = ctx_.make_node<Typeof>(assignment.loc, *map_type_before);
-    assignment.expr = ctx_.make_node<Cast>(assignment.loc,
-                                           typeof,
-                                           assignment.expr);
-  }
-
-  if (!is_valid_assignment(assignment.expr, map_type_before == nullptr)) {
-    auto &err = assignment.addError();
-    const auto &type = assignment.expr.type();
-    auto hint = AGGREGATE_HINTS.find(type.GetTy());
-    if (hint == AGGREGATE_HINTS.end()) {
-      err << "Not a valid assignment: " << type.GetTy();
-    } else {
-      err << "Map value '" << type
-          << "' cannot be assigned from one map to another. "
-             "The function that returns this type must be called directly "
-             "e.g. "
-             "`"
-          << assignment.map_access->map->ident << " = " << hint->second
-          << ";`.";
-
-      if (const auto *acc = assignment.expr.as<MapAccess>()) {
-        if (type.IsCastableMapTy()) {
-          err.addHint() << "Add a cast to integer if you want the value of the "
-                           "aggregate, "
-                        << "e.g. `" << assignment.map_access->map->ident
-                        << " = (int64)" << acc->map->ident << ";`.";
-        }
-      }
-    }
-  }
-
-  assign_map_type(*assignment.map_access->map,
-                  assignment.expr.type(),
-                  &assignment,
-                  &assignment);
-
-  const auto &map_ident = assignment.map_access->map->ident;
-  const auto &type = assignment.expr.type();
-
-  if (type.IsCStructTy() && map_val_[map_ident].IsCStructTy()) {
-    std::string ty = assignment.expr.type().GetName();
-    std::string stored_ty = map_val_[map_ident].GetName();
-    if (!stored_ty.empty() && stored_ty != ty) {
-      assignment.addError()
-          << "Type mismatch for " << map_ident << ": "
-          << "trying to assign value of type '" << ty
-          << "' when map already has a type '" << stored_ty << "'";
-    } else {
-      map_val_[map_ident] = assignment.expr.type();
-      map_val_[map_ident].is_internal = true;
-    }
-  } else if (type.IsStringTy()) {
-    auto map_size = map_val_[map_ident].GetSize();
-    auto expr_size = assignment.expr.type().GetSize();
-    if (map_size < expr_size) {
-      assignment.addWarning() << "String size mismatch: " << map_size << " < "
-                              << expr_size << ". The value may be truncated.";
-    }
-  } else if (type.IsBufferTy()) {
-    auto map_size = map_val_[map_ident].GetSize();
-    auto expr_size = assignment.expr.type().GetSize();
-    if (map_size != expr_size) {
-      std::stringstream buf;
-      buf << "Buffer size mismatch: " << map_size << " != " << expr_size << ".";
-      if (map_size < expr_size) {
-        buf << " The value may be truncated.";
-        assignment.addWarning() << buf.str();
-      } else {
-        // bpf_map_update_elem() expects map_size-length value
-        assignment.addError() << buf.str();
-      }
-    }
-  } else if (type.IsCtxAccess()) {
-    // bpf_map_update_elem() only accepts a pointer to a element in the stack
-    assignment.addError() << "context cannot be assigned to a map";
-  } else if (type.IsArrayTy()) {
-    const auto &map_type = map_val_[map_ident];
-    const auto &expr_type = assignment.expr.type();
-    if (map_type == expr_type) {
-      map_val_[map_ident].is_internal = true;
-    } else {
-      assignment.addError()
-          << "Array type mismatch: " << map_type << " != " << expr_type << ".";
-    }
-  } else if (type.IsNoneTy()) {
-    pass_tracker_.inc_num_unresolved();
-  }
-}
-
-void TypeResolver::visit(AssignVarStatement &assignment)
-{
-  visit(assignment.expr);
-
-  // Only visit the declaration if it is a `let` declaration,
-  // otherwise skip as it is not a variable access.
-  if (std::holds_alternative<VarDeclStatement *>(assignment.var_decl)) {
-    visit(assignment.var_decl);
-  }
-
-  if (assignment.expr.type().IsCastableMapTy()) {
-    auto *typeof = ctx_.make_node<Typeof>(assignment.loc, CreateInt64());
-    assignment.expr = ctx_.make_node<Cast>(assignment.loc,
-                                           typeof,
-                                           assignment.expr);
-  }
-
-  const auto &var_ident = assignment.var()->ident;
-
-  if (!is_valid_assignment(assignment.expr)) {
-    if (is_final_pass()) {
-      assignment.addError() << "Value '" << assignment.expr.type()
-                            << "' cannot be assigned to a scratch variable.";
-    }
-    return;
-  }
-
-  Node *var_scope = nullptr;
-  auto assignTy = assignment.expr.type();
-
-  if (auto *scope = find_variable_scope(var_ident)) {
-    auto &foundVar = variables_[scope][var_ident];
-    auto &storedTy = foundVar.type;
-    bool type_mismatch_error = false;
-    if (storedTy.IsNoneTy()) {
-      storedTy = assignTy;
-    } else if (!storedTy.IsCompatible(assignTy) &&
-               (!storedTy.IsIntegerTy() || !assignTy.IsIntegerTy())) {
-      if (!assignTy.IsNoneTy() || is_final_pass()) {
-        type_mismatch_error = true;
-      } else {
-        pass_tracker_.inc_num_unresolved();
-      }
-    } else if (assignTy.IsStringTy()) {
-      if (assignTy.GetSize() > storedTy.GetSize()) {
-        if (foundVar.can_resize) {
-          storedTy.SetSize(assignTy.GetSize());
-        } else {
-          type_mismatch_error = true;
-        }
-      } else {
-        create_string_cast(assignment.expr, storedTy);
-      }
-    } else if (storedTy.IsIntegerTy()) {
-      auto updatedTy = update_int_type(assignTy, assignment.expr, storedTy);
-      if (!updatedTy ||
-          (!updatedTy->IsEqual(storedTy) && !foundVar.can_resize)) {
-        type_mismatch_error = true;
-      } else {
-        storedTy = *updatedTy;
-        assignTy = *updatedTy;
-      }
-    } else if (assignTy.IsBufferTy()) {
-      auto var_size = storedTy.GetSize();
-      auto expr_size = assignTy.GetSize();
-      if (var_size != expr_size) {
-        assignment.addWarning()
-            << "Buffer size mismatch: " << var_size << " != " << expr_size
-            << (var_size < expr_size ? ". The value may be truncated."
-                                     : ". The value may contain garbage.");
-      }
-    } else if (assignTy.IsTupleTy()) {
-      auto updatedTy = get_promoted_tuple(storedTy, assignTy);
-      if (!updatedTy || (*updatedTy != storedTy && !foundVar.can_resize)) {
-        type_mismatch_error = true;
-      } else {
-        if (*updatedTy != assignTy) {
-          create_tuple_cast(assignment.expr, assignTy, *updatedTy);
-        }
-        storedTy = *updatedTy;
-        assignTy = *updatedTy;
-      }
-    } else if (assignTy.IsRecordTy()) {
-      auto updatedTy = get_promoted_record(storedTy, assignTy);
-      if (!updatedTy || (*updatedTy != storedTy && !foundVar.can_resize)) {
-        type_mismatch_error = true;
-      } else {
-        if (*updatedTy != assignTy) {
-          create_record_cast(assignment.expr, assignTy, *updatedTy);
-        }
-        storedTy = *updatedTy;
-        assignTy = *updatedTy;
-      }
-    }
-    if (type_mismatch_error) {
-      if (is_final_pass()) {
-        assignment.addError()
-            << "Type mismatch for " << var_ident << ": "
-            << "trying to assign value of type '" << assignTy
-            << "' when variable already has a type '" << storedTy << "'";
-      }
-    } else {
-      // The assign type is possibly more complete than the stored type,
-      // which could come from a variable declaration. The assign type may
-      // resolve builtins like `curtask` which also specifies the address
-      // space.
-      if (assignTy.GetSize() < storedTy.GetSize()) {
-        assignTy.SetSize(storedTy.GetSize());
-      }
-      foundVar.type = assignTy;
-      var_scope = scope;
-    }
-  }
-
-  if (var_scope == nullptr) {
-    variables_[scope_stack_.back()].insert({ var_ident,
-                                             {
-                                                 .type = assignTy,
-                                                 .can_resize = true,
-                                             } });
-    var_scope = scope_stack_.back();
-  }
-
-  const auto &storedTy = variables_[var_scope][var_ident].type;
-  assignment.var()->var_type = storedTy;
-}
-
-void TypeResolver::visit(VarDeclStatement &decl)
-{
-  visit(decl.typeof);
-  const std::string &var_ident = decl.var->ident;
-
-  if (decl.typeof) {
-    decl.var->var_type = decl.typeof->type();
-  }
-
-  if (is_first_pass() || is_final_pass()) {
-    if (auto *scope = find_variable_scope(var_ident)) {
-      auto &foundVar = variables_[scope][var_ident];
-      // Checking the first pass only for cases like this:
-      // `begin { if (1) { let $x; } $x = 2; }`
-      // Again, this is legal and there is no ambiguity but `$x = 2` gets
-      // placed in the outer scope so subsequent passes would consider
-      // this a use before declaration error (below)
-      if (!variable_decls_[scope].contains(var_ident) && is_first_pass()) {
-        decl.addError()
-            << "Variable declarations need to occur before variable usage or "
-               "assignment. Variable: "
-            << var_ident;
-      } else if (is_final_pass()) {
-        if (!decl.typeof || (decl.typeof->type().IsNoneTy() ||
-                             decl.typeof->type().GetSize() == 0)) {
-          // Update the declaration type if it was either not set e.g. `let $a;`
-          // or the type is ambiguous or resizable e.g. `let $a: string;`
-          decl.var->var_type = foundVar.type;
-        } else {
-          foundVar.type = decl.var->var_type;
-        }
-      }
-
-      return;
-    }
-  }
-
-  bool can_resize = decl.var->var_type.GetSize() == 0;
-
-  variables_[scope_stack_.back()].insert({ var_ident,
-                                           {
-                                               .type = decl.var->var_type,
-                                               .can_resize = can_resize,
-                                           } });
-  variable_decls_[scope_stack_.back()].insert({ var_ident, decl });
-}
-
-void TypeResolver::visit(BlockExpr &block)
-{
-  scope_stack_.push_back(&block);
-  visit(block.stmts);
-  visit(block.expr);
-  scope_stack_.pop_back();
-}
-
-void TypeResolver::visit(Probe &probe)
-{
-  top_level_node_ = &probe;
-  visit(probe.attach_points);
-  visit(probe.block);
-}
-
-void TypeResolver::visit(Subprog &subprog)
-{
-  // Note that we visit the subprogram and process arguments *after*
-  // constructing the stack with the variable states. This is because the
-  // arguments, etc. may have types defined in terms of the arguments
-  // themselves. We already handle detecting circular dependencies.
-  scope_stack_.push_back(&subprog);
-  top_level_node_ = &subprog;
-  for (SubprogArg *arg : subprog.args) {
-    const auto &ty = arg->typeof->type();
-    auto &var = variables_[scope_stack_.back()]
-                    .emplace(arg->var->ident,
-                             variable{
-                                 .type = ty,
-                                 .can_resize = true,
-                             })
-                    .first->second;
-    var.type = ty; // Override in case it has changed.
-  }
-
-  // Validate that arguments are set.
-  visit(subprog.args);
-  for (SubprogArg *arg : subprog.args) {
-    if (arg->typeof->type().IsNoneTy()) {
-      pass_tracker_.inc_num_unresolved();
-    }
-  }
-
-  // Visit all statements.
-  visit(subprog.block);
-
-  // Validate that the return type is valid.
-  visit(subprog.return_type);
-  if (subprog.return_type->type().IsNoneTy()) {
-    pass_tracker_.inc_num_unresolved();
-  }
-  scope_stack_.pop_back();
-}
-
-void TypeResolver::visit(Comptime &comptime)
-{
-  visit(comptime.expr);
-  // If something has not been resolved by the last pass, then we fail.
-  if (is_final_pass()) {
-    comptime.addError() << "Unable to resolve comptime expression.";
-  } else {
-    pass_tracker_.inc_num_unresolved();
-  }
-}
-
-int TypeResolver::analyse()
-{
-  std::string errors;
-
-  auto last_num_unresolved = std::numeric_limits<int>::max();
-  auto last_unresolved_branches = pass_tracker_.get_unresolved_branches();
-
-  // Multiple passes to handle variables being used before they are defined
-  while (ctx_.diagnostics().ok()) {
-    pass_tracker_.reset_num_unresolved();
-    visit(ctx_.root);
-    if (is_final_pass()) {
-      return pass_tracker_.get_num_passes();
-    }
-
-    auto num_unresolved = pass_tracker_.get_num_unresolved();
-    auto unresolved_branches = pass_tracker_.get_unresolved_branches();
-
-    if (unresolved_branches != last_unresolved_branches) {
-      // While we have unresolved branches that are changing, we need to reset
-      // our unresolved number since it may increase.
-      last_unresolved_branches = std::move(unresolved_branches);
-      last_num_unresolved = std::numeric_limits<int>::max();
-      if (pass_tracker_.is_second_chance()) {
-        pass_tracker_.clear_second_chance();
-      }
-    } else if (num_unresolved > 0 && num_unresolved < last_num_unresolved) {
-      // If we're making progress, keep making passes.
-      last_num_unresolved = num_unresolved;
-      if (pass_tracker_.is_second_chance()) {
-        pass_tracker_.clear_second_chance();
-      }
-    } else {
-      if (pass_tracker_.is_second_chance()) {
-        pass_tracker_.mark_final_pass();
-      } else {
-        pass_tracker_.mark_second_chance();
-      }
-    }
-
-    pass_tracker_.inc_num_passes();
-  }
-
-  return 1;
-}
-
-inline bool TypeResolver::is_final_pass() const
-{
-  return pass_tracker_.is_final_pass();
-}
-
-bool TypeResolver::is_first_pass() const
-{
-  return pass_tracker_.get_num_passes() == 1;
-}
-
-void TypeResolver::check_map_value(Map &map, Call &call, SizedType type)
-{
-  assign_map_type(map, type, &call);
-  if (type.IsMinTy() || type.IsMaxTy() || type.IsAvgTy() || type.IsSumTy() ||
-      type.IsStatsTy()) {
-    // N.B. this keeps track of the integers passed to these map
-    // aggregation calls to ensure they are compatible
-    // (similar to the logic in update_int_type)
-    const auto &assignTy = call.vargs.at(2).type();
-    auto found = agg_map_val_.find(map.ident);
-    if (found != agg_map_val_.end()) {
-      auto &storedTy = found->second;
-      if (assignTy.IsSigned() != storedTy.IsSigned()) {
-        auto updatedTy = get_promoted_int(
-            storedTy, assignTy, std::nullopt, call.vargs.at(2));
-        if (!updatedTy) {
-          call.addError() << "Type mismatch for " << map.ident << ": "
-                          << "trying to assign value of type '" << assignTy
-                          << "' when map already has a type '" << storedTy
-                          << "'";
-        } else {
-          storedTy.SetSize(updatedTy->GetSize());
-          storedTy.SetSign(true);
-        }
-      } else {
-        storedTy.SetSize(std::max(assignTy.GetSize(), storedTy.GetSize()));
-      }
-    } else {
-      agg_map_val_[map.ident] = assignTy;
-    }
-  }
-  if (is_final_pass() && map.type().IsNoneTy()) {
-    map.addError() << "Undefined map: " + map.ident;
-  }
-}
-
-SizedType *TypeResolver::get_map_type(const Map &map)
-{
-  const std::string &map_ident = map.ident;
-  auto search = map_val_.find(map_ident);
-  if (search == map_val_.end())
-    return nullptr;
-  return &search->second;
-}
-
-SizedType *TypeResolver::get_map_key_type(const Map &map)
-{
-  if (auto it = map_key_.find(map.ident); it != map_key_.end()) {
-    return &it->second;
-  }
-  return nullptr;
-}
-
-// Semantic analysis for assigning a value of the provided type to the given
-// map. The type within the passes `Map` node will be updated to reflect the
-// new type, if available.
-void TypeResolver::assign_map_type(Map &map,
-                                   const SizedType &type,
-                                   const Node *loc_node,
-                                   AssignMapStatement *assignment)
-{
-  const std::string &map_ident = map.ident;
-
-  if (type.IsCStructTy() && type.GetStruct() &&
-      type.GetStruct()->is_tracepoint_args) {
-    loc_node->addError() << "Storing tracepoint args in maps is not supported";
-  }
-
-  auto *maptype = get_map_type(map);
-  if (maptype) {
-    auto storedTy = *maptype;
-    bool type_mismatch_error = false;
-    if (storedTy.IsNoneTy()) {
-      pass_tracker_.inc_num_unresolved();
-      if (is_final_pass())
-        map.addError() << "Undefined map: " + map_ident;
-      else
-        storedTy = type;
-    } else if (storedTy.IsPtrTy() && type.IsIntegerTy()) {
-      // OK
-    } else if (storedTy.GetTy() != type.GetTy()) {
-      type_mismatch_error = true;
-    } else if (storedTy.IsIntegerTy()) {
-      if (!assignment) {
-        storedTy = type;
-      } else {
-        auto updatedTy = update_int_type(type, assignment->expr, storedTy);
-        if (!updatedTy) {
-          type_mismatch_error = true;
-        } else {
-          storedTy = *updatedTy;
-        }
-      }
-    } else if (storedTy.IsStringTy()) {
-      if (storedTy.GetSize() > type.GetSize()) {
-        create_string_cast(assignment->expr, storedTy);
-      } else {
-        storedTy.SetSize(type.GetSize());
-      }
-    } else if (storedTy.IsTupleTy()) {
-      if (!storedTy.IsCompatible(type)) {
-        type_mismatch_error = true;
-      } else {
-        auto updatedTy = get_promoted_tuple(storedTy, type);
-        if (!updatedTy) {
-          type_mismatch_error = true;
-        } else {
-          if (*updatedTy != type) {
-            create_tuple_cast(assignment->expr, type, *updatedTy);
-          }
-          storedTy = *updatedTy;
-        }
-      }
-    } else if (storedTy.IsRecordTy()) {
-      if (!storedTy.IsCompatible(type)) {
-        type_mismatch_error = true;
-      } else {
-        auto updatedTy = get_promoted_record(storedTy, type);
-        if (!updatedTy) {
-          type_mismatch_error = true;
-        } else {
-          if (*updatedTy != type) {
-            create_record_cast(assignment->expr, type, *updatedTy);
-          }
-          storedTy = *updatedTy;
-        }
-      }
-    } else if (type.IsMinTy() || type.IsMaxTy() || type.IsAvgTy() ||
-               type.IsSumTy() || type.IsStatsTy()) {
-      if (storedTy.IsSigned() != type.IsSigned()) {
-        storedTy.SetSign(true);
-      }
-    }
-    if (type_mismatch_error) {
-      if (is_final_pass()) {
-        loc_node->addError()
-            << "Type mismatch for " << map_ident << ": "
-            << "trying to assign value of type '" << type
-            << "' when map already has a type '" << storedTy << "'";
-      }
-    } else {
-      map.value_type = storedTy;
-      *maptype = storedTy;
-    }
-  } else {
-    // This map hasn't been seen before.
-    map_val_.insert({ map_ident, type });
-    map.value_type = map_val_[map_ident];
-  }
-}
-
-SizedType TypeResolver::create_key_type(const SizedType &expr_type, Node &node)
-{
-  SizedType new_key_type = expr_type;
-  if (expr_type.IsTupleTy()) {
-    std::vector<SizedType> elements;
-    for (const auto &field : expr_type.GetFields()) {
-      SizedType keytype = create_key_type(field.type, node);
-      elements.push_back(std::move(keytype));
-    }
-    new_key_type = CreateTuple(Struct::CreateTuple(elements));
-  } else if (expr_type.IsRecordTy()) {
-    std::vector<SizedType> elements;
-    std::vector<std::string_view> names;
-    for (const auto &field : expr_type.GetFields()) {
-      SizedType keytype = create_key_type(field.type, node);
-      elements.push_back(std::move(keytype));
-      names.emplace_back(field.name);
-    }
-    new_key_type = CreateRecord(Struct::CreateRecord(elements, names));
-  }
-
-  return new_key_type;
-}
-
-std::optional<SizedType> TypeResolver::get_promoted_int(
-    const SizedType &leftTy,
-    const SizedType &rightTy,
-    const std::optional<Expression> &leftExpr,
-    const std::optional<Expression> &rightExpr)
-{
-  if (leftTy.IsEqual(rightTy)) {
-    return leftTy;
-  }
-
-  bool leftSigned = leftTy.IsSigned();
-  bool rightSigned = rightTy.IsSigned();
-  auto leftSize = leftTy.GetSize();
-  auto rightSize = rightTy.GetSize();
-
-  if (leftSigned != rightSigned) {
-    if (leftSigned) {
-      if (leftSize > rightSize) {
-        return leftTy;
-      }
-      if (rightExpr && (*rightExpr).is<Integer>()) {
-        auto signed_ty = ast::get_signed_integer_type(
-            (*rightExpr).as<Integer>()->value);
-        if (!signed_ty) {
-          // The value is too large and can't fit into
-          // any supported signed int types
-          return std::nullopt;
-        }
-        if (signed_ty->GetSize() <= leftSize) {
-          return leftTy;
-        }
-      }
-    } else if (rightSigned) {
-      if (rightSize > leftSize) {
-        return rightTy;
-      }
-      if (leftExpr && (*leftExpr).is<Integer>()) {
-        auto signed_ty = ast::get_signed_integer_type(
-            (*leftExpr).as<Integer>()->value);
-        if (!signed_ty) {
-          // The value is too large and can't fit into
-          // any supported signed int types
-          return std::nullopt;
-        }
-        if (signed_ty->GetSize() <= rightSize) {
-          return rightTy;
-        }
-      }
-    }
-
-    size_t new_size = std::max(leftSize, rightSize) * 2;
-    if (new_size > 8) {
-      return std::nullopt;
-    } else {
-      return CreateInteger(new_size * 8, true);
-    }
-  }
-
-  // Same sign - return the larger of the two
-  size_t new_size = std::max(leftSize, rightSize);
-  return CreateInteger(new_size * 8, leftSigned);
-}
-
-std::optional<SizedType> TypeResolver::get_promoted_tuple(
-    const SizedType &leftTy,
-    const SizedType &rightTy)
-{
-  assert(leftTy.IsTupleTy() && leftTy.IsCompatible(rightTy));
-
-  std::vector<SizedType> new_elems;
-  for (ssize_t i = 0; i < rightTy.GetFieldCount(); i++) {
-    auto storedElemTy = leftTy.GetField(i).type;
-    auto assignElemTy = rightTy.GetField(i).type;
-    if (storedElemTy.IsIntegerTy()) {
-      auto updatedTy = get_promoted_int(storedElemTy, assignElemTy);
-      if (!updatedTy) {
-        return std::nullopt;
-      }
-
-      new_elems.emplace_back(*updatedTy);
-      continue;
-    } else if (storedElemTy.IsTupleTy()) {
-      auto new_elem = get_promoted_tuple(storedElemTy, assignElemTy);
-      if (!new_elem) {
-        return std::nullopt;
-      } else {
-        new_elems.emplace_back(*new_elem);
-        continue;
-      }
-    } else if (storedElemTy.IsRecordTy()) {
-      auto new_elem = get_promoted_record(storedElemTy, assignElemTy);
-      if (!new_elem) {
-        return std::nullopt;
-      } else {
-        new_elems.emplace_back(*new_elem);
-        continue;
-      }
-    } else if (storedElemTy.IsStringTy()) {
-      storedElemTy.SetSize(
-          std::max(storedElemTy.GetSize(), assignElemTy.GetSize()));
-      new_elems.emplace_back(storedElemTy);
-      continue;
-    } else if (storedElemTy.IsArrayTy()) {
-      if ((storedElemTy.GetSize() != assignElemTy.GetSize()) ||
-          (storedElemTy.GetElementTy() != assignElemTy.GetElementTy())) {
-        return std::nullopt;
-      }
-    }
-
-    new_elems.emplace_back(storedElemTy);
-  }
-  return CreateTuple(Struct::CreateTuple(new_elems));
-}
-
-std::optional<SizedType> TypeResolver::get_promoted_record(
-    const SizedType &storedTy,
-    const SizedType &assignTy)
-{
-  assert(storedTy.IsRecordTy() && storedTy.IsCompatible(assignTy));
-
-  std::vector<SizedType> new_elems;
-  std::vector<std::string_view> names;
-  // Maintain the ordering of the storedTy
-  for (const auto &storedElemField : storedTy.GetFields()) {
-    names.emplace_back(storedElemField.name);
-
-    auto storedElemTy = storedElemField.type;
-    auto assignElemTy = assignTy.GetField(storedElemField.name).type;
-    if (storedElemTy.IsIntegerTy()) {
-      auto updatedTy = get_promoted_int(storedElemTy, assignElemTy);
-      if (!updatedTy) {
-        return std::nullopt;
-      }
-
-      new_elems.emplace_back(*updatedTy);
-      continue;
-    } else if (storedElemTy.IsTupleTy()) {
-      auto new_elem = get_promoted_tuple(storedElemTy, assignElemTy);
-      if (!new_elem) {
-        return std::nullopt;
-      } else {
-        new_elems.emplace_back(*new_elem);
-        continue;
-      }
-    } else if (storedElemTy.IsRecordTy()) {
-      auto new_elem = get_promoted_record(storedElemTy, assignElemTy);
-      if (!new_elem) {
-        return std::nullopt;
-      } else {
-        new_elems.emplace_back(*new_elem);
-        continue;
-      }
-    } else if (storedElemTy.IsStringTy()) {
-      storedElemTy.SetSize(
-          std::max(storedElemTy.GetSize(), assignElemTy.GetSize()));
-      new_elems.emplace_back(storedElemTy);
-      continue;
-    } else if (storedElemTy.IsArrayTy()) {
-      if ((storedElemTy.GetSize() != assignElemTy.GetSize()) ||
-          (storedElemTy.GetElementTy() != assignElemTy.GetElementTy())) {
-        return std::nullopt;
-      }
-    }
-
-    new_elems.emplace_back(storedElemTy);
-  }
-  return CreateRecord(Struct::CreateRecord(new_elems, names));
-}
-
-// The leftExpr is optional because in cases of variable assignment,
-// and map key/value adjustment we can't modify/cast the left
-// but in cases of binops or if expressions we can modify/cast both
-// the left and the right expressions
-std::optional<SizedType> TypeResolver::update_int_type(
-    const SizedType &rightTy,
-    Expression &rightExpr,
-    const SizedType &leftTy,
-    std::optional<std::reference_wrapper<Expression>> leftExpr)
-{
-  assert(leftTy.IsIntegerTy() && rightTy.IsIntegerTy());
-
-  auto updatedTy =
-      leftExpr ? get_promoted_int(leftTy, rightTy, leftExpr->get(), rightExpr)
-               : get_promoted_int(leftTy, rightTy, std::nullopt, rightExpr);
-  if (!updatedTy) {
-    return std::nullopt;
-  }
-
-  if (*updatedTy != leftTy && leftExpr) {
-    create_int_cast(leftExpr->get(), *updatedTy);
-  }
-
-  if (*updatedTy != rightTy) {
-    create_int_cast(rightExpr, *updatedTy);
-  }
-
-  return *updatedTy;
-}
-
-void TypeResolver::resolve_struct_type(SizedType &type, Node &node)
-{
-  SizedType inner_type = type;
-  int pointer_level = 0;
-  while (inner_type.IsPtrTy()) {
-    inner_type = inner_type.GetPointeeTy();
-    pointer_level++;
-  }
-  if (inner_type.IsCStructTy() && !inner_type.GetStruct()) {
-    auto struct_type = bpftrace_.structs.Lookup(inner_type.GetName()).lock();
-    if (!struct_type) {
-      // Try to find the type as something other than a struct, e.g. 'char' or
-      // 'uint64_t'
-      auto stype = bpftrace_.btf_->get_stype(inner_type.GetName());
-      if (stype.IsNoneTy()) {
-        node.addError() << "Cannot resolve unknown type \""
-                        << inner_type.GetName() << "\"\n";
-      } else {
-        type = stype;
-        while (pointer_level > 0) {
-          type = CreatePointer(type);
-          pointer_level--;
-        }
-      }
-    } else {
-      type = CreateCStruct(inner_type.GetName(), struct_type);
-      while (pointer_level > 0) {
-        type = CreatePointer(type);
-        pointer_level--;
-      }
-    }
-  }
-}
-
-variable *TypeResolver::find_variable(const std::string &var_ident)
-{
-  if (auto *scope = find_variable_scope(var_ident)) {
-    return &variables_[scope][var_ident];
-  }
-  return nullptr;
-}
-
-Node *TypeResolver::find_variable_scope(const std::string &var_ident, bool safe)
+Node *TypeRuleCollector::find_variable_scope(const std::string &var_ident,
+                                             bool safe)
 {
   for (auto *scope : scope_stack_) {
     if (auto search_val = variables_[scope].find(var_ident);
@@ -3199,21 +2598,108 @@ Node *TypeResolver::find_variable_scope(const std::string &var_ident, bool safe)
   return nullptr;
 }
 
+// This pass consists of 4 visitors:
+// - TypeRuleCollector
+// - AstTransformer
+// - TypeApplicator
+// - CastCreator
+// Read more about how all this works in type_resolution.md
 Pass CreateTypeResolverPass()
 {
-  auto fn = [](ASTContext &ast,
-               BPFtrace &b,
-               CDefinitions &c_definitions,
-               MapMetadata &mm,
-               NamedParamDefaults &named_param_defaults,
-               TypeMetadata &types,
-               MacroRegistry &macro_registry) {
-    TypeResolver type_resolver(
-        ast, b, c_definitions, mm, named_param_defaults, types, macro_registry);
-    type_resolver.analyse();
-  };
+  return Pass::create(
+      "TypeResolver",
+      [](ASTContext &ast,
+         BPFtrace &b,
+         MapMetadata &mm,
+         CDefinitions &c_definitions,
+         NamedParamDefaults &named_param_defaults,
+         TypeMetadata &types,
+         MacroRegistry &macro_registry) {
+        // Fold up front
+        fold(ast);
 
-  return Pass::create("TypeResolver", fn);
+        // Passed to TypeApplicator when all runs are complete
+        ResolvedTypes resolved_types;
+
+        std::vector<Comptime *> prev_comptimes;
+        LockedNodes locked_nodes;
+
+        bool should_rerun = true; // First run
+        // This is just a safety mechanism so we don't spin forever
+        constexpr int MAX_ITERATIONS = 50;
+        int iteration = 0;
+
+        while (should_rerun) {
+          if (++iteration > MAX_ITERATIONS) {
+            ast.diagnostics().addError(ast.root->loc)
+                << "Type resolution exceeded maximum iterations ("
+                << MAX_ITERATIONS
+                << "); possible infinite loop in comptime expressions";
+            return;
+          }
+
+          TypeResolver resolver;
+          auto tr_collector = TypeRuleCollector(ast,
+                                                b,
+                                                mm,
+                                                c_definitions,
+                                                named_param_defaults,
+                                                types,
+                                                macro_registry,
+                                                resolver,
+                                                locked_nodes);
+          // Collect the TypeRules (TypeVariable → TypeRules)
+          tr_collector.visit(ast.root);
+
+          // Resolve the TypeRules collected by the TypeRuleCollector
+          // and generate a set of types for our TypeVariables
+          resolver.resolve(tr_collector.get_map_value_names());
+
+          if (!ast.diagnostics().ok()) {
+            return;
+          }
+
+          resolved_types = resolver.get_resolved_types();
+
+          // Create literals from expressions like `typeinfo`, `offsetof`, etc.
+          // Also handles AST transformations like tuple/record comparisons.
+          AstTransformer transformer(ast, macro_registry, resolved_types);
+          transformer.visit(ast.root);
+
+          // Fold literals like `comptime (typeof($a).base_ty == "int")` that
+          // relied on type information to resolve
+          fold(ast);
+
+          if (!ast.diagnostics().ok()) {
+            return;
+          }
+
+          // Check if we haven't made progress resolving comptime expressions
+          auto next_comptimes = tr_collector.get_unresolved_comptimes();
+          if (!next_comptimes.empty() && prev_comptimes == next_comptimes &&
+              !transformer.had_transforms()) {
+            for (auto *comptime : next_comptimes) {
+              comptime->addError() << "Unable to resolve comptime expression";
+            }
+            return;
+          }
+
+          prev_comptimes = next_comptimes;
+          locked_nodes = tr_collector.get_locked_nodes();
+
+          // Check if there are unresolved comptime expressions or there were
+          // AST transformations, if so we need to re-run everything above
+          should_rerun = !prev_comptimes.empty() ||
+                         transformer.had_transforms();
+        }
+
+        // Add the types to the AST nodes themselves
+        TypeApplicator(resolved_types).visit(ast.root);
+
+        // Apply casts in parts of the AST where we want the left and right
+        // sides to have the same type
+        CastCreator(ast, b).visit(ast.root);
+      });
 };
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/type_resolver.h
+++ b/src/ast/passes/type_resolver.h
@@ -1,8 +1,62 @@
 #pragma once
 
+#include "ast/ast.h"
 #include "ast/pass_manager.h"
+#include "types.h"
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
 
 namespace bpftrace::ast {
+
+using ScopedVariable = std::pair<Node *, std::string>;
+// Node * is a pointer to an AST node
+// ScopedVariable is for tracking the type of a scratch variable referenced in many AST nodes
+// std::string is for map key and value names as these are often resolved separately by different statements/expressions
+using TypeVariable = std::variant<Node *, ScopedVariable, std::string>;
+
+struct ScopedVariableHash {
+  std::size_t operator()(const ScopedVariable &sv) const
+  {
+    auto h1 = std::hash<Node *>{}(sv.first);
+    auto h2 = std::hash<std::string>{}(sv.second);
+    // Boost-style hash combine for better distribution
+    h1 ^= h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2);
+    return h1;
+  }
+};
+
+struct TypeVariableHash {
+  std::size_t operator()(const TypeVariable &gn) const
+  {
+    return std::visit(
+        [](const auto &val) -> std::size_t {
+          using T = std::decay_t<decltype(val)>;
+          if constexpr (std::is_same_v<T, Node *>) {
+            return std::hash<Node *>{}(val);
+          } else if constexpr (std::is_same_v<T, std::string>) {
+            return std::hash<std::string>{}(val);
+          } else {
+            return ScopedVariableHash{}(val);
+          }
+        },
+        gn);
+  }
+};
+
+using ResolvedTypes = std::unordered_map<TypeVariable, SizedType, TypeVariableHash>;
+
+inline std::string get_map_value_name(const std::string &ident)
+{
+  return ident + "__val";
+}
+
+inline std::string get_map_key_name(const std::string &ident)
+{
+  return ident + "__key";
+}
 
 Pass CreateTypeResolverPass();
 

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -47,7 +47,7 @@ macro check_key(@map, key, func)
   if comptime is_scalar(@map) {
     fail("call to %s expects a map with explicit keys (non-scalar map)", func);
   } else {
-    // The typeinfo(@map[key]) is a bit of a hack as it both checks if the passed key is compatible
+    // This is a bit of a hack as it both checks if the passed key is compatible
     // with the map key and it also possibly changes the key type to make them
     // compatible if possible, e.g.
     // @c[1, ("hello", (int8)5)] = 0;

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -106,7 +106,7 @@ macro strstr($haystack, $needle)
     // Special case: the needle is empty.
     0
   } else {
-    __bpf_strnstr((int8*)&$haystack, (int8*)&$needle, $haystack_size, $needle_size)
+    __bpf_strnstr((int8*)&$haystack, (int8*)&$needle, (uint64)$haystack_size, (uint64)$needle_size)
   }
 }
 macro strstr($haystack, needle)

--- a/src/types.h
+++ b/src/types.h
@@ -8,6 +8,7 @@
 #include <compare>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <sys/types.h>
@@ -345,7 +346,6 @@ public:
 
   const std::string &GetName() const
   {
-    assert(IsCStructTy() || IsEnumTy());
     return name_;
   }
 
@@ -518,6 +518,7 @@ public:
     return type_ == Type::count_t || type_ == Type::sum_t ||
            type_ == Type::max_t || type_ == Type::min_t || type_ == Type::avg_t;
   }
+
   bool IsMapIterableTy() const
   {
     if (IsMultiKeyMapTy()) {
@@ -606,6 +607,15 @@ SizedType CreateTimestamp();
 SizedType CreateMacAddress();
 SizedType CreateCgroupPath();
 SizedType CreateTimestampMode();
+
+std::optional<SizedType> get_promoted_int(const SizedType &currentType,
+                                          const SizedType &newType);
+std::optional<SizedType> get_promoted_tuple(const SizedType &currentType,
+                                            const SizedType &newType);
+std::optional<SizedType> get_promoted_record(const SizedType &currentType,
+                                             const SizedType &newType);
+std::optional<SizedType> get_promoted_type(const SizedType &currentType,
+                                           const SizedType &newType);
 
 std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(bpftrace_test
   required_resources.cpp
   scopeguard.cpp
   type_checker.cpp
+  type_resolver.cpp
   temp.cpp
   tracepoint_format_parser.cpp
   types.cpp

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -338,7 +338,7 @@ WILL_FAIL
 
 NAME has_key error type mismatch
 PROG begin { @g[1, "hi"] = 2; if (has_key(@g, (1, 2))) { printf("ok\n"); }  }
-EXPECT_REGEX .* ERROR: Type mismatch for \$\$has_key_\$key: trying to assign value of type '\(uint8,uint8\)' when variable already has a type '\(uint8,string\[3\]\)'.*
+EXPECT_REGEX .* ERROR: Argument mismatch for @g: trying to access with arguments: '\(uint8,uint8\)' when map expects arguments: '\(uint8,string\[3\]\)'.*
 WILL_FAIL
 
 NAME exit code

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -114,10 +114,6 @@ NAME variable declaration with builtin
 PROG begin { let $f: struct task_struct *; $f = curtask; print($f.pid); }
 EXPECT_REGEX [0-9]+
 
-NAME variable declaration with unresolved type
-PROG begin { let $x: struct Foo[1];  }
-EXPECT Attached 1 probe
-
 NAME variable declaration not initialized
 PROG begin { let $a; if ($a) { $a = 1; } @b = $a; }
 EXPECT @b: 0

--- a/tests/self/record.bt
+++ b/tests/self/record.bt
@@ -167,10 +167,6 @@ test:record_promotion_nested {
     if ($a.0 != -50 || $a.1.a != 500 || $a.1.b.x != "areallyreallyreallylongstr" || $a.1.b.y != 20) {
         return 1;
     }
-
-    if (typeinfo($a).full_type != "(int64,record { .a = uint64, .b = record { .x = string[27], .y = int64 } })") {
-        return 1;
-    }
 }
 
 test:record_binop_literal {

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -300,16 +300,9 @@ TEST_F(TypeCheckerTest, builtin_functions)
 TEST_F(TypeCheckerTest, undefined_map)
 {
   test("kprobe:f / @mymap == 123 / { @mymap = 0 }");
-  test("kprobe:f / @mymap == 123 / { 456; }", Error{ R"(
-stdin:1:12-18: ERROR: Undefined map: @mymap
-kprobe:f / @mymap == 123 / { 456; }
-           ~~~~~~
-)" });
-  test("kprobe:f / @mymap1 == 1234 / { 1234; @mymap1 = @mymap2; }", Error{ R"(
-stdin:1:48-55: ERROR: Undefined map: @mymap2
-kprobe:f / @mymap1 == 1234 / { 1234; @mymap1 = @mymap2; }
-                                               ~~~~~~~
-)" });
+  test("kprobe:f / @mymap == 123 / { 456; }");
+  test("kprobe:f / @mymap1 == 1234 / { 1234; @mymap1 = @mymap2; }");
+
   test("kprobe:f { print(@x); }", Error{ R"(
 stdin:1:18-20: ERROR: Undefined map: @x
 kprobe:f { print(@x); }
@@ -343,12 +336,12 @@ TEST_F(TypeCheckerTest, consistent_map_keys)
   test("begin { @y[1] = 0; @y[@x] = 2; @x = 1; }");
 
   test("begin { @x = 0; @x[1]; }", Error{ R"(
-stdin:1:17-22: ERROR: @x used as a map with an explicit key (non-scalar map), previously used without an explicit key (scalar map)
+ERROR: @x used as a map with an explicit key (non-scalar map), previously used without an explicit key (scalar map)
 begin { @x = 0; @x[1]; }
                 ~~~~~
 )" });
   test("begin { @x[1] = 0; @x; }", Error{ R"(
-stdin:1:20-22: ERROR: @x used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)
+ERROR: @x used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)
 begin { @x[1] = 0; @x; }
                    ~~
 )" });
@@ -358,12 +351,12 @@ begin { @x[1] = 0; @x; }
   test("begin { @x[1, ((int8)2, ((int16)3, 4))] = 0; @x[5, (6, (7, 8))]; }");
 
   test("begin { @x[1,2] = 0; @x[3]; }", Error{ R"(
-stdin:1:25-26: ERROR: Argument mismatch for @x: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: 'uint8'
 begin { @x[1,2] = 0; @x[3]; }
-                        ~
+        ~~~~~~~
 )" });
   test("begin { @x[1] = 0; @x[2,3]; }", Error{ R"(
-stdin:1:20-27: ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: 'uint8'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: 'uint8'
 begin { @x[1] = 0; @x[2,3]; }
                    ~~~~~~~
 )" });
@@ -376,7 +369,7 @@ begin { @x[1] = 0; @x[2,3]; }
       @x["b", 2, kstack];
     })",
        Error{ R"(
-stdin:3:7-25: ERROR: Argument mismatch for @x: trying to access with arguments: '(string[2],uint8,kstack_bpftrace_127)' when map expects arguments: '(uint8,string[2],kstack_bpftrace_127)'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(string[2],uint8,kstack_bpftrace_127)' when map expects arguments: '(uint8,string[2],kstack_bpftrace_127)'
       @x["b", 2, kstack];
       ~~~~~~~~~~~~~~~~~~
 )" });
@@ -385,9 +378,9 @@ stdin:3:7-25: ERROR: Argument mismatch for @x: trying to access with arguments: 
 
   test(R"(begin { @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0.0] = 2; } })",
        Error{ R"(
-stdin:1:55-56: ERROR: Argument mismatch for @map: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
+ERROR: Argument mismatch for @map: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
 begin { @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0.0] = 2; } }
-                                                      ~
+                                           ~~~~~~~~~~~~~
 )" });
 
   test(R"(begin { $a = (3, "hi"); @map[1, "by"] = 1; @map[$a] = 2; })");
@@ -487,37 +480,37 @@ TEST_F(TypeCheckerTest, ternary_expressions)
   // Error location is incorrect: #3063
   test("kprobe:f { $x = pid < 10000 ? 3 : cat(\"/proc/uptime\"); exit(); }",
        Error{ R"(
-stdin:1:17-54: ERROR: Branches must return the same type: have 'uint8' and 'void'
+stdin:1:17-54: ERROR: Branches must return the same type or compatible types: have 'uint8' and 'void'
 kprobe:f { $x = pid < 10000 ? 3 : cat("/proc/uptime"); exit(); }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? 1 : \"high\" }", Error{ R"(
-stdin:1:17-41: ERROR: Branches must return the same type: have 'uint8' and 'string[5]'
+stdin:1:17-41: ERROR: Branches must return the same type or compatible types: have 'uint8' and 'string[5]'
 kprobe:f { @x = pid < 10000 ? 1 : "high" }
                 ~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? \"lo\" : 2 }", Error{ R"(
-stdin:1:17-39: ERROR: Branches must return the same type: have 'string[3]' and 'uint8'
+stdin:1:17-39: ERROR: Branches must return the same type or compatible types: have 'string[3]' and 'uint8'
 kprobe:f { @x = pid < 10000 ? "lo" : 2 }
                 ~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? (1, 2) : (\"a\", 4) }", Error{ R"(
-stdin:1:17-48: ERROR: Branches must return the same type: have '(uint8,uint8)' and '(string[2],uint8)'
+stdin:1:17-48: ERROR: Branches must return the same type or compatible types: have '(uint8,uint8)' and '(string[2],uint8)'
 kprobe:f { @x = pid < 10000 ? (1, 2) : ("a", 4) }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? ustack(1) : ustack(2) }", Error{ R"(
-stdin:1:17-52: ERROR: Branches must return the same type: have 'ustack_bpftrace_1' and 'ustack_bpftrace_2'
+stdin:1:17-52: ERROR: Branches must return the same type or compatible types: have 'ustack_bpftrace_1' and 'ustack_bpftrace_2'
 kprobe:f { @x = pid < 10000 ? ustack(1) : ustack(2) }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? kstack(raw) : kstack(perf) }", Error{ R"(
-stdin:1:17-57: ERROR: Branches must return the same type: have 'kstack_raw_127' and 'kstack_perf_127'
+stdin:1:17-57: ERROR: Branches must return the same type or compatible types: have 'kstack_raw_127' and 'kstack_perf_127'
 kprobe:f { @x = pid < 10000 ? kstack(raw) : kstack(perf) }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -853,7 +846,7 @@ TEST_F(TypeCheckerTest, call_delete)
   test("kprobe:f { @y[(3, 4, 5)] = "
        "5; delete(@y, (1, 2)); }",
        Error{ R"(
-ERROR: Type mismatch for $$delete_$key: trying to assign value of type '(uint8,uint8)' when variable already has a type '(uint8,uint8,uint8)'
+ERROR: Argument mismatch for @y: trying to access with arguments: '(uint8,uint8)' when map expects arguments: '(uint8,uint8,uint8)'
 )" },
        Types{ types });
 
@@ -884,7 +877,7 @@ ERROR: call to delete() with two arguments expects a map with explicit keys (non
 
   test(R"(kprobe:f { @x[1, "hi"] = 1; delete(@x["hi", 1]); })",
        Error{ R"(
-ERROR: Type mismatch for $$delete_$key: trying to assign value of type '(string[3],uint8)' when variable already has a type '(uint8,string[3])'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(string[3],uint8)' when map expects arguments: '(uint8,string[3])'
 )" },
        Types{ types });
 
@@ -944,16 +937,12 @@ TEST_F(TypeCheckerTest, call_print_map_item)
   test(R"_(begin { @x[1] = 1; print(@x[2]); })_");
   test(R"_(begin { @x[3, 5] = 1; print(@x[3, 5]); })_");
   test(R"_(begin { @x[1,2] = "asdf"; print((1, 2, @x[1,2])); })_");
+  test("begin { print(@x[2]); }");
 
   test("begin { @x[1] = 1; print(@x[\"asdf\"]); }", Error{ R"(
-stdin:1:34-35: ERROR: Argument mismatch for @x: trying to access with arguments: 'string[5]' when map expects arguments: 'uint8'
+ERROR: Argument mismatch for @x: trying to access with arguments: 'string[5]' when map expects arguments: 'uint8'
 begin { @x[1] = 1; print(@x["asdf"]); }
-                                 ~
-)" });
-  test("begin { print(@x[2]); }", Error{ R"(
-stdin:1:15-20: ERROR: Undefined map: @x
-begin { print(@x[2]); }
-              ~~~~~
+                         ~~~~~~~~~~
 )" });
   test("begin { @x[1] = 1; print(@x[1], 3, 5); }", Error{ R"(
 stdin:1:20-38: ERROR: Non-map print() only takes 1 argument, 3 found
@@ -993,7 +982,6 @@ TEST_F(TypeCheckerTest, call_clear)
 
   test("kprobe:f { clear(@x); @x[1,2] = count(); }");
   test("kprobe:f { @x[1,2] = count(); clear(@x); }");
-  test("kprobe:f { @x[1,2] = count(); clear(@x[3,4]); }", Error{});
 
   test("kprobe:f { @x = count(); @ = clear(@x); }", Error{});
   test("kprobe:f { @x = count(); $y = clear(@x); }", Error{});
@@ -1009,7 +997,6 @@ TEST_F(TypeCheckerTest, call_zero)
 
   test("kprobe:f { zero(@x); @x[1,2] = count(); }");
   test("kprobe:f { @x[1,2] = count(); zero(@x); }");
-  test("kprobe:f { @x[1,2] = count(); zero(@x[3,4]); }", Error{});
 
   test("kprobe:f { @x = count(); @ = zero(@x); }", Error{});
   test("kprobe:f { @x = count(); $y = zero(@x); }", Error{});
@@ -1083,17 +1070,13 @@ TEST_F(TypeCheckerTest, call_has_key)
        Error{},
        Types{ types });
 
-  test(
-      "kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }",
-      Error{
-          R"(ERROR: Type mismatch for $$has_key_$key: trying to assign value of type 'uint8' when variable already has a type '(uint8,uint8)')" },
-      Types{ types });
+  test("kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }",
+       Error{ "ERROR: Argument mismatch" },
+       Types{ types });
 
-  test(
-      R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} })",
-      Error{
-          R"(ERROR: Type mismatch for $$has_key_$key: trying to assign value of type '(uint8,uint8)' when variable already has a type '(uint8,string[3])')" },
-      Types{ types });
+  test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} })",
+       Error{ "ERROR: Argument mismatch" },
+       Types{ types });
 
   test("kprobe:f { @a[1] = 1; has_key(@a, @a); }",
        Error{ R"(
@@ -1376,26 +1359,6 @@ TEST_F(TypeCheckerTest, call_kaddr)
 
 TEST_F(TypeCheckerTest, call_uaddr)
 {
-  test("u:/bin/sh:main { "
-       "__builtin_uaddr(\"github.com/golang/"
-       "glog.severityName\"); }");
-  test("uprobe:/bin/sh:main { "
-       "__builtin_uaddr(\"glob_asciirange\"); }");
-  test("u:/bin/sh:main,u:/bin/sh:readline "
-       "{ __builtin_uaddr(\"glob_asciirange\"); }");
-  test("uprobe:/bin/sh:main { @x = "
-       "__builtin_uaddr(\"glob_asciirange\"); }");
-  test("uprobe:/bin/sh:main { __builtin_uaddr(123); }", Error{});
-  test("uprobe:/bin/sh:main { "
-       "__builtin_uaddr(\"?\"); }",
-       Error{});
-  test("uprobe:/bin/sh:main { $str = "
-       "\"glob_asciirange\"; __builtin_uaddr($str); }",
-       Error{});
-  test("uprobe:/bin/sh:main { @str = "
-       "\"glob_asciirange\"; __builtin_uaddr(@str); }",
-       Error{});
-
   // The C struct parser should set the
   // is_signed flag on signed types
   BPFtrace bpftrace;
@@ -1714,7 +1677,8 @@ TEST_F(TypeCheckerTest, array_as_map_key)
     begin {
       @x[((struct MyStruct *)0)->x] = 0;
       @x[((struct MyStruct *)0)->y] = 1;
-    })");
+    })",
+       Error{});
 }
 
 TEST_F(TypeCheckerTest, array_compare)
@@ -1909,7 +1873,6 @@ TEST_F(TypeCheckerTest, unop_increment_decrement)
   test("kprobe:f { ++@x; }");
   test("kprobe:f { --@x; }");
 
-  test("kprobe:f { $x++; }", Error{});
   test("kprobe:f { @x = \"a\"; @x++; }", Error{});
   test("kprobe:f { $x = \"a\"; $x++; }", Error{});
   test("kprobe:f { ++true; }", Error{});
@@ -2488,9 +2451,9 @@ TEST_F(TypeCheckerTest, struct_as_map_key)
         @x[*((struct B *)0)] = 1;
     })",
        Error{ R"(
-stdin:4:12-13: ERROR: Argument mismatch for @x: trying to access with arguments: 'struct B' when map expects arguments: 'struct A'
+ERROR: Argument mismatch for @x: trying to access with arguments: 'struct B' when map expects arguments: 'struct A'
         @x[*((struct B *)0)] = 1;
-           ~
+        ~~~~~~~~~~~~~~~~~~~~
 )" });
 }
 
@@ -2503,27 +2466,27 @@ TEST_F(TypeCheckerTest, per_cpu_map_as_map_key)
   test("begin { @x = avg(1); @y[@x] = 1; }");
 
   test("begin { @x = hist(10); @y[@x] = 1; }", Error{ R"(
-stdin:1:27-29: ERROR: hist_t cannot be part of a map key
+ERROR: Value 'hist_t' cannot be used as a map key.
 begin { @x = hist(10); @y[@x] = 1; }
-                          ~~
+                       ~~~~~~
 )" });
 
   test("begin { @x = lhist(10, 0, 10, 1); @y[@x] = 1; }", Error{ R"(
-stdin:1:38-40: ERROR: lhist_t cannot be part of a map key
+ERROR: Value 'lhist_t' cannot be used as a map key.
 begin { @x = lhist(10, 0, 10, 1); @y[@x] = 1; }
-                                     ~~
+                                  ~~~~~~
 )" });
 
   test("begin { @x = tseries(10, 1s, 10); @y[@x] = 1; }", Error{ R"(
-stdin:1:38-40: ERROR: tseries_t cannot be part of a map key
+ERROR: Value 'tseries_t' cannot be used as a map key.
 begin { @x = tseries(10, 1s, 10); @y[@x] = 1; }
-                                     ~~
+                                  ~~~~~~
 )" });
 
   test("begin { @x = stats(10); @y[@x] = 1; }", Error{ R"(
-stdin:1:28-30: ERROR: ustats_t cannot be part of a map key
+ERROR: Value 'ustats_t' cannot be used as a map key.
 begin { @x = stats(10); @y[@x] = 1; }
-                           ~~
+                        ~~~~~~
 )" });
 }
 
@@ -3004,13 +2967,14 @@ kprobe:f { $x = -1; $x = 10223372036854775807; }
 )" });
 
   test("begin { $x = (int8)1; $x = 5; }",
-       ExpectedAST{ Program().WithProbe(
-           Probe({ "begin" },
-                 { AssignVarStatement(Variable("$x"),
-                                      Cast(Typeof(SizedType(Type::integer)),
-                                           Integer(1))),
-                   AssignVarStatement(Variable("$x"), Integer(5)),
-                   Jump(ast::JumpType::RETURN) })) });
+       ExpectedAST{ Program().WithProbe(Probe(
+           { "begin" },
+           { AssignVarStatement(Variable("$x"),
+                                Cast(Typeof(SizedType(Type::integer)),
+                                     Cast(Typeof(SizedType(Type::integer)),
+                                          Integer(1)))),
+             AssignVarStatement(Variable("$x"), Integer(5)),
+             Jump(ast::JumpType::RETURN) })) });
   test("begin { $x = (int8)1; $x = (uint8)5; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "begin" },
@@ -3050,27 +3014,20 @@ TEST_F(TypeCheckerTest, mixed_int_like_map_assignments)
   test("kprobe:f { @x = stats((uint32)1); @x = stats(-1); }");
 
   test("kprobe:f { @x = sum((uint64)1); @x = sum(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
-kprobe:f { @x = sum((uint64)1); @x = sum(-1); }
-                                     ~~~~~~~
+ERROR: Type mismatch for sum: trying to call function with type 'int8' when it already has a type 'uint64'
 )" });
   test("kprobe:f { @x = min((uint64)1); @x = min(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
-kprobe:f { @x = min((uint64)1); @x = min(-1); }
-                                     ~~~~~~~
+ERROR: Type mismatch for min: trying to call function with type 'int8' when it already has a type 'uint64'
 )" });
   test("kprobe:f { @x = max((uint64)1); @x = max(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
-kprobe:f { @x = max((uint64)1); @x = max(-1); }
-                                     ~~~~~~~
+ERROR: Type mismatch for max: trying to call function with type 'int8' when it already has a type 'uint64'
 )" });
   test("kprobe:f { @x = avg((uint64)1); @x = avg(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
-kprobe:f { @x = avg((uint64)1); @x = avg(-1); }
-                                     ~~~~~~~
+ERROR: Type mismatch for avg: trying to call function with type 'int8' when it already has a type 'uint64'
 )" });
+  // One errror test to validate the source location
   test("kprobe:f { @x = stats((uint64)1); @x = stats(-1); }", Error{ R"(
-stdin:1:40-49: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already has a type 'uint64'
+ERROR: Type mismatch for stats: trying to call function with type 'int8' when it already has a type 'uint64'
 kprobe:f { @x = stats((uint64)1); @x = stats(-1); }
                                        ~~~~~~~~~
 )" });
@@ -3093,14 +3050,14 @@ TEST_F(TypeCheckerTest, mixed_int_map_access)
   test("kprobe:f { @x[-1] = 1; @x[(uint32)1] }");
 
   test("kprobe:f { @x[-1] = 1; @x[10223372036854775807] }", Error{ R"(
-stdin:1:27-47: ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int8'
+ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int8'
 kprobe:f { @x[-1] = 1; @x[10223372036854775807] }
-                          ~~~~~~~~~~~~~~~~~~~~
+                       ~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   test("kprobe:f { @x[(uint64)1] = 1; @x[-1] }", Error{ R"(
-stdin:1:34-35: ERROR: Argument mismatch for @x: trying to access with arguments: 'int8' when map expects arguments: 'uint64'
+ERROR: Argument mismatch for @x: trying to access with arguments: 'int8' when map expects arguments: 'uint64'
 kprobe:f { @x[(uint64)1] = 1; @x[-1] }
-                                 ~
+                              ~~~~~~
 )" });
   test("kretprobe:f { @x[-1] = 1; @x[(uint64)1] }", Error{ R"(
 ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int8'
@@ -3184,7 +3141,8 @@ TEST_F(TypeCheckerTest, mixed_int_like_binop)
                  Binop(Operator::EQ,
                        Cast(Typeof(SizedType(Type::integer)),
                             Cast(Typeof(SizedType(Type::integer)), Integer(1))),
-                       MapAccess(Map("@a"), Integer(0)))),
+                       Cast(Typeof(SizedType(Type::integer)),
+                            MapAccess(Map("@a"), Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
 }
 
@@ -4109,7 +4067,7 @@ fn f(): void { return 1; }
 )" });
   // Error location is incorrect: #3063
   test("fn f(): int64 { return; }", Error{ R"(
-stdin:1:17-23: ERROR: Function f is of type int64, cannot return void
+ERROR: Function f is of type int64, cannot return void
 fn f(): int64 { return; }
                 ~~~~~~
 )" });
@@ -4137,8 +4095,8 @@ TEST_F(TypeCheckerTest, subprog_map)
 TEST_F(TypeCheckerTest, subprog_builtin)
 {
   test("fn f(): void { print(\"Hello world\"); }");
-  test("fn f(): uint8 { return sizeof(int64); }");
   test("fn f(): uint64 { return nsecs; }");
+  test("fn f(): uint8 { return (uint64)2; }", Error{});
 }
 
 TEST_F(TypeCheckerTest, subprog_builtin_disallowed)
@@ -4596,9 +4554,7 @@ begin { for ($i : 0.."str") { printf("%d", $i); } }
 )" });
 
   test(R"(begin { for ($i : 0.0..5) { printf("%d", $i); } })", Error{ R"(
-stdin:1:19-25: ERROR: Loop range requires an integer for the start value
-begin { for ($i : 0.0..5) { printf("%d", $i); } }
-                  ~~~~~~
+ERROR: Could not resolve the type of this variable
 )" });
 }
 
@@ -4735,11 +4691,11 @@ TEST_F(TypeCheckerTest, variable_declarations)
   test("struct x { int a; }; begin { let $a: struct x; }");
   test("struct x { int a; }; begin { let $a: struct x *; }");
   test("struct x { int a; } begin { let $a: struct x[10]; }");
-  test("begin { if (pid) { let $x; } $x = 2; }");
-  test("begin { if (pid) { let $x; } else { let $x; } let $x; }");
+  test("begin { if (pid) { let $x = 1; } $x = 2; }");
+  test("begin { if (pid) { let $x = 1; } else { let $x = 1; } let $x = 1; }");
 
   test("begin { let $a: uint16; $a = -1; }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for $a: trying to assign value of type 'int32' when variable already has a type 'uint16'
+ERROR: Type mismatch for $a: trying to assign value of type 'int8' when variable already has a type 'uint16'
 begin { let $a: uint16; $a = -1; }
                         ~~~~~~~
 )" });
@@ -4757,19 +4713,13 @@ begin { let $a: int8 = 1; $a = -10000; }
 )" });
 
   test("begin { let $a: int8; $a = 10000; }", Error{ R"(
-stdin:1:23-33: ERROR: Type mismatch for $a: trying to assign value of type 'int32' when variable already has a type 'int8'
+ERROR: Type mismatch for $a: trying to assign value of type 'uint16' when variable already has a type 'int8'
 begin { let $a: int8; $a = 10000; }
                       ~~~~~~~~~~
 )" });
 
-  test("begin { $a = -1; let $a; }", Error{ R"(
-stdin:1:18-24: ERROR: Variable declarations need to occur before variable usage or assignment. Variable: $a
-begin { $a = -1; let $a; }
-                 ~~~~~~
-)" });
-
   test("begin { let $a: uint16 = -1; }", Error{ R"(
-stdin:1:9-28: ERROR: Type mismatch for $a: trying to assign value of type 'int32' when variable already has a type 'uint16'
+ERROR: Type mismatch for $a: trying to assign value of type 'int8' when variable already has a type 'uint16'
 begin { let $a: uint16 = -1; }
         ~~~~~~~~~~~~~~~~~~~
 )" });
@@ -4785,12 +4735,6 @@ stdin:1:17-32: ERROR: Cannot resolve unknown type "struct bad_task"
 begin { let $a: struct bad_task; print($a); }
                 ~~~~~~~~~~~~~~~
 )" });
-
-  test(R"(begin { $x = 2; if (pid) { let $x; } })", Error{ R"(
-stdin:1:28-34: ERROR: Variable declarations need to occur before variable usage or assignment. Variable: $x
-begin { $x = 2; if (pid) { let $x; } }
-                           ~~~~~~
-)" });
 }
 
 TEST_F(TypeCheckerTest, variable_address)
@@ -4805,9 +4749,9 @@ TEST_F(TypeCheckerTest, variable_address)
   ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy().IsIntTy());
 
   test("begin { let $a; $b = &$a; }", Error{ R"(
-stdin:1:22-25: ERROR: No type available for variable $a
+ERROR: Could not resolve the type of this variable
 begin { let $a; $b = &$a; }
-                     ~~~
+            ~~
 )" });
 }
 
@@ -4816,9 +4760,9 @@ TEST_F(TypeCheckerTest, map_address)
   test("begin { @a = 1; @b[1] = 2; $x = &@a; $y = &@b; }");
 
   test("begin { $x = &@a; }", Error{ R"(
-stdin:1:14-17: ERROR: Undefined map: @a
+ERROR: Undefined map: @a
 begin { $x = &@a; }
-             ~~~
+              ~~
 )" });
 }
 
@@ -5207,25 +5151,29 @@ TEST_F(TypeCheckerTest, typeof_decls)
   test(R"(kprobe:f { let $x: string[3] = "helloooooo"; })", Error{});
   test(R"(kprobe:f { let $x: string[3] = "hi"; $x = "helloooooo"; })", Error{});
   test(
-      R"(begin { @a["hi", 2] = 1; let $x: typeof(@a) = ("hello", (uint64)1); @a["hello", (int32)2] = 2; })",
+      R"(begin { @a["hi", 2] = 1; let $x: typeof(@a) = ("hello",
+        (uint64)1); @a["hello", (int32)2] = 2; })",
       Error{});
 
-  test(R"(kprobe:f { $a = (1, "hi"); let $x: typeof($a) = (1, "helllooo"); })",
+  test(R"(kprobe:f { $a = (1, "hi"); let $x: typeof($a) = (1, "helllooo");
+    })",
        Error{});
   test(
-      R"(kprobe:f { $a = (1, "hi"); let $x: typeof($a) = (2, "by"); $x = (1, "helllooo"); })",
+      R"(kprobe:f { $a = (1, "hi"); let $x: typeof($a) = (2, "by"); $x =
+        (1, "helllooo"); })",
       Error{});
-  test(R"(kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; })",
-       Error{ R"(
-stdin:1:48-58: ERROR: Type mismatch for $y: trying to assign value of type 'string[4]' when variable already has a type 'uint8'
+  test(
+      R"(kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; })",
+      Error{
+          R"(ERROR: Type mismatch for $y: trying to assign value of type 'string[4]' when variable already has a type 'uint8'
 kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; }
-                                               ~~~~~~~~~~
-)" });
-  test(R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; })", Error{ R"(
-stdin:1:45-51: ERROR: Type mismatch for $y: trying to assign value of type 'uint8' when variable already has a type 'string[4]'
+                                               ~~~~~~~~~~)" });
+  test(
+      R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; })",
+      Error{
+          R"(ERROR: Type mismatch for $y: trying to assign value of type 'uint8' when variable already has a type 'string[4]'
 kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; }
-                                            ~~~~~~
-)" });
+                                            ~~~~~~)" });
 
   // But ordering should not matter, as long as the scope is the same.
   test("kprobe:f { let $x; let $y : typeof($x); $y = 2; $x = (uint8)1; }");
@@ -5298,12 +5246,12 @@ TEST_F(TypeCheckerTest, comptime)
   test(R"(begin { @x = 1; comptime (typeinfo(@x)) })");
 
   test(R"(begin { $x = 0; comptime ($x + 1) })", Error{ R"(
-stdin:1:17-34: ERROR: Unable to resolve comptime expression.
+ERROR: Unable to resolve comptime expression
 begin { $x = 0; comptime ($x + 1) }
                 ~~~~~~~~~~~~~~~~~
 )" });
   test(R"(begin { @x = 0; comptime (@x + 1) })", Error{ R"(
-stdin:1:17-34: ERROR: Unable to resolve comptime expression.
+ERROR: Unable to resolve comptime expression
 begin { @x = 0; comptime (@x + 1) }
                 ~~~~~~~~~~~~~~~~~
 )" });
@@ -5341,16 +5289,6 @@ TEST_F(TypeCheckerTest, no_meta_used_warnings)
        NoWarning{ "Variable used" });
   test("begin { let $a; print(typeinfo($a)); $a = 1; }",
        NoWarning{ "Variable used" });
-}
-
-TEST_F(TypeCheckerTest, no_meta_map_assignments)
-{
-  test("begin { let $b : typeof({ @a = 1; 1 }); }", Error{});
-  test("begin { $b = typeinfo({ @a = 1; 1 }); }", Error{});
-  test("begin { print(sizeof({ @a = 1; 1 })); }", Error{});
-  test("struct Foo { int x; }  begin { let $a : struct Foo*; print(offsetof({ "
-       "@a =1; *$a}, x)); }",
-       Error{});
 }
 
 TEST_F(TypeCheckerTest, probe_return)

--- a/tests/type_resolver.cpp
+++ b/tests/type_resolver.cpp
@@ -1,0 +1,1138 @@
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "ast/ast.h"
+#include "ast/passes/builtins.h"
+#include "ast/passes/clang_parser.h"
+#include "ast/passes/collect_nodes.h"
+#include "ast/passes/fold_literals.h"
+#include "ast/passes/macro_expansion.h"
+#include "ast/passes/map_sugar.h"
+#include "ast/passes/named_param.h"
+#include "ast/passes/type_resolver.h"
+#include "ast/passes/type_system.h"
+#include "bpftrace.h"
+#include "driver.h"
+#include "mocks.h"
+
+namespace bpftrace::test::type_resolver {
+
+using ::testing::HasSubstr;
+
+// Lightweight type query helpers — look up resolved types on AST nodes by name,
+// avoiding the need for full AST structure matchers.
+::bpftrace::SizedType var_type(ast::ASTContext &ast, const std::string &name)
+{
+  ast::CollectNodes<ast::Variable> collector;
+  collector.visit(*ast.root,
+                  [&](const ast::Variable &v) { return v.ident == name; });
+  if (collector.nodes().empty()) {
+    ADD_FAILURE() << "No variable named " << name;
+    return CreateNone();
+  }
+  return collector.nodes().front().get().var_type;
+}
+
+::bpftrace::SizedType map_val_type(ast::ASTContext &ast,
+                                   const std::string &name)
+{
+  ast::CollectNodes<ast::Map> collector;
+  collector.visit(*ast.root,
+                  [&](const ast::Map &m) { return m.ident == name; });
+  if (collector.nodes().empty()) {
+    ADD_FAILURE() << "No map named " << name;
+    return CreateNone();
+  }
+  return collector.nodes().front().get().value_type;
+}
+
+::bpftrace::SizedType map_key_type(ast::ASTContext &ast,
+                                   const std::string &name)
+{
+  ast::CollectNodes<ast::Map> collector;
+  collector.visit(*ast.root,
+                  [&](const ast::Map &m) { return m.ident == name; });
+  if (collector.nodes().empty()) {
+    ADD_FAILURE() << "No map named " << name;
+    return CreateNone();
+  }
+  return collector.nodes().front().get().key_type;
+}
+
+struct Error {
+  std::string_view str;
+};
+
+std::string_view clean_prefix(std::string_view view)
+{
+  while (!view.empty() && view[0] == '\n')
+    view.remove_prefix(1); // Remove initial '\n'
+  return view;
+}
+
+class TypeResolverHarness {
+public:
+  ast::ASTContext test(std::string_view input,
+                       std::optional<Error> error = std::nullopt)
+  {
+    ast::ASTContext ast("stdin", std::string(clean_prefix(input)));
+
+    ast::TypeMetadata no_types; // No external types defined.
+    auto mock_bpftrace = get_mock_bpftrace();
+    BPFtrace &bpftrace = *mock_bpftrace;
+
+    auto ok = ast::PassManager()
+                  .put(ast)
+                  .put(bpftrace)
+                  .put(no_types)
+                  .add(CreateParsePass())
+                  .add(ast::CreateMacroExpansionPass())
+                  .add(ast::CreateClangParsePass())
+                  .add(ast::CreateFoldLiteralsPass())
+                  .add(ast::CreateBuiltinsPass())
+                  .add(ast::CreateMapSugarPass())
+                  .add(ast::CreateNamedParamsPass())
+                  .add(ast::CreateTypeResolverPass())
+                  .run();
+    EXPECT_TRUE(bool(ok));
+
+    std::stringstream out;
+    out.str("");
+    ast.diagnostics().emit(out, ast::Diagnostics::Severity::Error);
+    const auto errstr = out.str();
+    if (error) {
+      if (!error->str.empty()) {
+        EXPECT_THAT(errstr, HasSubstr(clean_prefix(error->str))) << errstr;
+      } else {
+        EXPECT_TRUE(!errstr.empty()) << errstr;
+      }
+    } else {
+      EXPECT_EQ(errstr, "") << errstr;
+    }
+    out.str("");
+
+    return ast;
+  }
+};
+
+class TypeResolverTest : public TypeResolverHarness, public testing::Test {};
+
+TEST_F(TypeResolverTest, variable_promotion_integers)
+{
+  {
+    auto ast = test(R"(begin { $a = 1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt8());
+  }
+  {
+    auto ast = test(R"(begin { $a = -1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt8());
+  }
+  {
+    auto ast = test(R"(begin { $a = 1; $a = (uint32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt32());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int8)1; $a = (uint8)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt16());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint32)1; $a = (int32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint32)1; $b = (int32)2; $a = $b; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { let $v; $a = $v; $v = 10; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt8());
+    EXPECT_EQ(var_type(ast, "$v"), CreateUInt8());
+  }
+
+  // Errors
+  test(R"(begin { $a = (uint64)1; $a = (int64)2 })", Error{});
+}
+
+TEST_F(TypeResolverTest, variable_promotion_strings)
+{
+  {
+    auto ast = test(R"(begin { $a = "str"; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateString(4));
+  }
+  {
+    auto ast = test(R"(begin { $a = "str"; $a = "longer" })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateString(7));
+  }
+  {
+    auto ast = test(R"(begin { $a = "str"; $b = "longer"; $a = $b; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateString(7));
+  }
+}
+
+TEST_F(TypeResolverTest, variable_promotion_tuples)
+{
+  {
+    auto ast = test(R"(begin { $a = (1, "str"); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt8(), CreateString(4) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = ((uint32)1, "str"); $a = (1, "longer"); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), CreateString(7) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = ((uint32)1, "str"); $a = (1, "longer"); $a = ((int64)1, "a"); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateInt64(), CreateString(7) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = ((uint32)1, ("str", (int16)2)); $a = (1, ("longer", (uint16)2)); })");
+    auto nested_tuple = CreateTuple(
+        Struct::CreateTuple({ CreateString(7), CreateInt32() }));
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_tuple })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = ((uint32)1, (x="str", y=(int16)2)); $a = (1, (x="longer", y=(uint16)2)); })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "x", "y" }));
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_record })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $b = ("str", (int16)2); $a = ((uint32)1, $b); $c = ("longer", (uint16)2); $a = (1, $c); })");
+    auto nested_tuple = CreateTuple(
+        Struct::CreateTuple({ CreateString(7), CreateInt32() }));
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_tuple })));
+    // Make sure the referenced variables don't change size
+    EXPECT_EQ(var_type(ast, "$b"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateString(4), CreateInt16() })));
+    EXPECT_EQ(var_type(ast, "$c"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateString(7), CreateUInt16() })));
+  }
+
+  // Errors
+  test(
+      R"(begin { $a = ((uint64)1, "str"); $a = (1, "longer"); $a = ((int64)1, "a"); })",
+      Error{});
+  test(
+      R"(begin { $a = (1, ("str", (uint64)2)); $a = (1, ("longer", (int64)2)); })",
+      Error{});
+}
+
+TEST_F(TypeResolverTest, variable_promotion_records)
+{
+  {
+    auto ast = test(R"(begin { $a = (x = 1, y = "str"); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt8(), CreateString(4) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = (x = (uint32)1, y = "str"); $a = (x = 1, y = "longer"); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = (x = (uint32)1, y = "str"); $a = (y = "longer", x = (int32)1); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = (x = (uint32)1, y = "str"); $a = (x = 1, y = "longer"); $a = (x = (int64)1, y = "a"); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = (x = (uint32)1, y = (s = "str", n = (int16)2)); $a = (x = 1, y = (s = "longer", n = (uint16)2)); })");
+    auto nested = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateRecord(Struct::CreateRecord({ CreateUInt32(), nested },
+                                                { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = (x = (uint32)1, y = ("str", (int16)2)); $a = (x = (int32)1, y = ("longer", (uint16)2)); })");
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(),
+                    CreateTuple(Struct::CreateTuple(
+                        { CreateString(7), CreateInt32() })) },
+                  { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $b = (s = "str", n = (int16)2); $a = (x = (uint32)1, y = $b); $c = (s = "longer", n = (uint16)2); $a = (x = 1, y = $c); })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(var_type(ast, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), nested_record }, { "x", "y" })));
+    // Make sure the referenced variables don't change size
+    EXPECT_EQ(var_type(ast, "$b"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(4), CreateInt16() }, { "s", "n" })));
+    EXPECT_EQ(var_type(ast, "$c"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(7), CreateUInt16() }, { "s", "n" })));
+  }
+
+  // Errors
+  test(
+      R"(begin { $a = (x = (uint64)1, y = "str"); $a = (x = 1, y = "longer"); $a = (x = (int64)1, y = "a"); })",
+      Error{});
+  test(
+      R"(begin { $a = (x = 1, y = (s = "str", n = (uint64)2)); $a = (x = 1, y = (s = "longer", n = (int64)2)); })",
+      Error{});
+}
+
+TEST_F(TypeResolverTest, variable_castable_maps)
+{
+  {
+    auto ast = test(R"(begin { @a = sum(1); $a = @a; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { @a = sum(-1); $a = @a; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { @a = sum(1); @a = sum(-1); $a = @a; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { @a = sum(-1); $a = (int16)2; $a = @a; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+
+  // Errors
+  test(R"(begin { @a = sum(1); $a = (int64)1; $a = @a; })", Error{});
+}
+
+TEST_F(TypeResolverTest, map_value_promotion_integers)
+{
+  {
+    auto ast = test(R"(begin { @a = 1; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateUInt8());
+  }
+  {
+    auto ast = test(R"(begin { @a = -1; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateInt8());
+  }
+  {
+    auto ast = test(R"(begin { @a = 1; @a = (uint32)2; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateUInt32());
+  }
+  {
+    auto ast = test(R"(begin { @a = (int8)1; @a = (uint8)2; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateInt16());
+  }
+  {
+    auto ast = test(R"(begin { @a = (uint32)1; @a = (int32)2; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { @a = (uint32)1; $b = (int32)2; @a = $b; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { let $v; @a = $v; $v = 10; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateUInt8());
+    EXPECT_EQ(var_type(ast, "$v"), CreateUInt8());
+  }
+
+  // Errors
+  test(R"(begin { @a = (uint64)1; @a = (int64)2 })", Error{});
+}
+
+TEST_F(TypeResolverTest, map_value_promotion_strings)
+{
+  {
+    auto ast = test(R"(begin { @a = "str"; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateString(4));
+  }
+  {
+    auto ast = test(R"(begin { @a = "str"; @a = "longer" })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateString(7));
+  }
+  {
+    auto ast = test(R"(begin { @a = "str"; $b = "longer"; @a = $b; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateString(7));
+  }
+}
+
+TEST_F(TypeResolverTest, map_value_promotion_tuples)
+{
+  {
+    auto ast = test(R"(begin { @a = (1, "str"); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt8(), CreateString(4) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = ((uint32)1, "str"); @a = (1, "longer"); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), CreateString(7) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = ((uint32)1, "str"); @a = (1, "longer"); @a = ((int64)1, "a"); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateInt64(), CreateString(7) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = ((uint32)1, ("str", (int16)2)); @a = (1, ("longer", (uint16)2)); })");
+    auto nested_tuple = CreateTuple(
+        Struct::CreateTuple({ CreateString(7), CreateInt32() }));
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_tuple })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = ((uint32)1, (x="str", y=(int16)2)); @a = (1, (x="longer", y=(uint16)2)); })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "x", "y" }));
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_record })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $b = ("str", (int16)2); @a = ((uint32)1, $b); $c = ("longer", (uint16)2); @a = (1, $c); })");
+    auto nested_tuple = CreateTuple(
+        Struct::CreateTuple({ CreateString(7), CreateInt32() }));
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_tuple })));
+    // Make sure the referenced variables don't change size
+    EXPECT_EQ(var_type(ast, "$b"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateString(4), CreateInt16() })));
+    EXPECT_EQ(var_type(ast, "$c"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateString(7), CreateUInt16() })));
+  }
+
+  // Errors
+  test(
+      R"(begin { @a = ((uint64)1, "str"); @a = (1, "longer"); @a = ((int64)1, "a"); })",
+      Error{});
+  test(
+      R"(begin { @a = (1, ("str", (uint64)2)); @a = (1, ("longer", (int64)2)); })",
+      Error{});
+}
+
+TEST_F(TypeResolverTest, map_value_promotion_records)
+{
+  {
+    auto ast = test(R"(begin { @a = (x = 1, y = "str"); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt8(), CreateString(4) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = (x = (uint32)1, y = "str"); @a = (x = 1, y = "longer"); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = (x = (uint32)1, y = "str"); @a = (y = "longer", x = (int32)1); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = (x = (uint32)1, y = "str"); @a = (x = 1, y = "longer"); @a = (x = (int64)1, y = "a"); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = (x = (uint32)1, y = (s = "str", n = (int16)2)); @a = (x = 1, y = (s = "longer", n = (uint16)2)); })");
+    auto nested = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord({ CreateUInt32(), nested },
+                                                { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a = (x = (uint32)1, y = ("str", (int16)2)); @a = (x = (int32)1, y = ("longer", (uint16)2)); })");
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(),
+                    CreateTuple(Struct::CreateTuple(
+                        { CreateString(7), CreateInt32() })) },
+                  { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $b = (s = "str", n = (int16)2); @a = (x = (uint32)1, y = $b); $c = (s = "longer", n = (uint16)2); @a = (x = 1, y = $c); })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), nested_record }, { "x", "y" })));
+    // Make sure the referenced variables don't change size
+    EXPECT_EQ(var_type(ast, "$b"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(4), CreateInt16() }, { "s", "n" })));
+    EXPECT_EQ(var_type(ast, "$c"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(7), CreateUInt16() }, { "s", "n" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @b = (s = "str", n = (int16)2); @a = (x = (uint32)1, y = @b); @c = (s = "longer", n = (uint16)2); @a = (x = 1, y = @c); })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(map_val_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), nested_record }, { "x", "y" })));
+    // Make sure the referenced map values don't change size
+    EXPECT_EQ(map_val_type(ast, "@b"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(4), CreateInt16() }, { "s", "n" })));
+    EXPECT_EQ(map_val_type(ast, "@c"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(7), CreateUInt16() }, { "s", "n" })));
+  }
+
+  // Errors
+  test(
+      R"(begin { @a = (x = (uint64)1, y = "str"); @a = (x = 1, y = "longer"); @a = (x = (int64)1, y = "a"); })",
+      Error{});
+  test(
+      R"(begin { @a = (x = 1, y = (s = "str", n = (uint64)2)); @a = (x = 1, y = (s = "longer", n = (int64)2)); })",
+      Error{});
+}
+
+TEST_F(TypeResolverTest, map_value_castable_maps)
+{
+  {
+    auto ast = test(R"(begin { @a = sum(1); })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateSum(false));
+  }
+  {
+    auto ast = test(R"(begin { @a = sum(-1); })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateSum(true));
+  }
+  {
+    auto ast = test(R"(begin { @a = sum(1); @a = sum(-1); })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateSum(true));
+  }
+
+  // Errors
+  test(R"(begin { @a = sum(1); @a = avg(-1); })", Error{});
+  test(R"(begin { @a = sum(1); @a = 1; })", Error{});
+  test(R"(begin { @a = sum((uint64)1); @a = sum((int64)-1); })", Error{});
+}
+
+TEST_F(TypeResolverTest, map_key_promotion_integers)
+{
+  {
+    auto ast = test(R"(begin { @a[1] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateUInt8());
+  }
+  {
+    auto ast = test(R"(begin { @a[-1] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateInt8());
+  }
+  {
+    auto ast = test(R"(begin { @a[1] = 1; @a[(uint32)2] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateUInt32());
+  }
+  {
+    auto ast = test(R"(begin { @a[(int8)1] = 1; @a[(uint8)2] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateInt16());
+  }
+  {
+    auto ast = test(R"(begin { @a[(uint32)1] = 1; @a[(int32)2] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[(uint32)1] = 1; $b = (int32)2; @a[$b] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateInt64());
+  }
+
+  // Errors
+  test(R"(begin { @a[(uint64)1] = 1; @a[(int64)2] = 1 })", Error{});
+}
+
+TEST_F(TypeResolverTest, map_key_promotion_strings)
+{
+  {
+    auto ast = test(R"(begin { @a["str"] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateString(4));
+  }
+  {
+    auto ast = test(R"(begin { @a["str"] = 1; @a["longer"] = 1 })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateString(7));
+  }
+  {
+    auto ast = test(R"(begin { @a["str"] = 1; $b = "longer"; @a[$b] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"), CreateString(7));
+  }
+}
+
+TEST_F(TypeResolverTest, map_key_promotion_tuples)
+{
+  {
+    auto ast = test(R"(begin { @a[(1, "str")] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt8(), CreateString(4) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[((uint32)1, "str")] = 1; @a[(1, "longer")] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), CreateString(7) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[((uint32)1, "str")] = 1; @a[(1, "longer")] = 1; @a[((int64)1, "a")] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateInt64(), CreateString(7) })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[((uint32)1, ("str", (int16)2))] = 1; @a[(1, ("longer", (uint16)2))] = 1; })");
+    auto nested_tuple = CreateTuple(
+        Struct::CreateTuple({ CreateString(7), CreateInt32() }));
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_tuple })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[((uint32)1, (x="str", y=(int16)2))] = 1; @a[(1, (x="longer", y=(uint16)2))] = 1; })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "x", "y" }));
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_record })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $b = ("str", (int16)2); @a[((uint32)1, $b)] = 1; $c = ("longer", (uint16)2); @a[(1, $c)] = 1; })");
+    auto nested_tuple = CreateTuple(
+        Struct::CreateTuple({ CreateString(7), CreateInt32() }));
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_tuple })));
+    // Make sure the referenced variables don't change size
+    EXPECT_EQ(var_type(ast, "$b"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateString(4), CreateInt16() })));
+    EXPECT_EQ(var_type(ast, "$c"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateString(7), CreateUInt16() })));
+  }
+
+  // Errors
+  test(
+      R"(begin { @a[((uint64)1, "str")] = 1; @a[(1, "longer")] = 1; @a[((int64)1, "a")] = 1; })",
+      Error{});
+  test(
+      R"(begin { @a[(1, ("str", (uint64)2))] = 1; @a[(1, ("longer", (int64)2))] = 1; })",
+      Error{});
+}
+
+TEST_F(TypeResolverTest, map_key_promotion_records)
+{
+  {
+    auto ast = test(R"(begin { @a[(x = 1, y = "str")] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt8(), CreateString(4) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[(x = (uint32)1, y = "str")] = 1; @a[(x = 1, y = "longer")] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[(x = (uint32)1, y = "str")] = 1; @a[(y = "longer", x = (int32)1)] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[(x = (uint32)1, y = "str")] = 1; @a[(x = 1, y = "longer")] = 1; @a[(x = (int64)1, y = "a")] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[(x = (uint32)1, y = (s = "str", n = (int16)2))] = 1; @a[(x = 1, y = (s = "longer", n = (uint16)2))] = 1; })");
+    auto nested = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord({ CreateUInt32(), nested },
+                                                { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @a[(x = (uint32)1, y = ("str", (int16)2))] = 1; @a[(x = (int32)1, y = ("longer", (uint16)2))] = 1; })");
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(),
+                    CreateTuple(Struct::CreateTuple(
+                        { CreateString(7), CreateInt32() })) },
+                  { "x", "y" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { $b = (s = "str", n = (int16)2); @a[(x = (uint32)1, y = $b)] = 1; $c = (s = "longer", n = (uint16)2); @a[(x = 1, y = $c)] = 1; })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), nested_record }, { "x", "y" })));
+    // Make sure the referenced variables don't change size
+    EXPECT_EQ(var_type(ast, "$b"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(4), CreateInt16() }, { "s", "n" })));
+    EXPECT_EQ(var_type(ast, "$c"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(7), CreateUInt16() }, { "s", "n" })));
+  }
+  {
+    auto ast = test(
+        R"(begin { @b = (s = "str", n = (int16)2); @a[(x = (uint32)1, y = @b)] = 1; @c = (s = "longer", n = (uint16)2); @a[(x = 1, y = @c)] = 1; })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "s", "n" }));
+    EXPECT_EQ(map_key_type(ast, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateUInt32(), nested_record }, { "x", "y" })));
+    // Make sure the referenced map values don't change size
+    EXPECT_EQ(map_val_type(ast, "@b"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(4), CreateInt16() }, { "s", "n" })));
+    EXPECT_EQ(map_val_type(ast, "@c"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateString(7), CreateUInt16() }, { "s", "n" })));
+  }
+
+  // Errors
+  test(
+      R"(begin { @a[(x = (uint64)1, y = "str")] = 1; @a[(x = 1, y = "longer")] = 1; @a[(x = (int64)1, y = "a")] = 1; })",
+      Error{});
+  test(
+      R"(begin { @a[(x = 1, y = (s = "str", n = (uint64)2))] = 1; @a[(x = 1, y = (s = "longer", n = (int64)2))] = 1; })",
+      Error{});
+}
+
+TEST_F(TypeResolverTest, variable_no_type)
+{
+  test(R"(begin { let $z; $a = 1; $b = typeinfo($z); })", Error{ R"(
+ERROR: Could not resolve the type of this variable
+begin { let $z; $a = 1; $b = typeinfo($z); }
+            ~~
+stdin:1:25-27: ERROR: Could not resolve the type of this variable
+begin { let $z; $a = 1; $b = typeinfo($z); }
+                        ~~
+stdin:1:39-41: ERROR: Could not resolve the type of this variable
+begin { let $z; $a = 1; $b = typeinfo($z); }
+                                      ~~
+)" });
+
+  test(R"(begin { let $a; let $b; $b = $a; $a = $b; })", Error{});
+}
+
+TEST_F(TypeResolverTest, variable_with_type_decl)
+{
+  {
+    auto ast = test(R"(begin { let $a: uint32 = 1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt32());
+  }
+  {
+    auto ast = test(
+        R"(begin { let $b; let $a: typeof($b) = (uint64)1; $b = (uint32)2; $b = (uint64)3; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+    EXPECT_EQ(var_type(ast, "$b"), CreateUInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { let $b; let $a: typeof($b) = (uint16)1; $b = (uint32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt32());
+    EXPECT_EQ(var_type(ast, "$b"), CreateUInt32());
+  }
+}
+
+TEST_F(TypeResolverTest, variable_map_promotion)
+{
+  {
+    auto ast = test(
+        R"(begin { $a = 1; @x = (uint32)1; $a = @x; @y = $a; } end { @x = (uint64)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+    EXPECT_EQ(map_val_type(ast, "@x"), CreateUInt64());
+    EXPECT_EQ(map_val_type(ast, "@y"), CreateUInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { $a = 1; @x = (uint32)1; if comptime (typeinfo(@x).full_type == "uint64") { $a = (int16)2; } } end { @x = (uint64)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt16());
+    EXPECT_EQ(map_val_type(ast, "@x"), CreateUInt64());
+  }
+}
+
+TEST_F(TypeResolverTest, typeof)
+{
+  {
+    auto ast = test(R"(begin { $a = (typeof(uint64))1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { let $b; $a = (typeof($b))1; $b = 1; $b = (uint64)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+    EXPECT_EQ(var_type(ast, "$b"), CreateUInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { let $b; let $c; $a = (typeof($b))1; $b = (typeof($c))1; $c = (int64)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+    EXPECT_EQ(var_type(ast, "$b"), CreateInt64());
+    EXPECT_EQ(var_type(ast, "$c"), CreateInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { @x = 2; $a = (typeof(@x))1; } end { @x = (int32)1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt32());
+    EXPECT_EQ(map_val_type(ast, "@x"), CreateInt32());
+  }
+  {
+    auto ast = test(R"(begin { @x[(int16)1] = 1; $a = (typeof(@x))1; })");
+    EXPECT_EQ(map_key_type(ast, "@x"), CreateInt16());
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt16());
+  }
+  {
+    auto ast = test(
+        R"(begin { @x[(int16)1] = 1; $a = (typeof({ print(1); @x[0] }))1; })");
+    EXPECT_EQ(map_val_type(ast, "@x"), CreateUInt8());
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt8());
+  }
+}
+
+TEST_F(TypeResolverTest, comptime)
+{
+  {
+    auto ast = test(
+        R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { $c = (int64)2; } $a = (uint64)2; })");
+    EXPECT_EQ(var_type(ast, "$c"), CreateInt64());
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { let $c; $a = 1; if comptime (typeinfo(sizeof($a)).base_type == "int") { $c = (int64)2; } $a = (uint64)2; })");
+    EXPECT_EQ(var_type(ast, "$c"), CreateInt64());
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { let $d; if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $d = (int64)2; } $a = (uint64)2; })");
+    EXPECT_EQ(var_type(ast, "$c"), CreateInt16());
+  }
+  {
+    auto ast = test(
+        R"(begin { let $c; let $e; let $d; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $e = (int32)1; } $a = (uint64)2; if comptime (typeinfo($e).full_type == "int32") { $d = (int64)3; } })");
+    EXPECT_EQ(var_type(ast, "$c"), CreateInt16());
+  }
+  {
+    auto ast = test(
+        R"(begin { @x = 1; if comptime (typeinfo(@y[1]).full_type == "uint64") { @x = (int32)2; } } end { @y[1] = (uint64)2; })");
+    EXPECT_EQ(map_val_type(ast, "@x"), CreateInt32());
+    EXPECT_EQ(map_val_type(ast, "@y"), CreateUInt64());
+  }
+  {
+    auto ast = test(
+        R"(begin { @x = 1; if comptime (typeinfo(@y[1]).full_type != "uint64") { @x = (int32)2; } } end { @y[1] = (uint64)2; })");
+    EXPECT_EQ(map_val_type(ast, "@x"), CreateUInt8());
+    EXPECT_EQ(map_val_type(ast, "@y"), CreateUInt64());
+  }
+
+  // Errors
+  test(
+      R"(begin { let $c; if comptime (typeinfo($c).base_type == "int") { 1 } })",
+      Error{ R"(
+ERROR: Unable to resolve comptime expression
+begin { let $c; if comptime (typeinfo($c).base_type == "int") { 1 } }
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)" });
+
+  test(
+      R"(begin { let $c; if comptime (typeinfo({ let $x = $c; $x }).full_type == "uint32") { $c = (uint64)2; } $c = (uint32)1; })",
+      Error{});
+}
+
+TEST_F(TypeResolverTest, locked_types)
+{
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = 2; } @a = (uint32)1; })");
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[2] = 2; } @a[(uint32)1] = 1; })");
+  test(
+      R"(begin { let $c; if comptime (typeinfo($c).full_type == "uint32") { $c = (uint16)2; } $c = (uint32)1; })");
+
+  // Errors
+  test(
+      R"(begin { let $c; if comptime (typeinfo($c).full_type == "uint32") { $c = (uint64)2; } $c = (uint32)1; })",
+      Error{});
+
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = (uint64)2; } @a = (uint32)1; })",
+      Error{});
+
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[(uint64)2] = 2; } @a[(uint32)1] = 1; })",
+      Error{ R"(
+ERROR: Type mismatch for @a: this type has been locked because it was used in another part of the type graph that was already resolved (e.g. `sizeof`, `typeinfo`, etc.). The new type 'uint64' doesn't fit into the locked type 'uint32'
+begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[(uint64)2] = 2; } @a[(uint32)1] = 1; }
+                                                           ~~~~~~~~~~~~~
+)" });
+
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { $a = 1; if comptime (typeinfo($a).full_type == "uint8") { @a[(uint64)2] = 2; } } @a[(uint32)1] = 1; })",
+      Error{ R"(
+ERROR: Type mismatch for @a: this type has been locked because it was used in another part of the type graph that was already resolved (e.g. `sizeof`, `typeinfo`, etc.). The new type 'uint64' doesn't fit into the locked type 'uint32'
+begin { if comptime (typeinfo(@a).full_type == "uint32") { $a = 1; if comptime (typeinfo($a).full_type == "uint8") { @a[(uint64)2] = 2; } } @a[(uint32)1] = 1; }
+                                                                                                                     ~~~~~~~~~~~~~
+)" });
+}
+
+TEST_F(TypeResolverTest, unop)
+{
+  {
+    auto ast = test(R"(begin { @a = (int16)2; ++@a; })");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { @a = 0; ++@a; $b = @a; })");
+    EXPECT_EQ(var_type(ast, "$b"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { ++@a; $b = @a; })");
+    EXPECT_EQ(var_type(ast, "$b"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { @a = (int64)0; ++@a; $b = @a; })");
+    EXPECT_EQ(var_type(ast, "$b"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = 1; $c = ++$a; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+    EXPECT_EQ(var_type(ast, "$c"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { let $a: int16; $c = ++$a; $b = $a; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt16());
+    EXPECT_EQ(var_type(ast, "$c"), CreateInt16());
+    EXPECT_EQ(var_type(ast, "$b"), CreateInt16());
+  }
+  {
+    auto ast = test(R"(begin { $a = 1; $b = &$a; $c = *$b; $a = (uint32)2; })");
+    EXPECT_EQ(var_type(ast, "$c"), CreateUInt32());
+  }
+
+  // Errors
+  test(R"(begin { ++$a; })", Error{});
+  test(R"(begin { ++@a; @a = "hello"; })", Error{});
+  test(R"(begin { ++$a; $a = "hello"; })", Error{});
+}
+
+TEST_F(TypeResolverTest, binop)
+{
+  {
+    auto ast = test(R"(begin { $a = (uint32)1 + (uint32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int32)1 + (int32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint32)1 + (int32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int8)1 * 2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = ((uint32)1 == (uint32)2); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+  {
+    auto ast = test(R"(begin { $a = ((int32)1 < (int32)2); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+  {
+    auto ast = test(R"(begin { $a = ((uint32)1 != (int32)2); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+  {
+    auto ast = test(R"(begin { $a = (1 && 2); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+  {
+    auto ast = test(R"(begin { $a = (1 || 0); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+  {
+    auto ast = test(R"(begin { $x = (1 == 2); $a = $x + $x; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint16)1 & (uint16)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint16)1 | (uint16)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint16)1 ^ (uint16)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int16)1 & (int16)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint32)1 << (int32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int32)1 << (uint32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int32)1 >> (uint32)2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = 3; $a = (int8)1 + 2; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
+  }
+  {
+    auto ast = test(R"(begin { $pv = 1; $p = &$pv; $a = $p + 1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreatePointer(CreateUInt8()));
+  }
+  {
+    auto ast = test(R"(begin { $pv = 1; $p = &$pv; $a = $p - 1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreatePointer(CreateUInt8()));
+  }
+  {
+    auto ast = test(
+        R"(begin { $pv = 1; $p = &$pv; $qv = 1; $q = &$qv; $a = ($p == $q); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+  {
+    auto ast = test(
+        R"(begin { $pv = 1; $p = &$pv; $qv = 1; $q = &$qv; $a = ($p != $q); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateBool());
+  }
+
+  // Errors
+  test(R"(begin { $pv = 1; $p = &$pv; $a = 1 - $p; })", Error{});
+  test(R"(begin { $pv = 1; $p = &$pv; $qv = 1; $q = &$qv; $a = $p * $q; })",
+       Error{});
+}
+
+TEST_F(TypeResolverTest, cast)
+{
+  {
+    auto ast = test(
+        R"(begin { $a = (uint8)1; $b = (int8)1; $c = (int32)1; $d = (uint64)1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt8());
+    EXPECT_EQ(var_type(ast, "$b"), CreateInt8());
+    EXPECT_EQ(var_type(ast, "$c"), CreateInt32());
+    EXPECT_EQ(var_type(ast, "$d"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int32)-1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt32());
+  }
+  {
+    auto ast = test(R"(begin { $a = (uint64)-1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int8)(uint64)1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt8());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int32)1; $b = $a; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateInt32());
+    EXPECT_EQ(var_type(ast, "$b"), CreateInt32());
+  }
+  {
+    auto ast = test(R"(begin { $a = (int8[])1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateArray(1, CreateInt8()));
+  }
+  {
+    auto ast = test("begin { $a = (int8[])\"hello\"; }");
+    EXPECT_EQ(var_type(ast, "$a"), CreateArray(6, CreateInt8()));
+  }
+  {
+    auto ast = test(R"(begin { $a = (int8[8])1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateArray(8, CreateInt8()));
+  }
+  {
+    auto ast = test(R"(begin { $a = (int8[2])(int16)1; })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateArray(2, CreateInt8()));
+  }
+  {
+    auto ast = test("begin { $a = (int8[6])\"hello\"; }");
+    EXPECT_EQ(var_type(ast, "$a"), CreateArray(6, CreateInt8()));
+  }
+  {
+    auto ast = test("begin { @a = (int8[])\"hello\"; }");
+    EXPECT_EQ(map_val_type(ast, "@a"), CreateArray(6, CreateInt8()));
+  }
+}
+
+} // namespace bpftrace::test::type_resolver


### PR DESCRIPTION
Stacked PRs:
 * __->__#5007


--- --- ---

### Refactor TypeResolver pass


This replaces the current type_resolver with an entirely new architecture
for resolving types. It utilizes a constraint solver pattern for resolving
types in a graph.

More details on how all this works in the added readme:
docs/type_resolution.md

There are a few minor things to note:
- For maps where we can't infer the type, presume they are Int64. This is
  for cases where scripts have just `@a++` or `@a += 1` and no other assignment.
  It also means this is ok and prints `0`: `begin { $a = @a; print($a); }`.
- No longer preserve the original ordering of a variable, map key/value, if
  it's a record type. This was probably not working completely in trunk
  anyway but is more visible with how the TypeGraph resolves types.

This fixes this issue:
- https://github.com/bpftrace/bpftrace/issues/4926

There will be follow-up refactoring for both TypeChecker and it's suite of
unit tests. TypeChecker will be moved as another visitor inside of
CreateTypeResolverPass but it left out of this PR for simplicity and
verification that the end behavior hasn't changed.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>