### PR TITLE
ci: stdlib: monitor stdlib.md file changes

### DIFF
--- a/.github/workflows/stdlib-docs.yml
+++ b/.github/workflows/stdlib-docs.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "src/stdlib/**/*.bt"
       - "scripts/generate_stdlib_docs.py"
+      - "docs/stdlib.md"
 
 # Cancel previous run if a new one is started
 concurrency:


### PR DESCRIPTION
It may only modify the stdlib.md file, so it needs to be monitored.
