### PR TITLE
Fix listing multi-probes error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix listing multi-probes error
+  - [#5022](https://github.com/bpftrace/bpftrace/pull/5022)
 #### Security
 #### Docs
 #### Tools

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -780,6 +780,52 @@ bool is_colorize()
   }
 }
 
+void list_probes(BPFtrace& bpftrace,
+                 const std::string& search,
+                 const symbols::KernelInfo& kernel_func_info,
+                 const symbols::UserInfoImpl& user_func_info)
+{
+  if (search.find(".") != std::string::npos &&
+      search.find_first_of(":*") == std::string::npos) {
+    LOG(WARNING) << "It appears that \'" << search
+                 << "\' is a filename but the file does not exist. Treating \'"
+                 << search << "\' as a search pattern.";
+  }
+
+  for (auto& probe : util::split_string(search, ',')) {
+    bool is_search_a_type = is_type_name(probe);
+
+    // Ensure that BTF is loaded for all listing.
+    auto parts = util::split_string(probe, ':');
+    if (is_search_a_type || parts.empty() || parts.size() < 3) {
+      bpftrace.btf_->load_module_btfs(kernel_func_info.get_modules());
+    } else {
+      bpftrace.btf_->load_module_btfs(kernel_func_info.get_modules(parts[1]));
+    }
+
+    // Use ProbeMatcher directly to list probes matching the search pattern.
+    ProbeMatcher probe_matcher(&bpftrace, kernel_func_info, user_func_info);
+    if (is_search_a_type) {
+      for (const auto& s : probe_matcher.get_structs_for_listing(probe)) {
+        std::cout << s << std::endl;
+      }
+    } else {
+      // For patterns without a colon (like "*do_nanosleep*"), treat as
+      // wildcard probe type with the pattern as function match.
+      std::string value = probe;
+      if (value.empty()) {
+        value = "*:*";
+      } else if (value.find(':') == std::string::npos) {
+        value = "*:" + value;
+      }
+      for (const auto& probe :
+           probe_matcher.get_probes_for_listing(value, bpftrace.pid())) {
+        std::cout << probe << std::endl;
+      }
+    }
+  }
+}
+
 int main(int argc, char* argv[])
 {
   Log::get().set_colorize(is_colorize());
@@ -864,45 +910,7 @@ int main(int argc, char* argv[])
   if (args.listing && args.script.empty() && args.filename.empty()) {
     check_privileges();
 
-    if (args.search.find(".") != std::string::npos &&
-        args.search.find_first_of(":*") == std::string::npos) {
-      LOG(WARNING)
-          << "It appears that \'" << args.search
-          << "\' is a filename but the file does not exist. Treating \'"
-          << args.search << "\' as a search pattern.";
-    }
-
-    bool is_search_a_type = is_type_name(args.search);
-
-    // Ensure that BTF is loaded for all listing.
-    auto parts = util::split_string(args.search, ':');
-    if (is_search_a_type || parts.empty() || parts.size() < 3) {
-      bpftrace.btf_->load_module_btfs(kernel_func_info->get_modules());
-    } else {
-      bpftrace.btf_->load_module_btfs(kernel_func_info->get_modules(parts[1]));
-    }
-
-    // Use ProbeMatcher directly to list probes matching the search pattern.
-    ProbeMatcher probe_matcher(&bpftrace, *kernel_func_info, user_func_info);
-    if (is_search_a_type) {
-      for (const auto& s : probe_matcher.get_structs_for_listing(args.search)) {
-        std::cout << s << std::endl;
-      }
-    } else {
-      // For patterns without a colon (like "*do_nanosleep*"), treat as
-      // wildcard probe type with the pattern as function match.
-      std::string search = args.search;
-      if (search.empty()) {
-        search = "*:*";
-      } else if (search.find(':') == std::string::npos) {
-        search = "*:" + search;
-      }
-      for (const auto& probe :
-           probe_matcher.get_probes_for_listing(search, bpftrace.pid())) {
-        std::cout << probe << std::endl;
-      }
-    }
-
+    list_probes(bpftrace, args.search, *kernel_func_info, user_func_info);
     return 0;
   }
 

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -55,8 +55,8 @@ class BPFtrace;
 class ProbeMatcher {
 public:
   explicit ProbeMatcher(BPFtrace *bpftrace,
-                        symbols::KernelInfo &kernel_func_info,
-                        symbols::UserInfo &user_func_info)
+                        const symbols::KernelInfo &kernel_func_info,
+                        const symbols::UserInfo &user_func_info)
       : bpftrace_(bpftrace),
         kernel_func_info_(kernel_func_info),
         user_func_info_(user_func_info)
@@ -84,8 +84,8 @@ public:
   std::vector<std::string> get_structs_for_listing(const std::string &search);
 
   const BPFtrace *bpftrace_;
-  symbols::KernelInfo &kernel_func_info_;
-  symbols::UserInfo &user_func_info_;
+  const symbols::KernelInfo &kernel_func_info_;
+  const symbols::UserInfo &user_func_info_;
 
 private:
   std::set<std::string> get_matches_in_stream(const std::string &search_input,

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -41,6 +41,13 @@ EXPECT_REGEX [ ]+[a-zA-Z_\*\s]+
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
+NAME it lists multiple kprobes in verbose mode
+RUN {{BPFTRACE}} -lv kprobe:vfs_read,kprobe:vfs_write
+EXPECT kprobe:vfs_read
+EXPECT kprobe:vfs_write
+REQUIRES_FEATURE btf
+TIMEOUT 1
+
 NAME it lists tracepoints
 RUN {{BPFTRACE}} -l | grep tracepoint
 EXPECT_REGEX tracepoint:.*
@@ -194,11 +201,24 @@ RUN {{BPFTRACE}} -lv 'struct task_struct'
 EXPECT struct task_struct {
 TIMEOUT 2
 
+NAME it lists multiple struct definitions
+RUN {{BPFTRACE}} -lv 'struct task_struct,struct file,struct fd'
+EXPECT struct task_struct {
+EXPECT struct file {
+EXPECT struct fd {
+TIMEOUT 2
+
 NAME it lists probes in a given file
 RUN {{BPFTRACE}} -l runtime/scripts/interval_order.bt
 EXPECT interval:ms:
 EXPECT interval:s:
 EXPECT interval:us:
+
+NAME it lists misc in verbose mode
+RUN {{BPFTRACE}} -lv 'kprobe:vfs_read,struct file'
+EXPECT kprobe:vfs_read
+EXPECT struct file {
+TIMEOUT 2
 
 NAME warning on non existent file
 RUN {{BPFTRACE}} -l non_existent_file.bt


### PR DESCRIPTION
When displaying multiple probes in verbose mode, no information is displayed because the comma ',' is not handled.

For example, the following command fails to retrieve any content:

    $ sudo bpftrace -lv 'kprobe:vfs_read,kretprobe:vfs_read'
    $ sudo bpftrace -lv 'struct task_struct,struct file'

The string should be split using comma ',' first, and then processed one string at a time.
