### PR TITLE
Skip is-traceable checks for kprobes in unsafe mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to
   - [#4836](https://github.com/bpftrace/bpftrace/pull/4836)
 - Stabilize map declarations (remove 'unstable_map_decl' flag)
   - [#5005](https://github.com/bpftrace/bpftrace/pull/5005)
+- Skip traceable function checks with --unsafe to allow probing functions not listed by ftrace
+  - [#5015](https://github.com/bpftrace/bpftrace/pull/5015)
 #### Deprecated
 - `while` is now deprecated in favor of range-based for loops
   - [#4886](https://github.com/bpftrace/bpftrace/pull/4886)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -189,6 +189,10 @@ Keep messages quiet.
 Some calls, like 'system', are marked as unsafe as they can have dangerous side effects ('system("rm -rf")') and are disabled by default.
 This flag allows their use.
 
+In addition, it makes certain probe checks less restrictive. It can be used to probe functions that
+bpftrace reports as not traceable, but are supported by kprobes (e.g. if the kernel is configured to
+allow probing notrace functions).
+
 === *--usdt-file-activation*
 
 Activate usdt semaphores based on file path.

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -41,9 +41,10 @@ void AttachPointChecker::visit(AttachPoint &ap)
   if (ap.provider == "kprobe" || ap.provider == "kretprobe") {
     if (ap.func.empty())
       ap.addError() << "kprobes should be attached to a function";
-    // Warn if user tries to attach to a non-traceable function
+    // Warn if user tries to attach to a non-traceable function. In unsafe mode
+    // we're not rejecting probes early so skip the check.
     if (bpftrace_.config_->missing_probes != ConfigMissingProbes::ignore &&
-        !util::has_wildcard(ap.func) &&
+        !util::has_wildcard(ap.func) && bpftrace_.safe_mode_ &&
         !func_info_state_.kernel_info().is_traceable(ap.func)) {
       ap.addWarning() << ap.func
                       << " is not traceable (either non-existing, inlined, "

--- a/src/symbols/kernel.h
+++ b/src/symbols/kernel.h
@@ -129,7 +129,7 @@ private:
   void populate_lazy(const std::optional<std::string> &mod_name = std::nullopt) const;
   ModulesFuncsMap filter_funcs(const ModulesFuncsMap &source, const std::optional<std::string> &mod_name = std::nullopt) const;
 
-  mutable std::ifstream available_filter_functions_;
+  mutable std::optional<std::ifstream> available_filter_functions_;
   mutable std::string last_checked_line_;
 
   ModuleSet modules_loaded_;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -683,3 +683,15 @@ RUN {{BPFTRACE}} --traceable-functions /dev/null -e 'kprobe:vfs_read {}'
 EXPECT_REGEX .* ERROR: No matches for kprobe vfs_read.
 TIMEOUT 5
 WILL_FAIL
+
+NAME traceable_functions_empty_unsafe
+RUN {{BPFTRACE}} --traceable-functions /dev/null --unsafe -e 'kprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }'
+EXPECT_REGEX SUCCESS [0-9][0-9]*
+AFTER ./testprogs/syscall read
+TIMEOUT 5
+
+NAME unsafe_bad
+RUN {{BPFTRACE}} --unsafe -e 'k:nonsense {}'
+EXPECT ERROR: Unable to attach probe: kprobe:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
+TIMEOUT 5
+WILL_FAIL


### PR DESCRIPTION
If the target function cannot be found in `available_filter_functions` (which depends on dynamic ftrace), the probe is rejected early. This allows us to emit useful warnings and avoid compiling BPF programs/loading BTF data for invalid probes.

However, this also assumes that kprobes can only be installed in functions supported by ftrace, which isn't the case in general. For example, the kernel may be compiled with `CONFIG_KPROBE_EVENTS_ON_NOTRACE` [1] or not enable dynamic ftrace at all.

When --unsafe is used, bypass the ftrace check and pass the function name to `bpf_program__attach_kprobe_opts()` verbatim. Note that this is not done for wildcard probes; we still need to know which functions are traceable in order to perform probe expansion.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/trace/trace_kprobe.c?h=v6.12.73#n441

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
