### PR TITLE
[TypeMap] Create immutable TypeMap pass state

### DIFF
--- a/src/ast/passes/types/ast_transformer.cpp
+++ b/src/ast/passes/types/ast_transformer.cpp
@@ -84,23 +84,25 @@ std::optional<Expression> AstTransformer::visit(Binop &binop)
     return std::nullopt;
   }
 
+  auto updated_lht = lht;
   if (*updatedTy != lht) {
-    if (is_tuple) {
-      try_tuple_cast(ast_, binop.left, lht, *updatedTy);
-    } else {
-      try_record_cast(ast_, binop.left, lht, *updatedTy);
+    auto updated = is_tuple
+                       ? try_tuple_cast(ast_, binop.left, lht, *updatedTy)
+                       : try_record_cast(ast_, binop.left, lht, *updatedTy);
+    if (updated) {
+      updated_lht = *updated;
     }
   }
+
+  auto updated_rht = rht;
   if (*updatedTy != rht) {
-    if (is_tuple) {
-      try_tuple_cast(ast_, binop.right, rht, *updatedTy);
-    } else {
-      try_record_cast(ast_, binop.right, rht, *updatedTy);
+    auto updated = is_tuple
+                       ? try_tuple_cast(ast_, binop.right, rht, *updatedTy)
+                       : try_record_cast(ast_, binop.right, rht, *updatedTy);
+    if (updated) {
+      updated_rht = *updated;
     }
   }
-
-  bool types_equal = binop.left.type() == binop.right.type();
-
   auto *size = ast_.make_node<Integer>(binop.loc,
                                        updatedTy->GetSize(),
                                        CreateUInt64());
@@ -112,10 +114,10 @@ std::optional<Expression> AstTransformer::visit(Binop &binop)
   // before assignment (e.g. `let $right: typeof($left) = right;`)
   // as this ensures the temporary `$right` variable has the same
   // field ordering as the `$left`.
-  auto *call = ast_.make_node<Call>(binop.loc,
-                                    types_equal ? "memcmp" : "memcmp_record",
-                                    ExpressionList{
-                                        binop.left, binop.right, size });
+  auto *call = ast_.make_node<Call>(
+      binop.loc,
+      updated_rht == updated_lht ? "memcmp" : "memcmp_record",
+      ExpressionList{ binop.left, binop.right, size });
   auto *typeof_node = ast_.make_node<Typeof>(binop.loc, CreateBool());
   auto *cast = ast_.make_node<Cast>(binop.loc, typeof_node, call);
   if (binop.op == Operator::NE) {
@@ -150,14 +152,9 @@ std::optional<Expression> AstTransformer::visit(FieldAccess &acc)
     auto *unop = ast_.make_node<Unop>(acc.expr.node().loc,
                                       acc.expr,
                                       Operator::MUL);
-    unop->result_type = type.GetPointeeTy();
-    if (type.IsCtxAccess())
-      unop->result_type.MarkCtxAccess();
-    unop->result_type.is_internal = type.is_internal;
-    unop->result_type.SetAS(type.GetAS());
     acc.expr.value = unop;
     had_transforms_ = true;
-    type = unop->result_type;
+    type = type.GetPointeeTy();
   }
 
   return std::nullopt;
@@ -222,19 +219,10 @@ std::optional<Expression> AstTransformer::visit(Typeinfo &typeinfo)
   auto *base_ty = ast_.make_node<String>(typeinfo.loc, to_string(type.GetTy()));
   auto *full_ty = ast_.make_node<String>(typeinfo.loc, typestr(type));
 
-  std::vector<SizedType> elements = { CreateUInt64(),
-                                      base_ty->type(),
-                                      full_ty->type() };
-  std::vector<std::string_view> names = { "btf_id", "base_type", "full_type" };
-
-  auto record_type = CreateRecord(Struct::CreateRecord(elements, names));
-
   auto *record = make_record(
       ast_,
       typeinfo.loc,
       { { "btf_id", id }, { "base_type", base_ty }, { "full_type", full_ty } });
-
-  record->record_type = record_type;
 
   return record;
 }

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -1,6 +1,7 @@
 #include "ast/passes/types/cast_creator.h"
 #include "ast/ast.h"
 #include "ast/passes/map_sugar.h"
+#include "ast/passes/types/type_map.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
 #include "log.h"
@@ -47,7 +48,6 @@ std::optional<SizedType> try_tuple_cast(ASTContext &ctx,
       elem = ctx.make_node<TupleAccess>(Location(exp.loc()),
                                         clone(ctx, exp.loc(), exp),
                                         i);
-      elem.as<TupleAccess>()->element_type = expr_field_ty;
     }
     auto cast_type = try_expression_cast(
         ctx, elem, expr_field_ty, target_field_ty);
@@ -59,9 +59,7 @@ std::optional<SizedType> try_tuple_cast(ASTContext &ctx,
   }
 
   auto tuple_type = CreateTuple(Struct::CreateTuple(element_types));
-
   exp = ctx.make_node<Tuple>(Location(exp.loc()), std::move(expr_list));
-  exp.as<Tuple>()->tuple_type = tuple_type;
 
   return tuple_type;
 }
@@ -97,7 +95,6 @@ std::optional<SizedType> try_record_cast(ASTContext &ctx,
       elem = ctx.make_node<FieldAccess>(Location(exp.loc()),
                                         clone(ctx, exp.loc(), exp),
                                         target_field.name);
-      elem.as<FieldAccess>()->field_type = expr_field_ty;
     }
     auto cast_type = try_expression_cast(
         ctx, elem, expr_field_ty, target_field_ty);
@@ -124,7 +121,6 @@ std::optional<SizedType> try_record_cast(ASTContext &ctx,
   auto record_type = CreateRecord(Struct::CreateRecord(elements, names));
 
   exp = ctx.make_node<Record>(Location(exp.loc()), std::move(named_args));
-  exp.as<Record>()->record_type = record_type;
 
   return record_type;
 }
@@ -134,7 +130,6 @@ static std::optional<SizedType> try_int_cast(ASTContext &ctx,
                                              const SizedType &expr_type,
                                              const SizedType &target_type)
 {
-  // We don't need a cast if it's a literal
   if (auto *integer = exp.as<Integer>()) {
     if (target_type.IsSigned()) {
       auto signed_ty = ast::get_signed_integer_type(integer->value);
@@ -149,9 +144,6 @@ static std::optional<SizedType> try_int_cast(ASTContext &ctx,
         return std::nullopt;
       }
     }
-    exp = ctx.make_node<Integer>(
-        Location(exp.loc()), integer->value, target_type, integer->original);
-    return target_type;
   } else if (auto *negative_integer = exp.as<NegativeInteger>()) {
     if (!target_type.IsSigned()) {
       return std::nullopt;
@@ -162,14 +154,10 @@ static std::optional<SizedType> try_int_cast(ASTContext &ctx,
       // The integer is too large
       return std::nullopt;
     }
-
-    exp = ctx.make_node<NegativeInteger>(Location(exp.loc()),
-                                         negative_integer->value,
-                                         target_type);
-    return target_type;
   }
 
-  if (!expr_type.FitsInto(target_type) && !expr_type.IsCastableMapTy()) {
+  if (!expr_type.FitsInto(target_type) && !expr_type.IsCastableMapTy() &&
+      !exp.is<Integer>() && !exp.is<NegativeInteger>()) {
     return std::nullopt;
   }
 
@@ -186,7 +174,7 @@ static std::optional<SizedType> try_string_cast(ASTContext &ctx,
                                                 const SizedType &expr_type,
                                                 const SizedType &target_type)
 {
-  if (exp.type().GetSize() == target_type.GetSize()) {
+  if (expr_type.GetSize() == target_type.GetSize()) {
     return target_type;
   }
 
@@ -250,7 +238,9 @@ namespace {
 
 class CastCreator : public Visitor<CastCreator> {
 public:
-  explicit CastCreator(ASTContext &ast, BPFtrace &bpftrace);
+  explicit CastCreator(ASTContext &ast,
+                       BPFtrace &bpftrace,
+                       const TypeMap &type_map);
 
   using Visitor<CastCreator>::visit;
   void visit(AssignMapStatement &assignment);
@@ -267,14 +257,29 @@ public:
   void visit(Subprog &subprog);
 
 private:
+  std::optional<SizedType> cast_expression(Expression &expr,
+                                           const SizedType &expr_type,
+                                           const SizedType &target_type);
+
   ASTContext &ctx_;
   BPFtrace &bpftrace_;
+  const TypeMap &type_map_;
   std::variant<std::monostate, Probe *, Subprog *> top_level_node_;
 };
 
-CastCreator::CastCreator(ASTContext &ast, BPFtrace &bpftrace)
-    : ctx_(ast), bpftrace_(bpftrace)
+CastCreator::CastCreator(ASTContext &ast,
+                         BPFtrace &bpftrace,
+                         const TypeMap &type_map)
+    : ctx_(ast), bpftrace_(bpftrace), type_map_(type_map)
 {
+}
+
+std::optional<SizedType> CastCreator::cast_expression(
+    Expression &expr,
+    const SizedType &expr_type,
+    const SizedType &target_type)
+{
+  return try_expression_cast(ctx_, expr, expr_type, target_type);
 }
 
 void CastCreator::visit(AssignMapStatement &assignment)
@@ -282,14 +287,15 @@ void CastCreator::visit(AssignMapStatement &assignment)
   visit(assignment.map_access);
   visit(assignment.expr);
 
-  const auto &expr_type = assignment.expr.type();
-  const auto &value_type = assignment.map_access->map->value_type;
+  const auto &expr_type = type_map_.type(assignment.expr);
+  const auto &value_type = type_map_.map_value_type(
+      assignment.map_access->map->ident);
 
   if (value_type == expr_type) {
     return;
   }
 
-  if (!try_expression_cast(ctx_, assignment.expr, expr_type, value_type)) {
+  if (!cast_expression(assignment.expr, expr_type, value_type)) {
     assignment.addError() << "Type mismatch for "
                           << assignment.map_access->map->ident << ": "
                           << "trying to assign value of type '" << expr_type
@@ -303,14 +309,14 @@ void CastCreator::visit(AssignVarStatement &assignment)
   visit(assignment.expr);
   visit(assignment.var_decl);
 
-  const auto &expr_type = assignment.expr.type();
-  const auto &var_type = assignment.var()->type();
+  const auto &expr_type = type_map_.type(assignment.expr);
+  const auto &var_type = type_map_.type(assignment.var());
 
   if (var_type == expr_type) {
     return;
   }
 
-  if (!try_expression_cast(ctx_, assignment.expr, expr_type, var_type)) {
+  if (!cast_expression(assignment.expr, expr_type, var_type)) {
     assignment.addError() << "Type mismatch for " << assignment.var()->ident
                           << ": "
                           << "trying to assign value of type '" << expr_type
@@ -324,8 +330,8 @@ void CastCreator::visit(Binop &binop)
   visit(binop.left);
   visit(binop.right);
 
-  const auto &left_type = binop.left.type();
-  const auto &right_type = binop.right.type();
+  const auto &left_type = type_map_.type(binop.left);
+  const auto &right_type = type_map_.type(binop.right);
 
   // N.B. don't upcast strings as there are cases when one size is the max
   // string size and we don't want to create a cast like (string[1024])"hi"
@@ -336,12 +342,13 @@ void CastCreator::visit(Binop &binop)
   if (is_comparison_op(binop.op)) {
     auto promoted = get_promoted_type(left_type, right_type);
     if (promoted) {
-      try_expression_cast(ctx_, binop.left, left_type, *promoted);
-      try_expression_cast(ctx_, binop.right, right_type, *promoted);
+      cast_expression(binop.left, left_type, *promoted);
+      cast_expression(binop.right, right_type, *promoted);
     }
   } else {
-    try_expression_cast(ctx_, binop.left, left_type, binop.result_type);
-    try_expression_cast(ctx_, binop.right, right_type, binop.result_type);
+    const auto &result_type = type_map_.type(&binop);
+    cast_expression(binop.left, left_type, result_type);
+    cast_expression(binop.right, right_type, result_type);
   }
 }
 
@@ -359,12 +366,13 @@ void CastCreator::visit(Call &call)
 
   if (getAssignRewriteFuncs().contains(call.func)) {
     if (auto *map = call.vargs.at(0).as<Map>()) {
-      try_expression_cast(
-          ctx_, call.vargs.at(1), call.vargs.at(1).type(), map->key_type);
+      cast_expression(call.vargs.at(1),
+                      type_map_.type(call.vargs.at(1)),
+                      type_map_.map_key_type(map->ident));
     }
   } else if (call.func == "percpu_kaddr") {
     if (call.vargs.size() == 2) {
-      auto arg_type = call.vargs.at(1).type();
+      auto arg_type = type_map_.type(call.vargs.at(1));
       if (arg_type != CreateUInt32() && arg_type.IsIntegerTy()) {
         auto *typeof_c = ctx_.make_node<Typeof>(
             Location(call.vargs.at(1).loc()), CreateUInt32());
@@ -375,10 +383,11 @@ void CastCreator::visit(Call &call)
       }
     }
   } else if (call.func == "usym") {
-    auto arg_type = call.vargs.at(0).type();
+    auto arg_type = type_map_.type(call.vargs.at(0));
     if (arg_type.IsIntegerTy() && arg_type.GetSize() != 8) {
-      try_expression_cast(
-          ctx_, call.vargs.at(0), call.vargs.at(0).type(), CreateUInt64());
+      cast_expression(call.vargs.at(0),
+                      type_map_.type(call.vargs.at(0)),
+                      CreateUInt64());
     }
   }
 }
@@ -400,15 +409,15 @@ void CastCreator::visit(For &f)
     visit(range->start);
     visit(range->end);
 
-    const auto &start_type = range->start.type();
-    const auto &end_type = range->end.type();
+    const auto &start_type = type_map_.type(range->start);
+    const auto &end_type = type_map_.type(range->end);
     if (start_type == end_type) {
       return;
     }
     auto larger = start_type.GetSize() > end_type.GetSize() ? start_type
                                                             : end_type;
-    try_expression_cast(ctx_, range->start, start_type, larger);
-    try_expression_cast(ctx_, range->end, end_type, larger);
+    cast_expression(range->start, start_type, larger);
+    cast_expression(range->end, end_type, larger);
   }
 }
 
@@ -418,18 +427,18 @@ void CastCreator::visit(IfExpr &if_expr)
   visit(if_expr.left);
   visit(if_expr.right);
 
-  const auto &result_type = if_expr.result_type;
-  const auto &left_type = if_expr.left.type();
-  const auto &right_type = if_expr.right.type();
+  const auto &result_type = type_map_.type(&if_expr);
+  const auto &left_type = type_map_.type(if_expr.left);
+  const auto &right_type = type_map_.type(if_expr.right);
 
   if (result_type != left_type) {
-    if (!try_expression_cast(ctx_, if_expr.left, left_type, result_type)) {
+    if (!cast_expression(if_expr.left, left_type, result_type)) {
       LOG(BUG) << "IfExpr left should be castable";
     }
   }
 
   if (result_type != right_type) {
-    if (!try_expression_cast(ctx_, if_expr.right, right_type, result_type)) {
+    if (!cast_expression(if_expr.right, right_type, result_type)) {
       LOG(BUG) << "IfExpr right should be castable";
     }
   }
@@ -441,30 +450,29 @@ void CastCreator::visit(Jump &jump)
     visit(jump.return_value);
     if (std::holds_alternative<Probe *>(top_level_node_)) {
       if (jump.return_value.has_value()) {
-        const auto &ty = jump.return_value->type();
+        const auto &ty = type_map_.type(*jump.return_value);
         if (ty.IsIntegerTy() && ty.GetSize() != 8) {
           // Probes always return 64 bit ints
-          try_expression_cast(ctx_, *jump.return_value, ty, CreateInt64());
+          cast_expression(*jump.return_value, ty, CreateInt64());
         }
       }
     } else if (auto **subprog_ptr = std::get_if<Subprog *>(&top_level_node_)) {
       auto *subprog = *subprog_ptr;
+      const auto &return_type = type_map_.type(subprog->return_type);
       if (!jump.return_value.has_value()) {
-        if (!subprog->return_type->type().IsVoidTy()) {
+        if (!return_type.IsVoidTy()) {
           jump.addError() << "Function " << subprog->name << " is of type "
-                          << subprog->return_type->type() << ", cannot return "
-                          << CreateVoid();
+                          << return_type << ", cannot return " << CreateVoid();
           return;
         }
         return;
       }
-      if (!try_expression_cast(ctx_,
-                               *jump.return_value,
-                               jump.return_value->type(),
-                               subprog->return_type->type())) {
+      if (!cast_expression(*jump.return_value,
+                           type_map_.type(*jump.return_value),
+                           return_type)) {
         jump.addError() << "Function " << subprog->name << " is of type "
-                        << subprog->return_type->type() << ", cannot return "
-                        << jump.return_value->type();
+                        << return_type << ", cannot return "
+                        << type_map_.type(*jump.return_value);
         return;
       }
     }
@@ -475,14 +483,14 @@ void CastCreator::visit(MapAccess &acc)
 {
   visit(acc.key);
   visit(acc.map);
-  const auto &expr_type = acc.key.type();
-  const auto &key_type = acc.map->key_type;
+  const auto &expr_type = type_map_.type(acc.key);
+  const auto &key_type = type_map_.map_key_type(acc.map->ident);
 
   if (key_type.IsNoneTy() || expr_type.IsNoneTy()) {
     return;
   }
 
-  if (!try_expression_cast(ctx_, acc.key, expr_type, key_type)) {
+  if (!cast_expression(acc.key, expr_type, key_type)) {
     acc.addError() << "Type mismatch for " << acc.map->ident << ": "
                    << "trying to assign key of type '" << expr_type
                    << "' when map already has a key type '" << key_type << "'";
@@ -510,9 +518,11 @@ void CastCreator::visit(Subprog &subprog)
 
 } // namespace
 
-void RunCastCreator(ASTContext &ast, BPFtrace &bpftrace)
+void RunCastCreator(ASTContext &ast,
+                    BPFtrace &bpftrace,
+                    const TypeMap &type_map)
 {
-  CastCreator(ast, bpftrace).visit(ast.root);
+  CastCreator(ast, bpftrace, type_map).visit(ast.root);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/cast_creator.h
+++ b/src/ast/passes/types/cast_creator.h
@@ -12,6 +12,7 @@ namespace bpftrace::ast {
 
 class ASTContext;
 class Expression;
+class TypeMap;
 struct Program;
 
 std::optional<SizedType> try_tuple_cast(ASTContext &ctx,
@@ -24,6 +25,8 @@ std::optional<SizedType> try_record_cast(ASTContext &ctx,
                                          const SizedType &expr_type,
                                          const SizedType &target_type);
 
-void RunCastCreator(ASTContext &ast, BPFtrace &bpftrace);
+void RunCastCreator(ASTContext &ast,
+                    BPFtrace &bpftrace,
+                    const TypeMap &type_map);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -532,6 +532,11 @@ void CallPreCheck::visit(Call &call)
 
   // Per-function literal/structural checks
   if (call.func == "hist") {
+    // Inject default bits argument (0) if not provided, so that downstream
+    // passes always see 4 arguments.
+    if (call.vargs.size() == 3) {
+      call.vargs.emplace_back(ctx_.make_node<Integer>(call.loc, 0));
+    }
     if (call.vargs.size() == 4) {
       const auto *bits = call.vargs.at(3).as<Integer>();
       if (!bits) {

--- a/src/ast/passes/types/type_applicator.cpp
+++ b/src/ast/passes/types/type_applicator.cpp
@@ -1,5 +1,6 @@
 #include "ast/passes/types/type_applicator.h"
 #include "ast/ast.h"
+#include "ast/passes/types/type_map.h"
 #include "ast/visitor.h"
 
 namespace bpftrace::ast {
@@ -8,8 +9,7 @@ namespace {
 
 class TypeApplicator : public Visitor<TypeApplicator> {
 public:
-  explicit TypeApplicator(const ResolvedTypes &resolved_types)
-      : resolved_types_(resolved_types) {};
+  explicit TypeApplicator(const TypeMap &type_map) : type_map_(type_map) {};
 
   using Visitor<TypeApplicator>::visit;
 
@@ -31,13 +31,13 @@ public:
   void visit(VariableAddr &var_addr);
 
 private:
-  const ResolvedTypes &resolved_types_;
+  const TypeMap &type_map_;
 
   void apply(Node &node, SizedType &target)
   {
-    auto it = resolved_types_.find(&node);
-    if (it != resolved_types_.end()) {
-      target = it->second;
+    const auto &type = type_map_.type(&node);
+    if (!type.IsNoneTy()) {
+      target = type;
     }
   }
 };
@@ -98,16 +98,16 @@ void TypeApplicator::visit(Identifier &identifier)
 
 void TypeApplicator::visit(Map &map)
 {
-  auto key_it = resolved_types_.find(get_map_key_name(map.ident));
-  if (key_it != resolved_types_.end()) {
-    map.key_type = key_it->second;
+  const auto *key_type = type_map_.find_map_key_type(map.ident);
+  if (key_type) {
+    map.key_type = *key_type;
   }
   if (map.key_type.IsNoneTy()) {
     map.addError() << "Undefined map: " + map.ident;
   }
-  auto val_it = resolved_types_.find(get_map_value_name(map.ident));
-  if (val_it != resolved_types_.end()) {
-    map.value_type = val_it->second;
+  const auto *val_type = type_map_.find_map_value_type(map.ident);
+  if (val_type) {
+    map.value_type = *val_type;
   }
   if (map.value_type.IsNoneTy()) {
     map.addError() << "Undefined map: " + map.ident;
@@ -160,9 +160,9 @@ void TypeApplicator::visit(VariableAddr &var_addr)
 
 } // namespace
 
-void RunTypeApplicator(ASTContext &ast, const ResolvedTypes &resolved_types)
+void RunTypeApplicator(ASTContext &ast, const TypeMap &type_map)
 {
-  TypeApplicator(resolved_types).visit(ast.root);
+  TypeApplicator(type_map).visit(ast.root);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/type_applicator.h
+++ b/src/ast/passes/types/type_applicator.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "ast/passes/types/type_resolver.h"
-
 namespace bpftrace::ast {
 
 class ASTContext;
+class TypeMap;
 
-void RunTypeApplicator(ASTContext &ast, const ResolvedTypes &resolved_types);
+void RunTypeApplicator(ASTContext &ast, const TypeMap &type_map);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -9,6 +9,7 @@
 #include "ast/integer_types.h"
 #include "ast/passes/collect_nodes.h"
 #include "ast/passes/types/type_checker.h"
+#include "ast/passes/types/type_map.h"
 #include "ast/passes/types/type_system.h"
 #include "bpftrace.h"
 #include "btf/compat.h"
@@ -35,11 +36,13 @@ public:
   explicit TypeChecker(ASTContext &ctx,
                        BPFtrace &bpftrace,
                        CDefinitions &c_definitions,
-                       TypeMetadata &type_metadata)
+                       TypeMetadata &type_metadata,
+                       const TypeMap &type_map)
       : ctx_(ctx),
         bpftrace_(bpftrace),
         c_definitions_(c_definitions),
-        type_metadata_(type_metadata)
+        type_metadata_(type_metadata),
+        type_map_(type_map)
   {
   }
 
@@ -73,6 +76,7 @@ private:
   BPFtrace &bpftrace_;
   const CDefinitions &c_definitions_;
   const TypeMetadata &type_metadata_;
+  const TypeMap &type_map_;
 
   [[nodiscard]] bool check_arg(Call &call,
                                size_t index,
@@ -235,7 +239,7 @@ void TypeChecker::visit(Identifier &identifier)
       identifier.ident == "current_pid" || identifier.ident == "current_tid") {
     return;
   }
-  if (identifier.ident_type.IsNoneTy()) {
+  if (type_map_.type(&identifier).IsNoneTy()) {
     identifier.addError() << "Unknown identifier: '" + identifier.ident + "'";
   }
 }
@@ -250,27 +254,15 @@ void TypeChecker::visit(Call &call)
     return;
   }
 
-  if (call.func == "hist") {
-    if (call.vargs.size() == 3) {
-      call.vargs.emplace_back(ctx_.make_node<Integer>(call.loc, 0)); // default
-                                                                     // bits is
-                                                                     // 0
-    }
-
-    call.return_type = CreateHist();
-  } else if (call.func == "tseries") {
-    call.return_type = CreateVoid();
-  } else if (call.func == "str") {
+  if (call.func == "str") {
     auto &arg = call.vargs.at(0);
-    const auto &t = arg.type();
+    const auto &t = type_map_.type(arg);
     if (!t.IsStringTy() && !t.IsIntegerTy() && !t.IsPtrTy()) {
       call.addError()
           << call.func
           << "() expects a string, integer or a pointer type as first "
           << "argument (" << t << " provided)";
     }
-    call.return_type = CreateString(call.type().GetSize());
-    call.return_type.SetAS(AddrSpace::kernel);
   } else if (call.func == "buf") {
     const uint64_t max_strlen = bpftrace_.config_->max_strlen;
     if (max_strlen >
@@ -281,19 +273,20 @@ void TypeChecker::visit(Call &call)
     }
 
     auto &arg = call.vargs.at(0);
-    if (!(arg.type().IsIntTy() || arg.type().IsStringTy() ||
-          arg.type().IsPtrTy() || arg.type().IsArrayTy())) {
+    const auto &arg_type = type_map_.type(arg);
+    if (!(arg_type.IsIntTy() || arg_type.IsStringTy() || arg_type.IsPtrTy() ||
+          arg_type.IsArrayTy())) {
       call.addError()
           << call.func
           << "() expects an integer, string, or array argument but saw "
-          << typestr(arg.type().GetTy());
+          << typestr(arg_type.GetTy());
     }
 
     if (call.vargs.size() == 1) {
-      if (!arg.type().IsArrayTy()) {
+      if (!arg_type.IsArrayTy()) {
         call.addError() << call.func
                         << "() expects a length argument for non-array type "
-                        << typestr(arg.type().GetTy());
+                        << typestr(arg_type.GetTy());
       }
     } else {
       if (auto *integer = call.vargs.at(1).as<NegativeInteger>()) {
@@ -304,7 +297,7 @@ void TypeChecker::visit(Call &call)
   } else if (call.func == "ksym" || call.func == "usym") {
     // allow symbol lookups on casts (eg, function pointers)
     auto &arg = call.vargs.at(0);
-    const auto &type = arg.type();
+    const auto &type = type_map_.type(arg);
     if (!type.IsIntegerTy() && !type.IsPtrTy()) {
       call.addError() << call.func
                       << "() expects an integer or pointer argument";
@@ -317,11 +310,11 @@ void TypeChecker::visit(Call &call)
     }
 
     auto &arg = call.vargs.at(index);
-    if (!arg.type().IsIntTy() && !arg.type().IsStringTy() &&
-        !arg.type().IsArrayTy())
+    const auto &arg_type = type_map_.type(arg);
+    if (!arg_type.IsIntTy() && !arg_type.IsStringTy() && !arg_type.IsArrayTy())
       call.addError() << call.func
                       << "() expects an integer or array argument, got "
-                      << arg.type().GetTy();
+                      << arg_type.GetTy();
 
     // Kind of:
     //
@@ -332,17 +325,18 @@ void TypeChecker::visit(Call &call)
     //     char[16] inet6;
     //   }
     // }
-    auto type = arg.type();
+    auto type = arg_type;
 
-    if ((arg.type().IsArrayTy() || arg.type().IsStringTy()) &&
+    if ((arg_type.IsArrayTy() || arg_type.IsStringTy()) &&
         type.GetSize() != 4 && type.GetSize() != 16)
       call.addError() << call.func
                       << "() argument must be 4 or 16 bytes in size";
   } else if (call.func == "join") {
     auto &arg = call.vargs.at(0);
-    if (!(arg.type().IsIntTy() || arg.type().IsPtrTy())) {
+    const auto &arg_type = type_map_.type(arg);
+    if (!(arg_type.IsIntTy() || arg_type.IsPtrTy())) {
       call.addError() << "() only supports int or pointer arguments" << " ("
-                      << arg.type().GetTy() << " provided)";
+                      << arg_type.GetTy() << " provided)";
     }
   } else if (call.func == "percpu_kaddr") {
     const auto &symbol = call.vargs.at(0).as<String>()->value;
@@ -356,7 +350,7 @@ void TypeChecker::visit(Call &call)
     const auto &fmt = call.vargs.at(0).as<String>()->value;
     std::vector<SizedType> args;
     for (size_t i = 1; i < call.vargs.size(); i++) {
-      args.push_back(call.vargs[i].type());
+      args.push_back(type_map_.type(call.vargs[i]));
     }
     FormatString fs(fmt);
     auto ok = fs.check(args);
@@ -404,7 +398,8 @@ void TypeChecker::visit(Call &call)
                              "likely be updated "
                              "before the runtime can 'print' it.";
       }
-      if (map->value_type.IsStatsTy() && call.vargs.size() > 1) {
+      if (type_map_.map_value_type(map->ident).IsStatsTy() &&
+          call.vargs.size() > 1) {
         call.addWarning()
             << "print()'s top and div arguments are ignored when used on "
                "stats() maps.";
@@ -417,27 +412,28 @@ void TypeChecker::visit(Call &call)
     //
     // We rely on the fact that type checking enforces types like count(),
     // min(), max(), etc. to be assigned directly to a map.
-    else if (call.vargs.at(0).type().IsMultiKeyMapTy()) {
-      call.addError()
-          << "Map type " << call.vargs.at(0).type()
-          << " cannot print the value of individual keys. You must print "
-             "the whole map.";
-    } else if (call.vargs.at(0).type().IsPrintableTy()) {
-      if (call.vargs.size() != 1)
-        call.addError() << "Non-map print() only takes 1 argument, "
-                        << call.vargs.size() << " found";
-    } else {
-      call.addError() << call.vargs.at(0).type() << " type passed to "
-                      << call.func << "() is not printable";
+    else {
+      const auto &varg_type = type_map_.type(call.vargs.at(0));
+      if (varg_type.IsMultiKeyMapTy()) {
+        call.addError()
+            << "Map type " << varg_type
+            << " cannot print the value of individual keys. You must print "
+               "the whole map.";
+      } else if (varg_type.IsPrintableTy()) {
+        if (call.vargs.size() != 1)
+          call.addError() << "Non-map print() only takes 1 argument, "
+                          << call.vargs.size() << " found";
+      } else {
+        call.addError() << varg_type << " type passed to " << call.func
+                        << "() is not printable";
+      }
     }
   } else if (call.func == "stack_len") {
-    if (!call.vargs.at(0).type().IsStack()) {
+    if (!type_map_.type(call.vargs.at(0)).IsStack()) {
       call.addError() << "len() expects a map or stack to be provided";
     }
   } else if (call.func == "strftime") {
-    auto &arg = call.vargs.at(1);
-    call.return_type.ts_mode = arg.type().ts_mode;
-    if (call.return_type.ts_mode == TimestampMode::monotonic) {
+    if (type_map_.type(&call).ts_mode == TimestampMode::monotonic) {
       call.addError() << "strftime() can not take a monotonic timestamp";
     }
   } else if (call.func == "path") {
@@ -452,27 +448,30 @@ void TypeChecker::visit(Call &call)
     // It's record when it's referenced as object pointer
     // member, like: path(args.filp->f_path))
     auto &arg = call.vargs.at(0);
-    if (arg.type().GetTy() != Type::c_struct &&
-        arg.type().GetTy() != Type::pointer) {
+    const auto &arg_type = type_map_.type(arg);
+    if (arg_type.GetTy() != Type::c_struct &&
+        arg_type.GetTy() != Type::pointer) {
       call.addError() << "path() only supports pointer or record argument ("
-                      << arg.type().GetTy() << " provided)";
+                      << arg_type.GetTy() << " provided)";
     }
   } else if (call.func == "kptr" || call.func == "uptr") {
     // kptr should accept both integer or pointer. Consider case: kptr($1)
     auto &arg = call.vargs.at(0);
-    if (!arg.type().IsIntTy() && !arg.type().IsPtrTy()) {
+    const auto &arg_type = type_map_.type(arg);
+    if (!arg_type.IsIntTy() && !arg_type.IsPtrTy()) {
       call.addError() << call.func << "() only supports "
-                      << "integer or pointer arguments (" << arg.type().GetTy()
+                      << "integer or pointer arguments (" << arg_type.GetTy()
                       << " provided)";
       return;
     }
   } else if (call.func == "macaddr") {
     auto &arg = call.vargs.at(0);
-    if (!arg.type().IsIntTy() && !arg.type().IsArrayTy() &&
-        !arg.type().IsByteArray() && !arg.type().IsPtrTy())
+    const auto &arg_type = type_map_.type(arg);
+    if (!arg_type.IsIntTy() && !arg_type.IsArrayTy() &&
+        !arg_type.IsByteArray() && !arg_type.IsPtrTy())
       call.addError() << call.func
                       << "() only supports array or pointer arguments" << " ("
-                      << arg.type().GetTy() << " provided)";
+                      << arg_type.GetTy() << " provided)";
 
     if (arg.is<String>())
       call.addError() << call.func
@@ -481,18 +480,19 @@ void TypeChecker::visit(Call &call)
     // N.B. When converting from BTF, we can treat string types as 7 bytes in
     // order to signal to userspace that they are well-formed. However, we can
     // convert from anything as long as there are at least 6 bytes to read.
-    const auto &type = arg.type();
-    if ((type.IsArrayTy() || type.IsByteArray()) && type.GetSize() < 6) {
+    if ((arg_type.IsArrayTy() || arg_type.IsByteArray()) &&
+        arg_type.GetSize() < 6) {
       call.addError() << call.func
                       << "() argument must be at least 6 bytes in size";
     }
   } else if (call.func == "nsecs") {
-    if (call.return_type.ts_mode == TimestampMode::tai &&
+    const auto &nsecs_type = type_map_.type(&call);
+    if (nsecs_type.ts_mode == TimestampMode::tai &&
         !bpftrace_.feature_->has_helper_ktime_get_tai_ns()) {
       call.addError()
           << "Kernel does not support tai timestamp, please try sw_tai";
     }
-    if (call.return_type.ts_mode == TimestampMode::sw_tai &&
+    if (nsecs_type.ts_mode == TimestampMode::sw_tai &&
         !bpftrace_.delta_taitime_.has_value()) {
       call.addError() << "Failed to initialize sw_tai in "
                          "userspace. This is very unexpected.";
@@ -504,7 +504,7 @@ void TypeChecker::visit(Call &call)
                       << name << " provided)";
     };
 
-    const auto &type = call.vargs.at(0).type();
+    const auto &type = type_map_.type(call.vargs.at(0));
     if (!type.IsPtrTy() || !type.GetPointeeTy().IsCStructTy()) {
       logError(type.GetTy());
       return;
@@ -553,7 +553,7 @@ void TypeChecker::visit(Call &call)
     auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
     if (!maybe_func) {
       consumeError(std::move(maybe_func));
-      if (call.return_type.IsNoneTy()) {
+      if (type_map_.type(&call).IsNoneTy()) {
         LOG(BUG) << "Unknown builtin function " << call.func;
       }
       return;
@@ -583,18 +583,19 @@ void TypeChecker::visit(Call &call)
     std::vector<std::pair<std::string, SizedType>> args;
     for (size_t i = 0; i < argument_types->size(); i++) {
       const auto &[name, type] = argument_types->at(i);
+      const auto &varg_type = type_map_.type(call.vargs[i]);
       auto compat_arg_type = getCompatType(type);
       if (!compat_arg_type) {
         // If the required type is a **pointer**, and the provided type is
         // a **pointer**, then we let it slide. Just assume the user knows
         // what they are doing. The verifier will catch them out otherwise.
-        if (type.is<btf::Pointer>() && call.vargs[i].type().IsPtrTy()) {
-          args.emplace_back(name, call.vargs[i].type());
+        if (type.is<btf::Pointer>() && varg_type.IsPtrTy()) {
+          args.emplace_back(name, varg_type);
           continue;
         }
         call.addError() << "Unable to convert argument type, "
                         << "function requires '" << type << "', " << "found '"
-                        << typestr(call.vargs[i].type())
+                        << typestr(varg_type)
                         << "': " << compat_arg_type.takeError();
         continue;
       }
@@ -607,15 +608,15 @@ void TypeChecker::visit(Call &call)
     bool ok = true;
     for (size_t i = 0; i < args.size(); i++) {
       const auto &[name, type] = args[i];
-      if (type != call.vargs[i].type()) {
+      const auto &varg_type = type_map_.type(call.vargs[i]);
+      if (type != varg_type) {
         if (!name.empty()) {
           call.vargs[i].node().addError()
               << "Expected " << typestr(type) << " for argument `" << name
-              << "` got " << typestr(call.vargs[i].type());
+              << "` got " << typestr(varg_type);
         } else {
           call.vargs[i].node().addError()
-              << "Expected " << typestr(type) << " got "
-              << typestr(call.vargs[i].type());
+              << "Expected " << typestr(type) << " got " << typestr(varg_type);
         }
         ok = false;
       }
@@ -662,8 +663,9 @@ void TypeChecker::visit(Map &map)
   // is applied to the node at the `MapAccess` level.
   auto found_kind = bpf_map_type_.find(map.ident);
   if (found_kind != bpf_map_type_.end()) {
-    if (!bpf_map_types_compatible(map.value_type, found_kind->second)) {
-      auto map_type = get_bpf_map_type(map.value_type);
+    const auto &value_type = type_map_.map_value_type(map.ident);
+    if (!bpf_map_types_compatible(value_type, found_kind->second)) {
+      auto map_type = get_bpf_map_type(value_type);
       map.addError() << "Incompatible map types. Type from declaration: "
                      << get_bpf_map_type_str(found_kind->second)
                      << ". Type from value/key type: "
@@ -674,7 +676,7 @@ void TypeChecker::visit(Map &map)
 
 void TypeChecker::visit(VariableAddr &var_addr)
 {
-  if (var_addr.var_addr_type.IsNoneTy()) {
+  if (type_map_.type(&var_addr).IsNoneTy()) {
     var_addr.addError() << "No type available for variable "
                         << var_addr.var->ident;
   }
@@ -685,7 +687,7 @@ void TypeChecker::visit(ArrayAccess &arr)
   visit(arr.expr);
   visit(arr.indexpr);
 
-  const SizedType &type = arr.expr.type();
+  const SizedType &type = type_map_.type(arr.expr);
 
   if (type.IsPtrTy() && type.GetPointeeTy().GetSize() == 0) {
     arr.addError() << "The array index operator [] cannot be used "
@@ -706,17 +708,20 @@ void TypeChecker::visit(ArrayAccess &arr)
       arr.addError() << "the index " << integer->value
                      << " is out of bounds for array of size " << num;
     }
-  } else if (!arr.indexpr.type().IsIntTy() || arr.indexpr.type().IsSigned()) {
-    arr.addError() << "The array index operator [] only "
-                      "accepts positive (unsigned) integer indices. Got: "
-                   << arr.indexpr.type();
+  } else {
+    const auto &idx_type = type_map_.type(arr.indexpr);
+    if (!idx_type.IsIntTy() || idx_type.IsSigned()) {
+      arr.addError() << "The array index operator [] only "
+                        "accepts positive (unsigned) integer indices. Got: "
+                     << idx_type;
+    }
   }
 }
 
 void TypeChecker::visit(TupleAccess &acc)
 {
   visit(acc.expr);
-  const SizedType &type = acc.expr.type();
+  const SizedType &type = type_map_.type(acc.expr);
 
   if (!type.IsTupleTy()) {
     acc.addError() << "Can not access index '" << acc.index
@@ -735,8 +740,8 @@ void TypeChecker::visit(Binop &binop)
   visit(binop.left);
   visit(binop.right);
 
-  const auto &lht = binop.left.type();
-  const auto &rht = binop.right.type();
+  const auto &lht = type_map_.type(binop.left);
+  const auto &rht = type_map_.type(binop.right);
   bool is_int_binop = (lht.IsCastableMapTy() || lht.IsIntTy() ||
                        lht.IsBoolTy()) &&
                       (rht.IsCastableMapTy() || rht.IsIntTy() ||
@@ -782,7 +787,7 @@ void TypeChecker::visit(IfExpr &if_expr)
   visit(if_expr.left);
   visit(if_expr.right);
 
-  const Type &cond = if_expr.cond.type().GetTy();
+  const Type &cond = type_map_.type(if_expr.cond).GetTy();
 
   if (cond != Type::integer && cond != Type::pointer && cond != Type::boolean) {
     if_expr.addError() << "Invalid condition: " << cond;
@@ -796,7 +801,7 @@ void TypeChecker::visit(Jump &jump)
     visit(jump.return_value);
     if (dynamic_cast<Probe *>(top_level_node_)) {
       if (jump.return_value.has_value()) {
-        const auto &ty = jump.return_value->type();
+        const auto &ty = type_map_.type(*jump.return_value);
         if (!ty.IsIntegerTy()) {
           jump.addError() << "Probe return values can only be integers. Found "
                           << ty;
@@ -831,8 +836,8 @@ void TypeChecker::visit(For &f)
   // which require ctx access.
   CollectNodes<Builtin> builtins;
   builtins.visit(f.block);
-  for (const Builtin &builtin : builtins.nodes()) {
-    if (builtin.builtin_type.IsCtxAccess()) {
+  for (Builtin &builtin : builtins.nodes()) {
+    if (type_map_.type(&builtin).IsCtxAccess()) {
       builtin.addError() << "'" << builtin.ident
                          << "' builtin is not allowed in a for-loop";
     }
@@ -843,7 +848,7 @@ void TypeChecker::visit(FieldAccess &acc)
 {
   visit(acc.expr);
 
-  SizedType type = acc.expr.type();
+  SizedType type = type_map_.type(acc.expr);
   while (type.IsPtrTy()) {
     type = type.GetPointeeTy();
   }
@@ -872,13 +877,13 @@ void TypeChecker::visit(MapAccess &acc)
   visit(acc.map);
   visit(acc.key);
 
-  if (acc.map->type().IsCastableMapTy() &&
+  if (type_map_.map_value_type(acc.map->ident).IsCastableMapTy() &&
       !bpftrace_.feature_->has_helper_map_lookup_percpu_elem()) {
     acc.addError() << "Missing required kernel feature: map_lookup_percpu_elem";
   }
 
   // Validate map key type
-  const auto &key_type = acc.key.type();
+  const auto &key_type = type_map_.type(acc.key);
   if (key_type.IsPtrTy() && key_type.IsCtxAccess()) {
     // map functions only accepts a pointer to a element in the stack
     acc.key.node().addError() << "context cannot be part of a map key";
@@ -913,19 +918,18 @@ void TypeChecker::visit(Cast &cast)
   visit(cast.expr);
   visit(cast.typeof);
 
-  const auto &resolved_ty = cast.type();
+  const auto &resolved_ty = type_map_.type(&cast);
   if (resolved_ty.IsNoneTy()) {
     cast.addError() << "Incomplete cast, unknown type";
     return;
   }
 
-  auto rhs = cast.expr.type();
+  auto rhs = type_map_.type(cast.expr);
   if (rhs.IsCStructTy()) {
-    cast.addError() << "Cannot cast from struct type \"" << cast.expr.type()
-                    << "\"";
+    cast.addError() << "Cannot cast from struct type \"" << rhs << "\"";
     return;
   } else if (rhs.IsNoneTy()) {
-    cast.addError() << "Cannot cast from \"" << cast.expr.type() << "\" type";
+    cast.addError() << "Cannot cast from \"" << rhs << "\" type";
     return;
   }
 
@@ -1018,9 +1022,10 @@ void TypeChecker::visit(Tuple &tuple)
     visit(elem);
 
     // If elem type is none that means that the tuple is not yet resolved.
-    if (elem.type().IsMultiKeyMapTy()) {
+    const auto &elem_type = type_map_.type(elem);
+    if (elem_type.IsMultiKeyMapTy()) {
       elem.node().addError()
-          << "Map type " << elem.type() << " cannot exist inside a tuple.";
+          << "Map type " << elem_type << " cannot exist inside a tuple.";
     }
   }
 }
@@ -1031,9 +1036,10 @@ void TypeChecker::visit(Record &record)
     auto &elem = named_arg->expr;
     visit(elem);
 
-    if (elem.type().IsMultiKeyMapTy()) {
+    const auto &elem_type = type_map_.type(elem);
+    if (elem_type.IsMultiKeyMapTy()) {
       elem.node().addError()
-          << "Map type " << elem.type() << " cannot exist inside a record.";
+          << "Map type " << elem_type << " cannot exist inside a record.";
     }
   }
 }
@@ -1052,7 +1058,8 @@ void TypeChecker::visit(ExprStatement &expr)
     }
   }
 
-  if (expr.expr.type().IsNoneTy() || expr.expr.type().IsVoidTy()) {
+  const auto &expr_type = type_map_.type(expr.expr);
+  if (expr_type.IsNoneTy() || expr_type.IsVoidTy()) {
     warn_discarded = false;
   }
 
@@ -1071,7 +1078,7 @@ void TypeChecker::visit(AssignVarStatement &assignment)
     visit(assignment.var_decl);
   }
 
-  if (assignment.var()->var_type.IsNoneTy()) {
+  if (type_map_.type(assignment.var()).IsNoneTy()) {
     assignment.addError() << "Invalid expression for assignment";
   }
 }
@@ -1081,12 +1088,10 @@ void TypeChecker::visit(VarDeclStatement &decl)
   visit(decl.typeof);
 
   if (decl.typeof) {
-    const auto &ty = decl.typeof->type();
+    const auto &ty = type_map_.type(decl.typeof);
     if (!ty.IsNoneTy()) {
       if (!IsValidVarDeclType(ty)) {
         decl.addError() << "Invalid variable declaration type: " << ty;
-      } else {
-        decl.var->var_type = ty;
       }
     } else {
       // We couldn't resolve that specific type by now.
@@ -1109,7 +1114,7 @@ void TypeChecker::visit(Subprog &subprog)
   // Validate that arguments are set.
   visit(subprog.args);
   for (SubprogArg *arg : subprog.args) {
-    if (arg->typeof->type().IsNoneTy()) {
+    if (type_map_.type(arg->typeof).IsNoneTy()) {
       arg->addError() << "Unable to resolve argument type.";
     }
   }
@@ -1119,7 +1124,7 @@ void TypeChecker::visit(Subprog &subprog)
 
   // Validate that the return type is valid.
   visit(subprog.return_type);
-  if (subprog.return_type->type().IsNoneTy()) {
+  if (type_map_.type(subprog.return_type).IsNoneTy()) {
     subprog.return_type->addError()
         << "Unable to resolve suitable return type.";
   }
@@ -1170,10 +1175,11 @@ bool TypeChecker::check_arg(Call &call,
                             bool want_literal)
 {
   const auto &arg = call.vargs.at(index);
+  const auto &arg_type = type_map_.type(arg);
 
-  if (want_literal && (!arg.is_literal() || arg.type().GetTy() != type)) {
+  if (want_literal && (!arg.is_literal() || arg_type.GetTy() != type)) {
     call.addError() << call.func << "() expects a " << type << " literal ("
-                    << arg.type().GetTy() << " provided)";
+                    << arg_type.GetTy() << " provided)";
     if (type == Type::string) {
       // If the call requires a string literal and a positional parameter is
       // given, tell user to use str()
@@ -1183,9 +1189,9 @@ bool TypeChecker::check_arg(Call &call,
                               << pos_param->n << " as a string";
     }
     return false;
-  } else if (arg.type().GetTy() != type) {
+  } else if (arg_type.GetTy() != type) {
     call.addError() << call.func << "() only supports " << type
-                    << " arguments (" << arg.type().GetTy() << " provided)";
+                    << " arguments (" << arg_type.GetTy() << " provided)";
     return false;
   }
   return true;
@@ -1194,9 +1200,10 @@ bool TypeChecker::check_arg(Call &call,
 void RunTypeChecker(ASTContext &ast,
                     BPFtrace &b,
                     CDefinitions &c_definitions,
-                    TypeMetadata &types)
+                    TypeMetadata &types,
+                    const TypeMap &type_map)
 {
-  TypeChecker checker(ast, b, c_definitions, types);
+  TypeChecker checker(ast, b, c_definitions, types, type_map);
   checker.visit(ast.root);
 }
 

--- a/src/ast/passes/types/type_checker.h
+++ b/src/ast/passes/types/type_checker.h
@@ -7,12 +7,14 @@ class BPFtrace;
 namespace bpftrace::ast {
 
 class ASTContext;
+class TypeMap;
 struct CDefinitions;
 struct TypeMetadata;
 
 void RunTypeChecker(ASTContext &ast,
                     BPFtrace &b,
                     CDefinitions &c_definitions,
-                    TypeMetadata &types);
+                    TypeMetadata &types,
+                    const TypeMap &type_map);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/type_map.h
+++ b/src/ast/passes/types/type_map.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "ast/ast.h"
+#include "ast/pass_manager.h"
+#include "ast/passes/types/type_resolver.h"
+#include "log.h"
+
+namespace bpftrace::ast {
+
+class TypeMap : public State<"resolved-types"> {
+public:
+  explicit TypeMap(ResolvedTypes resolved_types)
+      : resolved_types_(std::move(resolved_types))
+  {
+  }
+
+  TypeMap(TypeMap &&) = default;
+  TypeMap &operator=(TypeMap &&) = default;
+
+  const SizedType &type(Node *node) const
+  {
+    auto it = resolved_types_.find(node);
+    if (it != resolved_types_.end()) {
+      return it->second;
+    }
+    return none_type();
+  }
+
+  const SizedType &type(const Expression &expr) const
+  {
+    return type(&expr.node());
+  }
+
+  const SizedType &map_key_type(const std::string &ident) const
+  {
+    auto it = resolved_types_.find(get_map_key_name(ident));
+    if (it != resolved_types_.end()) {
+      return it->second;
+    }
+    return none_type();
+  }
+
+  const SizedType &map_value_type(const std::string &ident) const
+  {
+    auto it = resolved_types_.find(get_map_value_name(ident));
+    if (it != resolved_types_.end()) {
+      return it->second;
+    }
+    return none_type();
+  }
+
+  const SizedType *find_map_key_type(const std::string &ident) const
+  {
+    auto it = resolved_types_.find(get_map_key_name(ident));
+    return it != resolved_types_.end() ? &it->second : nullptr;
+  }
+
+  const SizedType *find_map_value_type(const std::string &ident) const
+  {
+    auto it = resolved_types_.find(get_map_value_name(ident));
+    return it != resolved_types_.end() ? &it->second : nullptr;
+  }
+
+private:
+  static const SizedType &none_type()
+  {
+    static const SizedType none_ty = CreateNone();
+    return none_ty;
+  }
+
+  ResolvedTypes resolved_types_;
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1,6 +1,7 @@
 #include "ast/passes/types/type_resolver.h"
 #include "ast/ast.h"
 #include "ast/async_event_types.h"
+#include "ast/integer_types.h"
 #include "ast/passes/clang_parser.h"
 #include "ast/passes/collect_nodes.h"
 #include "ast/passes/fold_literals.h"
@@ -11,6 +12,7 @@
 #include "ast/passes/types/cast_creator.h"
 #include "ast/passes/types/type_applicator.h"
 #include "ast/passes/types/type_checker.h"
+#include "ast/passes/types/type_map.h"
 #include "ast/passes/types/type_system.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
@@ -403,7 +405,7 @@ private:
                             const std::string &name);
   Probe *get_probe();
   Probe *get_probe(Node &node, std::string name = "");
-  void check_stack_call(Call &call, bool kernel);
+  SizedType get_stack_type(Call &call, bool kernel);
 };
 
 SizedType binop_ptr(Binop &binop, const SizedType &lht, const SizedType &rht)
@@ -1203,11 +1205,9 @@ void TypeRuleCollector::visit(Call &call)
 
       return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
     } else if (call.func == "kstack") {
-      check_stack_call(call, true);
-      return_type = call.return_type;
+      return_type = get_stack_type(call, true);
     } else if (call.func == "ustack") {
-      check_stack_call(call, false);
-      return_type = call.return_type;
+      return_type = get_stack_type(call, false);
     } else if (call.func == "path") {
       auto call_type_size = bpftrace_.config_->max_strlen;
       if (call.vargs.size() == 2) {
@@ -1351,7 +1351,7 @@ void TypeRuleCollector::visit(BlockExpr &block)
 
 void TypeRuleCollector::visit(Boolean &boolean)
 {
-  resolver_.set_type(&boolean, boolean.type());
+  resolver_.set_type(&boolean, CreateBool());
 }
 
 SizedType update_cast_expr(const SizedType &cast_ty,
@@ -1778,7 +1778,7 @@ void TypeRuleCollector::visit(IfExpr &if_expr)
 
 void TypeRuleCollector::visit(Integer &integer)
 {
-  resolver_.set_type(&integer, integer.type());
+  resolver_.set_type(&integer, get_integer_type(integer.value));
 }
 
 void TypeRuleCollector::visit(Jump &jump)
@@ -1874,7 +1874,7 @@ void TypeRuleCollector::visit(MapAddr &map_addr)
 
 void TypeRuleCollector::visit(NegativeInteger &integer)
 {
-  resolver_.set_type(&integer, integer.type());
+  resolver_.set_type(&integer, get_signed_integer_type(integer.value));
 }
 
 void TypeRuleCollector::visit(PositionalParameter &param)
@@ -1974,7 +1974,7 @@ void TypeRuleCollector::visit(Sizeof &szof)
 
 void TypeRuleCollector::visit(String &str)
 {
-  auto type = str.type();
+  auto type = CreateString(str.value.size() + 1);
   type.SetAS(AddrSpace::kernel);
   resolver_.set_type(&str, type);
 }
@@ -1995,6 +1995,7 @@ void TypeRuleCollector::visit(Subprog &subprog)
       auto &ty = std::get<SizedType>(arg->typeof->record);
       if (resolve_struct_type(ty, *arg->typeof)) {
         resolver_.set_type(scoped_var, ty);
+        resolver_.set_type(arg->typeof, ty);
         if (ty.GetSize() != 0) {
           sized_decl_vars_.insert(scoped_var);
         }
@@ -2283,6 +2284,7 @@ void TypeRuleCollector::visit(VarDeclStatement &decl)
       return;
     }
     resolver_.set_type(scoped_var, ty);
+    resolver_.set_type(decl.typeof, ty);
     // Some declared types like 'string' have no size so we can factor in the
     // size of the assignment
     if (ty.GetSize() != 0) {
@@ -2532,9 +2534,9 @@ Probe *TypeRuleCollector::get_probe(Node &node, std::string name)
   return probe_;
 }
 
-void TypeRuleCollector::check_stack_call(Call &call, bool kernel)
+SizedType TypeRuleCollector::get_stack_type(Call &call, bool kernel)
 {
-  call.return_type = CreateStack(kernel);
+  auto return_type = CreateStack(kernel);
   StackType stack_type;
   stack_type.mode = bpftrace_.config_->stack_mode;
 
@@ -2574,7 +2576,7 @@ void TypeRuleCollector::check_stack_call(Call &call, bool kernel)
   if (stack_type.mode == StackMode::build_id && kernel) {
     call.addError() << "'build_id' stack mode can only be used for ustack";
   }
-  call.return_type = CreateStack(kernel, stack_type);
+  return CreateStack(kernel, stack_type);
 }
 
 LockedNodes TypeRuleCollector::get_locked_nodes()
@@ -2622,6 +2624,7 @@ Node *TypeRuleCollector::find_variable_scope(const std::string &var_ident,
 // - CastCreator
 // - TypeChecker
 // Read more about how all this works in type_resolution.md
+
 Pass CreateTypeResolverPass()
 {
   return Pass::create(
@@ -2632,11 +2635,10 @@ Pass CreateTypeResolverPass()
          CDefinitions &c_definitions,
          NamedParamDefaults &named_param_defaults,
          TypeMetadata &types,
-         MacroRegistry &macro_registry) {
+         MacroRegistry &macro_registry) -> TypeMap {
         // Fold up front
         fold(ast);
 
-        // Passed to TypeApplicator when all runs are complete
         ResolvedTypes resolved_types;
 
         std::vector<Comptime *> prev_comptimes;
@@ -2653,7 +2655,7 @@ Pass CreateTypeResolverPass()
                 << "Type resolution exceeded maximum iterations ("
                 << MAX_ITERATIONS
                 << "); possible infinite loop in comptime expressions";
-            return;
+            return TypeMap(ResolvedTypes{});
           }
 
           TypeResolver resolver;
@@ -2674,7 +2676,7 @@ Pass CreateTypeResolverPass()
           resolver.resolve(tr_collector.get_map_value_names());
 
           if (!ast.diagnostics().ok()) {
-            return;
+            return TypeMap(ResolvedTypes{});
           }
 
           resolved_types = resolver.get_resolved_types();
@@ -2690,7 +2692,7 @@ Pass CreateTypeResolverPass()
           fold(ast);
 
           if (!ast.diagnostics().ok()) {
-            return;
+            return TypeMap(ResolvedTypes{});
           }
 
           // Check if we haven't made progress resolving comptime expressions
@@ -2700,7 +2702,7 @@ Pass CreateTypeResolverPass()
             for (auto *comptime : next_comptimes) {
               comptime->addError() << "Unable to resolve comptime expression";
             }
-            return;
+            return TypeMap(ResolvedTypes{});
           }
 
           prev_comptimes = next_comptimes;
@@ -2711,15 +2713,40 @@ Pass CreateTypeResolverPass()
           should_rerun = !prev_comptimes.empty() || had_transforms;
         }
 
-        // Add the types to the AST nodes themselves
-        RunTypeApplicator(ast, resolved_types);
+        TypeMap type_map(std::move(resolved_types));
 
         // Apply casts in parts of the AST where we want the left and right
-        // sides to have the same type
-        RunCastCreator(ast, b);
+        // sides to have the same type.
+        RunCastCreator(ast, b, type_map);
+
+        // Re-resolve types for nodes created by CastCreator. This is just
+        // easier than having CastCreator update resolved_types
+        TypeResolver resolver;
+        auto collector = TypeRuleCollector(ast,
+                                           b,
+                                           mm,
+                                           c_definitions,
+                                           named_param_defaults,
+                                           types,
+                                           macro_registry,
+                                           resolver,
+                                           locked_nodes);
+        collector.visit(ast.root);
+        resolver.resolve(collector.get_map_value_names());
+        resolved_types = resolver.get_resolved_types();
+        type_map = TypeMap(std::move(resolved_types));
+
+        // Add the types to the AST nodes themselves
+        RunTypeApplicator(ast, type_map);
+
+        if (!ast.diagnostics().ok()) {
+          return TypeMap(ResolvedTypes{});
+        }
 
         // Run type checking as the final step
-        RunTypeChecker(ast, b, c_definitions, types);
+        RunTypeChecker(ast, b, c_definitions, types, type_map);
+
+        return type_map;
       });
 };
 

--- a/src/ast/passes/types/type_resolver.h
+++ b/src/ast/passes/types/type_resolver.h
@@ -58,6 +58,8 @@ inline std::string get_map_key_name(const std::string &ident)
   return ident + "__key";
 }
 
+class TypeMap;
+
 Pass CreateTypeResolverPass();
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/usdt_arguments.cpp
+++ b/src/ast/passes/usdt_arguments.cpp
@@ -28,8 +28,7 @@ public:
   {
     // The USDT arg function expects an long int type
     auto *int_arg = ast_.make_node<ast::Integer>(node.loc,
-                                                 static_cast<uint64_t>(arg),
-                                                 CreateInt64());
+                                                 static_cast<uint64_t>(arg));
     std::vector<Expression> args = { int_arg };
     Expression expr = ast_.make_node<ast::Call>(node.loc,
                                                 "usdt_arg",

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -636,7 +636,7 @@ macro len(e)
 //
 macro memcmp($left, $right, count)
 {
-  __memcmp((int8*)(&$left), (int8*)(&$right), count)
+  __memcmp((int8*)(&$left), (int8*)(&$right), (uint64)count)
 }
 
 macro memcmp($left, right, count)

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -68,7 +68,7 @@ macro is_literal(expr)
 
 macro usdt_arg(x)
 {
-  __usdt_arg((void *)ctx, x)
+  __usdt_arg((void *)ctx, (int64)x)
 }
 
 macro assert_userspace_probe(func) {

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -464,16 +464,18 @@ TEST_F(TypeCheckerTest, ternary_expressions)
        "Foo*)arg1 }");
   test(
       R"(kprobe:f { pid < 10000 ? ("a", "hellolongstr") : ("hellolongstr", "b") })",
-      ExpectedAST{ Program().WithProbe(
-          Probe({ "kprobe:f" },
-                { ExprStatement(
-                    If(Binop(Operator::LT, Builtin("pid"), Integer(10000)),
-                       Block({ ExprStatement(Tuple(
-                                   { String("a"), String("hellolongstr") })),
-                               Jump(ast::JumpType::RETURN) }),
-                       Block({ ExprStatement(Tuple(
-                                   { String("hellolongstr"), String("b") })),
-                               Jump(ast::JumpType::RETURN) }))) })) });
+      ExpectedAST{ Program().WithProbe(Probe(
+          { "kprobe:f" },
+          { ExprStatement(
+              If(Binop(Operator::LT,
+                       Builtin("pid"),
+                       Cast(Typeof(SizedType(Type::integer)), Integer(10000))),
+                 Block({ ExprStatement(
+                             Tuple({ String("a"), String("hellolongstr") })),
+                         Jump(ast::JumpType::RETURN) }),
+                 Block({ ExprStatement(
+                             Tuple({ String("hellolongstr"), String("b") })),
+                         Jump(ast::JumpType::RETURN) }))) })) });
 
   // Error location is incorrect: #3063
   test("kprobe:f { $x = pid < 10000 ? 3 : cat(\"/proc/uptime\"); exit(); }",
@@ -2116,60 +2118,68 @@ TEST_F(TypeCheckerTest, map_aggregations_implicit_cast)
   // When assigning an aggregation to a map
   // containing integers, the aggregation is
   // implicitly cast to an integer.
+  auto CastInt = [](auto &&expr) {
+    return Cast(Typeof(bpftrace::test::SizedType(Type::integer)),
+                std::forward<decltype(expr)>(expr));
+  };
   test("kprobe:f { @x = 1; @y = count(); @x = @y; }",
-       ExpectedAST{ Program().WithProbe(
-           Probe({ "kprobe:f" },
-                 { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-                   DiscardExpr(Call("count", { Map("@y"), Integer(0) })),
-                   AssignMapStatement(
-                       Map("@x"),
-                       Integer(0),
-                       Cast(Typeof(bpftrace::test::SizedType(Type::integer)),
-                            MapAccess(Map("@y"), Integer(0)))),
-                   Jump(ast::JumpType::RETURN) })) });
+       ExpectedAST{ Program().WithProbe(Probe(
+           { "kprobe:f" },
+           { AssignMapStatement(
+                 Map("@x"), CastInt(Integer(0)), CastInt(Integer(1))),
+             DiscardExpr(Call("count", { Map("@y"), CastInt(Integer(0)) })),
+             AssignMapStatement(Map("@x"),
+                                CastInt(Integer(0)),
+                                CastInt(
+                                    MapAccess(Map("@y"), CastInt(Integer(0))))),
+             Jump(ast::JumpType::RETURN) })) });
   test("kprobe:f { @x = 1; @y = sum(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             DiscardExpr(Call("sum", { Map("@y"), Integer(0), Integer(5) })),
-             AssignMapStatement(
-                 Map("@x"),
-                 Integer(0),
-                 Cast(Typeof(bpftrace::test::SizedType(Type::integer)),
-                      MapAccess(Map("@y"), Integer(0)))),
+           { AssignMapStatement(
+                 Map("@x"), CastInt(Integer(0)), CastInt(Integer(1))),
+             DiscardExpr(
+                 Call("sum", { Map("@y"), CastInt(Integer(0)), Integer(5) })),
+             AssignMapStatement(Map("@x"),
+                                CastInt(Integer(0)),
+                                CastInt(
+                                    MapAccess(Map("@y"), CastInt(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
   test("kprobe:f { @x = 1; @y = min(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             DiscardExpr(Call("min", { Map("@y"), Integer(0), Integer(5) })),
-             AssignMapStatement(
-                 Map("@x"),
-                 Integer(0),
-                 Cast(Typeof(bpftrace::test::SizedType(Type::integer)),
-                      MapAccess(Map("@y"), Integer(0)))),
+           { AssignMapStatement(
+                 Map("@x"), CastInt(Integer(0)), CastInt(Integer(1))),
+             DiscardExpr(
+                 Call("min", { Map("@y"), CastInt(Integer(0)), Integer(5) })),
+             AssignMapStatement(Map("@x"),
+                                CastInt(Integer(0)),
+                                CastInt(
+                                    MapAccess(Map("@y"), CastInt(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
   test("kprobe:f { @x = 1; @y = max(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             DiscardExpr(Call("max", { Map("@y"), Integer(0), Integer(5) })),
-             AssignMapStatement(
-                 Map("@x"),
-                 Integer(0),
-                 Cast(Typeof(bpftrace::test::SizedType(Type::integer)),
-                      MapAccess(Map("@y"), Integer(0)))),
+           { AssignMapStatement(
+                 Map("@x"), CastInt(Integer(0)), CastInt(Integer(1))),
+             DiscardExpr(
+                 Call("max", { Map("@y"), CastInt(Integer(0)), Integer(5) })),
+             AssignMapStatement(Map("@x"),
+                                CastInt(Integer(0)),
+                                CastInt(
+                                    MapAccess(Map("@y"), CastInt(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
   test("kprobe:f { @x = 1; @y = avg(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             DiscardExpr(Call("avg", { Map("@y"), Integer(0), Integer(5) })),
-             AssignMapStatement(
-                 Map("@x"),
-                 Integer(0),
-                 Cast(Typeof(bpftrace::test::SizedType(Type::integer)),
-                      MapAccess(Map("@y"), Integer(0)))),
+           { AssignMapStatement(
+                 Map("@x"), CastInt(Integer(0)), CastInt(Integer(1))),
+             DiscardExpr(
+                 Call("avg", { Map("@y"), CastInt(Integer(0)), Integer(5) })),
+             AssignMapStatement(Map("@x"),
+                                CastInt(Integer(0)),
+                                CastInt(
+                                    MapAccess(Map("@y"), CastInt(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
 
   // Assigning to a newly declared map
@@ -2971,7 +2981,9 @@ kprobe:f { $x = -1; $x = 10223372036854775807; }
                                 Cast(Typeof(SizedType(Type::integer)),
                                      Cast(Typeof(SizedType(Type::integer)),
                                           Integer(1)))),
-             AssignVarStatement(Variable("$x"), Integer(5)),
+             AssignVarStatement(Variable("$x"),
+                                Cast(Typeof(SizedType(Type::integer)),
+                                     Integer(5))),
              Jump(ast::JumpType::RETURN) })) });
   test("begin { $x = (int8)1; $x = (uint8)5; }",
        ExpectedAST{ Program().WithProbe(Probe(
@@ -3133,14 +3145,19 @@ TEST_F(TypeCheckerTest, mixed_int_like_binop)
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
            { DiscardExpr(
-                 Call("sum", { Map("@a"), Integer(0), NegativeInteger(-1) })),
+                 Call("sum",
+                      { Map("@a"),
+                        Cast(Typeof(SizedType(Type::integer)), Integer(0)),
+                        NegativeInteger(-1) })),
              AssignVarStatement(
                  Variable("$a"),
                  Binop(Operator::EQ,
                        Cast(Typeof(SizedType(Type::integer)),
                             Cast(Typeof(SizedType(Type::integer)), Integer(1))),
                        Cast(Typeof(SizedType(Type::integer)),
-                            MapAccess(Map("@a"), Integer(0))))),
+                            MapAccess(Map("@a"),
+                                      Cast(Typeof(SizedType(Type::integer)),
+                                           Integer(0)))))),
              Jump(ast::JumpType::RETURN) })) });
 }
 
@@ -3818,7 +3835,7 @@ TEST_F(TypeCheckerTest, mixed_tuple)
           { "begin" },
           { AssignMapStatement(
                 Map("@a"),
-                Integer(0),
+                Cast(Typeof(SizedType(Type::integer)), Integer(0)),
                 Tuple(
                     { Cast(Typeof(SizedType(Type::integer)
                                       .WithSize(4)
@@ -3826,17 +3843,25 @@ TEST_F(TypeCheckerTest, mixed_tuple)
                            Cast(Typeof(SizedType(Type::integer)), Integer(1))),
                       Cast(Typeof(SizedType(Type::string).WithSize(9)),
                            String("hi")) })),
-            AssignMapStatement(Map("@b"),
-                               Integer(0),
-                               Tuple({ Cast(Typeof(SizedType(Type::integer)),
-                                            Integer(2)),
-                                       String("hellostr") })),
+            AssignMapStatement(
+                Map("@b"),
+                Cast(Typeof(SizedType(Type::integer)), Integer(0)),
+                Tuple({ Cast(Typeof(SizedType(Type::integer)), Integer(2)),
+                        String("hellostr") })),
             AssignMapStatement(
                 Map("@a"),
-                Integer(0),
+                Cast(Typeof(SizedType(Type::integer)), Integer(0)),
                 Tuple({ Cast(Typeof(SizedType(Type::integer)),
-                             TupleAccess(MapAccess(Map("@b"), Integer(0)), 0)),
-                        TupleAccess(MapAccess(Map("@b"), Integer(0)), 1) })),
+                             TupleAccess(MapAccess(Map("@b"),
+                                                   Cast(Typeof(SizedType(
+                                                            Type::integer)),
+                                                        Integer(0))),
+                                         0)),
+                        TupleAccess(
+                            MapAccess(Map("@b"),
+                                      Cast(Typeof(SizedType(Type::integer)),
+                                           Integer(0))),
+                            1) })),
             Jump(ast::JumpType::RETURN) })) });
   test(
       R"(begin { print(if (pid == 1) { ((int16)1, "hi") } else { ((uint16)2, "hellostr") }); })",
@@ -3845,7 +3870,10 @@ TEST_F(TypeCheckerTest, mixed_tuple)
           { ExprStatement(Block(
               { ExprStatement(Call(
                     "print",
-                    { If(Binop(Operator::EQ, Builtin("pid"), Integer(1)),
+                    { If(Binop(Operator::EQ,
+                               Builtin("pid"),
+                               Cast(Typeof(SizedType(Type::integer)),
+                                    Integer(1))),
                          Tuple(
                              { Cast(Typeof(SizedType(Type::integer)
                                                .WithSize(4)
@@ -4394,7 +4422,9 @@ TEST_F(TypeCheckerTest, for_loop_variables_modified_during_loop)
       ExpectedAST{ Program().WithProbe(Probe(
           { "begin" },
           {
-              AssignVarStatement(Variable("$var"), Integer(0)),
+              AssignVarStatement(Variable("$var"),
+                                 Cast(Typeof(SizedType(Type::integer)),
+                                      Integer(0))),
               AssignMapStatement(Map("@map"), Integer(0), Integer(1)),
               For(Variable("$kv"),
                   Map("@map"),


### PR DESCRIPTION
Stacked PRs:
 * #5034
 * #5033
 * #5032
 * #5029
 * #5028
 * #5027
 * #5026
 * #5024
 * __->__#5023
 * #5058


--- --- ---

### [TypeMap] Create immutable TypeMap pass state


Create a TypeMap object that will be used by passes which follow type
resolution. The eventual goal is to completely remove SizedType members and
methods from the AST node classes and rely on a single immutable object
that stores all the types for the nodes.

Storing types on the AST nodes themselves has the following problems:
- The types are mutable throughout every pass in the bpftrace compile
  pipeline making them inherently difficult to debug. Having the
  type_resolver be a single source of truth for the types makes them easier
  to debug and leads to less issues when code is changed in other passes.
- All passes that come prior to type resolution don't need to know the
  types of the AST nodes so these objects are just carrying extra state for
  no reason.
- It makes the AST nodes simpler.
- Using a TypeMap forces mutations to the AST graph to come before or
  during type_resolution in order for these nodes to exist in the TypeMap,
  which prevents possible hard-to-debug issues where by added nodes don't
  have the correct types.

This change also has the vistors called in type_resolver use the new
TypeMap. This involved a bit of refactoring to ensure that only
TypeApplicator mutates or references the AST when it comes to the types.
TypeApplicator will eventually be deleted when types are looked up
exclusively in the TypeMap.

Small note: we have to add explicit casts to integers now so as not to rely
on their AST SizedTypes. This has no behavior change.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>