### PR TITLE
Add --traceable-functions CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to
   - [#4845](https://github.com/bpftrace/bpftrace/pull/4845)
 - Make `cpid` AOT friendly; using `cpid` while lacking a command is no longer a compile error and `has_cpid` has been added
   - [#4984](https://github.com/bpftrace/bpftrace/pull/4984)
+- Add `--traceable-functions` to allow the user to provide the list of kernel functions that can be probed
+  - [#5014](https://github.com/bpftrace/bpftrace/pull/5014)
 #### Changed
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -159,6 +159,13 @@ Probes that do not match are not loaded into the kernel.
 Special probes (`BEGIN` and `END`) are not affected by this filter.
 If no probes match, bpftrace exits with an error.
 
+=== *--traceable-functions* _FILENAME_
+
+Specify the file containing the list of traceable kernel functions. If not set,
+bpftrace uses `/sys/kernel/tracing/available_filter_functions`, which depends on
+dynamic ftrace. The format is the same as in `available_filter_functions`: each
+line is either "symbol" or "symbol [module]".
+
 === *-o* _FILENAME_
 
 Write bpftrace tracing output to _FILENAME_ instead of stdout.

--- a/src/symbols/kernel.h
+++ b/src/symbols/kernel.h
@@ -107,7 +107,7 @@ public:
 // Implementation that reads available functions from the kernel.
 class KernelInfoImpl : public KernelInfoBase<KernelInfoImpl> {
 public:
-  static Result<KernelInfoImpl> open();
+  static Result<KernelInfoImpl> open(const std::string &traceable_functions_file);
   KernelInfoImpl(const KernelInfoImpl &other) = delete;
   KernelInfoImpl &operator=(const KernelInfoImpl &other) = delete;
   KernelInfoImpl(KernelInfoImpl &&other) = default;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -677,3 +677,9 @@ RUN {{BPFTRACE}} --probe-filter '[invalid' -e 'kprobe:vfs_read { exit(); }'
 EXPECT_REGEX Invalid --probe-filter regex
 TIMEOUT 5
 WILL_FAIL
+
+NAME traceable_functions_empty
+RUN {{BPFTRACE}} --traceable-functions /dev/null -e 'kprobe:vfs_read {}'
+EXPECT_REGEX .* ERROR: No matches for kprobe vfs_read.
+TIMEOUT 5
+WILL_FAIL


### PR DESCRIPTION
We read `available_filter_functions` on startup to determine which functions are traceable and which modules to load BTF data for. However, reading this file can be slow: for each traceable function the kernel calls `kallsyms_lookup()`, which for modules involves a linear search over the symtab [1]. This primarily affects systems with large modules.

```
# time bpftrace -e 'kprobe:schedule{ @ = count() } BEGIN { exit() }'
Attached 2 probes
    0m06.43s real     0m01.31s user     0m04.24s system
```

Furthermore, this tracefs file depends on `CONFIG_DYNAMIC_FTRACE`, which may not be enabled on all systems. For example, Android common kernels support kprobes, but don't enable function_tracer at all.

This patch adds a new command line argument that can be used to provide the list of traceable functions. Since this list isn't expected to change often, the user can copy `available_filter_functions` to a file and use the flag to improve bpftrace's startup time. It's also useful if some functions aren't supported by ftrace, but the kernel allows them to be probed.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/module/kallsyms.c?h=v6.12.73#n280

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
