### PR TITLE
Implement --probe-filter CLI flag #4365

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
 - `BPFTRACE_DEBUG_OUTPUT` is removed, and errors are now propagated via the runtime error path
   - [#4976](https://github.com/bpftrace/bpftrace/pull/4976)
 #### Added
+- Add `--probe-filter` CLI flag to selectively run probes matching a regex
+  - [#5011](https://github.com/bpftrace/bpftrace/pull/5011)
 - Add `comm()` support for PID parameters.
   - [#4799](https://github.com/bpftrace/bpftrace/pull/4799)
 - Add `syscall_name()` to convert system call numbers into names.

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -152,6 +152,13 @@ Disable use of detected features, valid values are::
 
 Suppress all warning messages created by bpftrace.
 
+=== *--probe-filter* _REGEX_
+
+Only attach and run probes whose name matches the regular expression _REGEX_.
+Probes that do not match are not loaded into the kernel.
+Special probes (`BEGIN` and `END`) are not affected by this filter.
+If no probes match, bpftrace exits with an error.
+
 === *-o* _FILENAME_
 
 Write bpftrace tracing output to _FILENAME_ instead of stdout.

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -119,6 +119,11 @@ void BpfProgram::set_no_autoattach()
   bpf_program__set_autoattach(bpf_prog_, false);
 }
 
+void BpfProgram::set_no_autoload()
+{
+  bpf_program__set_autoload(bpf_prog_, false);
+}
+
 struct bpf_program *BpfProgram::bpf_prog() const
 {
   return bpf_prog_;

--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -25,6 +25,7 @@ public:
                          const BTF &btf,
                          const Config &config);
   void set_no_autoattach();
+  void set_no_autoload();
 
   int fd() const;
   struct bpf_program *bpf_prog() const;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -225,6 +225,7 @@ public:
   std::unique_ptr<Config> config_;
   bool run_tests_ = false;
   bool run_benchmarks_ = false;
+  std::string probe_filter_;
 
 private:
   Ksyms ksyms_;

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@ These are `test:` probes written to test core functionality, and standard librar
 
 * Run: `sudo <builddir>/tests/self-tests.sh`
 * To debug a test, you can run an individual file directly, e.g. `<builddir>src/bpftrace --test <builddir>/tests/<testfile>`
+* To run only specific self tests, use `--probe-filter REGEX` to select tests by name, e.g. `<builddir>src/bpftrace --test --probe-filter 'map_' <builddir>/tests/<testfile>`
 
 ## Runtime tests
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -645,3 +645,35 @@ RUN {{BPFTRACE}} runtime/scripts/bpf_attach.bt & sleep 3 && {{BPFTRACE}} -e 'fen
 EXPECT_REGEX fentry:bpf:[0-9]+:interval_us_100000_1
 EXPECT_REGEX fentry:bpf:[0-9]+:interval_us_100000_2
 TIMEOUT 10
+
+NAME probe_filter matches specific probe
+RUN {{BPFTRACE}} --probe-filter ':200' -e 'interval:ms:100 { printf("bad\n"); exit(); } interval:ms:200 { printf("hit\n"); exit(); }'
+EXPECT hit
+EXPECT_NONE bad
+TIMEOUT 5
+
+NAME probe_filter no match will fail
+RUN {{BPFTRACE}} --probe-filter 'nonexistent_probe_xyz_42' -e 'kprobe:vfs_read { exit(); }'
+EXPECT No probes to attach
+TIMEOUT 5
+WILL_FAIL
+
+NAME probe_filter preserves begin end
+RUN {{BPFTRACE}} --probe-filter ':200' -e 'BEGIN { printf("begin\n"); } interval:ms:200 { printf("hit\n"); exit(); } END { printf("end\n"); }'
+EXPECT begin
+EXPECT hit
+EXPECT end
+TIMEOUT 5
+
+NAME probe_filter matches multiple probes
+RUN {{BPFTRACE}} --probe-filter 'interval:ms:(200|300)' -e 'interval:ms:100 { printf("bad\n"); exit(); } interval:ms:200 { printf("a\n"); } interval:ms:300 { printf("b\n"); exit(); }'
+EXPECT a
+EXPECT b
+EXPECT_NONE bad
+TIMEOUT 5
+
+NAME probe_filter invalid regex
+RUN {{BPFTRACE}} --probe-filter '[invalid' -e 'kprobe:vfs_read { exit(); }'
+EXPECT_REGEX Invalid --probe-filter regex
+TIMEOUT 5
+WILL_FAIL


### PR DESCRIPTION
This PR implements a `--probe-filter` CLI flag that accepts a regex as a parameter and filters out probes whose names do not match the regex. This is to address issue #4365.

When `--probe-filter REGEX` is specified, we compile the regex and remove any probe from the active probe lists. For each filtered-out probe, the corresponding BPF program is marked with `set_no_autoload()`. This filtering happens early in `BPFtrace::run()`, before `prerun()` and program loading. Special probes like BEGIN and END are unaffected since they live outside the filtered probe lists.


##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
