### PR TITLE
Remove check_traceable from BTF::resolve_args

### DIFF
--- a/src/btf.h
+++ b/src/btf.h
@@ -115,12 +115,9 @@ public:
   Result<std::shared_ptr<Struct>> resolve_args(
       std::string_view func,
       bool ret,
-      bool check_traceable,
-      bool skip_first_arg,
-      const symbols::KernelInfo &func_info);
+      bool skip_first_arg);
   Result<std::shared_ptr<Struct>> resolve_raw_tracepoint_args(
-      std::string_view func,
-      const symbols::KernelInfo &func_info);
+      std::string_view func);
   void resolve_fields(const SizedType& type);
 
   int get_btf_id(std::string_view func,


### PR DESCRIPTION
Stacked PRs:
 * #5017
 * __->__#5016


--- --- ---

### Remove check_traceable from BTF::resolve_args


AFAICT - this is a dead code path because we prune functions/attachpoints
that aren't traceable in an earlier pass (ap_probe_expansion.cpp)

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>