### PR TITLE
Minor refactor to avoid large headers

### DIFF
--- a/src/ast/passes/types/ast_transformer.h
+++ b/src/ast/passes/types/ast_transformer.h
@@ -1,53 +1,14 @@
 #pragma once
 
 #include "ast/passes/types/type_resolver.h"
-#include "ast/visitor.h"
-
-#include <optional>
 
 namespace bpftrace::ast {
 
 class MacroRegistry;
 
-class AstTransformer
-    : public Visitor<AstTransformer, std::optional<Expression>> {
-public:
-  AstTransformer(ASTContext &ast,
-                 const MacroRegistry &macro_registry,
-                 const ResolvedTypes &resolved_types)
-      : ast_(ast),
-        macro_registry_(macro_registry),
-        resolved_types_(resolved_types) {};
-
-  using Visitor<AstTransformer, std::optional<Expression>>::visit;
-
-  std::optional<Expression> visit(Expression &expr);
-  std::optional<Expression> visit(Binop &binop);
-  std::optional<Expression> visit(Offsetof &offof);
-  std::optional<Expression> visit(Sizeof &szof);
-  std::optional<Expression> visit(Typeinfo &typeinfo);
-  std::optional<Expression> visit(FieldAccess &acc);
-
-  bool had_transforms() const
-  {
-    return had_transforms_;
-  }
-
-private:
-  ASTContext &ast_;
-  const MacroRegistry &macro_registry_;
-  const ResolvedTypes &resolved_types_;
-  bool had_transforms_ = false;
-
-  const SizedType &get_type(const TypeVariable &node) const
-  {
-    auto it = resolved_types_.find(node);
-    if (it != resolved_types_.end()) {
-      return it->second;
-    }
-    static SizedType none = CreateNone();
-    return none;
-  }
-};
+// Runs the AST transformer, returns true if any transforms were made.
+bool RunAstTransformer(ASTContext &ast,
+                       const MacroRegistry &macro_registry,
+                       const ResolvedTypes &resolved_types);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/cast_creator.h
+++ b/src/ast/passes/types/cast_creator.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#include "ast/pass_manager.h"
-#include "ast/visitor.h"
-
 #include <optional>
-#include <variant>
+
+#include "types.h"
 
 namespace bpftrace {
 class BPFtrace;
 } // namespace bpftrace
 
 namespace bpftrace::ast {
+
+class ASTContext;
+class Expression;
+struct Program;
 
 std::optional<SizedType> try_tuple_cast(ASTContext &ctx,
                                         Expression &exp,
@@ -22,28 +24,6 @@ std::optional<SizedType> try_record_cast(ASTContext &ctx,
                                          const SizedType &expr_type,
                                          const SizedType &target_type);
 
-class CastCreator : public Visitor<CastCreator> {
-public:
-  explicit CastCreator(ASTContext &ast, BPFtrace &bpftrace);
-
-  using Visitor<CastCreator>::visit;
-  void visit(AssignMapStatement &assignment);
-  void visit(AssignVarStatement &assignment);
-  void visit(Binop &binop);
-  void visit(BlockExpr &block);
-  void visit(Call &call);
-  void visit(Cast &cast);
-  void visit(For &f);
-  void visit(IfExpr &if_expr);
-  void visit(Jump &jump);
-  void visit(MapAccess &acc);
-  void visit(Probe &probe);
-  void visit(Subprog &subprog);
-
-private:
-  ASTContext &ctx_;
-  BPFtrace &bpftrace_;
-  std::variant<std::monostate, Probe *, Subprog *> top_level_node_;
-};
+void RunCastCreator(ASTContext &ast, BPFtrace &bpftrace);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/type_applicator.h
+++ b/src/ast/passes/types/type_applicator.h
@@ -1,44 +1,11 @@
 #pragma once
 
 #include "ast/passes/types/type_resolver.h"
-#include "ast/visitor.h"
 
 namespace bpftrace::ast {
 
-class TypeApplicator : public Visitor<TypeApplicator> {
-public:
-  explicit TypeApplicator(const ResolvedTypes &resolved_types)
-      : resolved_types_(resolved_types) {};
+class ASTContext;
 
-  using Visitor<TypeApplicator>::visit;
-
-  void visit(ArrayAccess &arr);
-  void visit(Binop &binop);
-  void visit(Builtin &builtin);
-  void visit(Call &call);
-  void visit(Cast &cast);
-  void visit(FieldAccess &acc);
-  void visit(Identifier &identifier);
-  void visit(IfExpr &if_expr);
-  void visit(Map &map);
-  void visit(MapAddr &map_addr);
-  void visit(Record &record);
-  void visit(Tuple &tuple);
-  void visit(TupleAccess &acc);
-  void visit(Unop &unop);
-  void visit(Variable &var);
-  void visit(VariableAddr &var_addr);
-
-private:
-  const ResolvedTypes &resolved_types_;
-
-  void apply(Node &node, SizedType &target)
-  {
-    auto it = resolved_types_.find(&node);
-    if (it != resolved_types_.end()) {
-      target = it->second;
-    }
-  }
-};
+void RunTypeApplicator(ASTContext &ast, const ResolvedTypes &resolved_types);
 
 } // namespace bpftrace::ast


### PR DESCRIPTION
Stacked PRs:
 * __->__#5021


--- --- ---

### Minor refactor to avoid large headers


Just expose single public functions, e.g. "RunTypeApplicator", so all the
visitors don't have to be defined in the header files. This is specifically
for visitors used in type_resolver.cpp.

No functional changes.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>