### PR TITLE
Only include the kconfig header if it exists

### DIFF
--- a/src/symbols/kernel.cpp
+++ b/src/symbols/kernel.cpp
@@ -496,8 +496,12 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
   cflags.push_back("-I" + ksrc + "/include/uapi");
   cflags.push_back("-I" + kobj + "/include/generated/uapi");
 
-  cflags.emplace_back("-include");
-  cflags.push_back(ksrc + "/include/linux/kconfig.h");
+  auto kconfig_path = ksrc + "/include/linux/kconfig.h";
+  if (access(kconfig_path.c_str(), R_OK) == 0) {
+    cflags.emplace_back("-include");
+    cflags.push_back(kconfig_path);
+  }
+
   cflags.emplace_back("-D__KERNEL__");
   cflags.emplace_back("-D__BPF_TRACING__");
   cflags.emplace_back("-D__HAVE_BUILTIN_BSWAP16__");


### PR DESCRIPTION
Stacked PRs:
 * __->__#5013


--- --- ---

### Only include the kconfig header if it exists


This can cause an ugly crash if this file doesn't exist so only include it
if it exists.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>