### PR TITLE
Switch is-traceable checks from ftrace to kallsyms

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -109,13 +109,6 @@ bool BPFfeature::try_load(enum bpf_prog_type prog_type,
     btf_id = btf_.get_btf_id(name, "vmlinux");
   }
 
-  if (prog_type == BPF_PROG_TYPE_TRACING) {
-    // List of available functions must be readable
-    std::ifstream traceable_funcs(tracefs::available_filter_functions());
-    if (!traceable_funcs.good())
-      return false;
-  }
-
   return try_load_(name,
                    prog_type,
                    attach_type,

--- a/src/symbols/kernel.h
+++ b/src/symbols/kernel.h
@@ -129,8 +129,8 @@ private:
   void populate_lazy(const std::optional<std::string> &mod_name = std::nullopt) const;
   ModulesFuncsMap filter_funcs(const ModulesFuncsMap &source, const std::optional<std::string> &mod_name = std::nullopt) const;
 
-  mutable std::ifstream available_filter_functions_;
-  mutable std::string last_checked_line_;
+  mutable std::ifstream kallsyms_;
+  mutable std::optional<std::pair<std::string, std::string>> last_func_mod_;
 
   ModuleSet modules_loaded_;
   ModulesFuncsMap tracepoints_;

--- a/src/tracefs/tracefs.h
+++ b/src/tracefs/tracefs.h
@@ -18,11 +18,6 @@ inline std::string events()
   return path("events");
 }
 
-inline std::string available_filter_functions()
-{
-  return path("available_filter_functions");
-}
-
 std::string event_format_file(const std::string &category,
                               const std::string &event);
 

--- a/src/util/symbols.h
+++ b/src/util/symbols.h
@@ -70,4 +70,6 @@ std::pair<std::string, std::string> split_symbol_module(
 std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
     const std::string &symbol);
 
+bool kallsyms_is_function_type(char sym_type);
+
 } // namespace bpftrace::util


### PR DESCRIPTION
We currently rely on `available_filter_functions`, which depends on dynamic ftrace, to determine if a function can be traced. This approach has several drawbacks:

- It assumes that kprobes can only be installed in functions supported by ftrace, which isn't always the case. For example, Android common kernels don't enable function_tracer at all, but support kprobes. Furthermore, kernels compiled with `CONFIG_KPROBE_EVENTS_ON_NOTRACE` can probe functions not listed in `available_filter_functions` [1].
- It's slow: for each traceable function the kernel calls `kallsyms_lookup()`, which for modules involves a linear search over the symtab [2]. This affects systems with large modules.

To prevent bpftrace from incorrectly rejecting some kprobes and to avoid the hard dependency on dynamic ftrace (which isn't typically enabled on Android), only check if the function exists and let the kernel determine whether it can be probed.

The list of traceable kernel functions is still necessary for wildcard probes and to determine which modules to load BTF data for, so get it from `kallsyms` instead. The downside is that `bpftrace -l` now includes some functions that cannot be probed.

The following test was run on an Android device with a custom kernel compiled with both dynamic ftrace and kprobe-on-notrace config flags set:

```
  # time ./bpftrace.old -e 'kprobe:__schedule {} BEGIN { exit() }'
  stdin:1:1-18: ERROR: No matches for kprobe __schedule.
      0m05.56s real     0m00.18s user     0m04.72s system
  # time ./bpftrace.new -e 'kprobe:__schedule {} BEGIN { exit() }'
  Attached 2 probes
      0m01.88s real     0m00.80s user     0m00.77s system
```

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/trace/trace_kprobe.c?h=v6.12.73#n441
[2] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/module/kallsyms.c?h=v6.12.73#n280

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
