### PR TITLE
Move type_checker into CreateTypeResolverPass

### DIFF
--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -1191,17 +1191,13 @@ bool TypeChecker::check_arg(Call &call,
   return true;
 }
 
-Pass CreateTypeCheckerPass()
+void RunTypeChecker(ASTContext &ast,
+                    BPFtrace &b,
+                    CDefinitions &c_definitions,
+                    TypeMetadata &types)
 {
-  auto fn = [](ASTContext &ast,
-               BPFtrace &b,
-               CDefinitions &c_definitions,
-               TypeMetadata &types) {
-    TypeChecker checker(ast, b, c_definitions, types);
-    checker.visit(ast.root);
-  };
-
-  return Pass::create("TypeChecker", fn);
-};
+  TypeChecker checker(ast, b, c_definitions, types);
+  checker.visit(ast.root);
+}
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/type_checker.h
+++ b/src/ast/passes/types/type_checker.h
@@ -1,9 +1,18 @@
 #pragma once
 
-#include "ast/pass_manager.h"
+namespace bpftrace {
+class BPFtrace;
+}
 
 namespace bpftrace::ast {
 
-Pass CreateTypeCheckerPass();
+class ASTContext;
+struct CDefinitions;
+struct TypeMetadata;
+
+void RunTypeChecker(ASTContext &ast,
+                    BPFtrace &b,
+                    CDefinitions &c_definitions,
+                    TypeMetadata &types);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -10,6 +10,7 @@
 #include "ast/passes/types/ast_transformer.h"
 #include "ast/passes/types/cast_creator.h"
 #include "ast/passes/types/type_applicator.h"
+#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_system.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
@@ -2598,11 +2599,12 @@ Node *TypeRuleCollector::find_variable_scope(const std::string &var_ident,
   return nullptr;
 }
 
-// This pass consists of 4 visitors:
+// This pass consists of 5 visitors:
 // - TypeRuleCollector
 // - AstTransformer
 // - TypeApplicator
 // - CastCreator
+// - TypeChecker
 // Read more about how all this works in type_resolution.md
 Pass CreateTypeResolverPass()
 {
@@ -2699,6 +2701,9 @@ Pass CreateTypeResolverPass()
         // Apply casts in parts of the AST where we want the left and right
         // sides to have the same type
         CastCreator(ast, b).visit(ast.root);
+
+        // Run type checking as the final step
+        RunTypeChecker(ast, b, c_definitions, types);
       });
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,6 @@
 #include "ast/passes/recursion_check.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/types/pre_type_check.h"
-#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_resolver.h"
 #include "ast/passes/types/type_system.h"
 #include "benchmark.h"
@@ -354,7 +353,6 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateTypeSystemPass());
   add(ast::CreatePreTypeCheckPass());
   add(ast::CreateTypeResolverPass());
-  add(ast::CreateTypeCheckerPass());
   add(ast::CreateResourcePass());
 }
 
@@ -365,7 +363,6 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateTypeSystemPass());
   add(ast::CreatePreTypeCheckPass());
   add(ast::CreateTypeResolverPass());
-  add(ast::CreateTypeCheckerPass());
   add(ast::CreateResourcePass());
 }
 

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -2,7 +2,6 @@
 #include "ast/passes/clang_build.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/parser.h"
-#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_system.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
@@ -23,7 +22,6 @@ BpfBytecode codegen(const std::string &input)
                 .add(ast::CreateLLVMInitPass())
                 .add(ast::CreateClangBuildPass())
                 .add(ast::CreateTypeSystemPass())
-                .add(ast::CreateTypeCheckerPass())
                 .add(ast::AllCompilePasses())
                 .run();
   if (!ok) {

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -12,7 +12,6 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
-#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_system.h"
 #include "bpfmap.h"
 #include "bpftrace.h"
@@ -75,7 +74,6 @@ static auto parse_probe(const std::string &str, BPFtrace &bpftrace)
                 .add(ast::CreateClangParsePass())
                 .add(ast::CreateMapSugarPass())
                 .add(ast::CreateNamedParamsPass())
-                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreateLLVMInitPass())
                 .add(ast::CreateCompilePass())
                 .run();

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -6,7 +6,6 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
-#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_resolver.h"
 #include "ast/passes/types/type_system.h"
 #include "btf_common.h"
@@ -44,7 +43,6 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
                 .add(ast::CreateFieldAnalyserPass())
                 .add(ast::CreateNamedParamsPass())
                 .add(ast::CreateTypeResolverPass())
-                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreatePortabilityPass())
                 .run();
   ASSERT_TRUE(bool(ok));

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -9,7 +9,6 @@
 #include "ast/passes/named_param.h"
 #include "ast/passes/resolve_imports.h"
 #include "ast/passes/resource_analyser.h"
-#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_system.h"
 #include "bpftrace.h"
 #include "btf.h"
@@ -53,7 +52,6 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
                 .add(ast::CreateLLVMInitPass())
                 .add(ast::CreateClangBuildPass())
                 .add(ast::CreateTypeSystemPass())
-                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreateResourcePass())
                 .add(ast::AllCompilePasses())
                 .run();

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -1,6 +1,5 @@
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/parser.h"
-#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_resolver.h"
 #include "ast/passes/types/type_system.h"
 #include "mocks.h"
@@ -30,7 +29,6 @@ void test(BPFtrace &bpftrace,
                 .put(no_types)
                 .add(ast::AllParsePasses())
                 .add(ast::CreateTypeResolverPass())
-                .add(ast::CreateTypeCheckerPass())
                 .add(ast::CreateResourcePass())
                 .run();
   ASSERT_TRUE(bool(ok)) << msg.str();

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -18,7 +18,6 @@
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
 #include "ast/passes/resolve_imports.h"
-#include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_resolver.h"
 #include "ast/passes/types/type_system.h"
 #include "ast_matchers.h"
@@ -175,7 +174,6 @@ public:
                   .add(ast::CreateMapSugarPass())
                   .add(ast::CreateNamedParamsPass())
                   .add(ast::CreateTypeResolverPass())
-                  .add(ast::CreateTypeCheckerPass())
                   .run();
     EXPECT_TRUE(bool(ok));
 


### PR DESCRIPTION
Stacked PRs:
 * #5021
 * __->__#5020


--- --- ---

### Move type_checker into CreateTypeResolverPass


Type checking is tied to type resolving so it doesn't need to be a separate
pass. Just call it at the end of CreateTypeResolverPass.

No functional changes.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>