### PR TITLE
[TypeMap] put types in NamedParamInfo

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -206,7 +206,7 @@ public:
   explicit CodegenLLVM(ASTContext &ast,
                        BPFtrace &bpftrace,
                        CDefinitions &c_definitions,
-                       NamedParamDefaults &named_param_defaults,
+                       NamedParamInfo &named_param_info,
                        LLVMContext &llvm_ctx,
                        ExpansionResult &expansions,
                        const TypeMap &type_map);
@@ -405,7 +405,7 @@ private:
   ASTContext &ast_;
   BPFtrace &bpftrace_;
   CDefinitions &c_definitions_;
-  NamedParamDefaults &named_param_defaults_;
+  NamedParamInfo &named_param_info_;
   LLVMContext &llvm_ctx_;
   ExpansionResult &expansions_;
   const TypeMap &type_map_;
@@ -458,14 +458,14 @@ private:
 CodegenLLVM::CodegenLLVM(ASTContext &ast,
                          BPFtrace &bpftrace,
                          CDefinitions &c_definitions,
-                         NamedParamDefaults &named_param_defaults,
+                         NamedParamInfo &named_param_info,
                          LLVMContext &llvm_ctx,
                          ExpansionResult &expansions,
                          const TypeMap &type_map)
     : ast_(ast),
       bpftrace_(bpftrace),
       c_definitions_(c_definitions),
-      named_param_defaults_(named_param_defaults),
+      named_param_info_(named_param_info),
       llvm_ctx_(llvm_ctx),
       expansions_(expansions),
       type_map_(type_map),
@@ -2754,7 +2754,7 @@ ScopedExpr CodegenLLVM::visit(TupleAccess &acc)
 
 ScopedExpr CodegenLLVM::visit(MapAccess &acc)
 {
-  if (named_param_defaults_.defaults.contains(acc.map->ident)) {
+  if (named_param_info_.defaults.contains(acc.map->ident)) {
     const auto &val_type = type_map_.map_value_type(acc.map->ident);
     if (val_type.IsStringTy()) {
       const auto max_strlen = bpftrace_.config_->max_strlen;
@@ -4829,14 +4829,14 @@ Pass CreateCompilePass()
                          [[maybe_unused]] ControlFlowChecked &control_flow,
                          BPFtrace &bpftrace,
                          CDefinitions &c_definitions,
-                         NamedParamDefaults &named_param_defaults,
+                         NamedParamInfo &named_param_info,
                          CompileContext &ctx,
                          ExpansionResult &expansions,
                          TypeMap &type_map) mutable {
                         CodegenLLVM llvm(ast,
                                          bpftrace,
                                          c_definitions,
-                                         named_param_defaults,
+                                         named_param_info,
                                          *ctx.context,
                                          expansions,
                                          type_map);

--- a/src/ast/passes/named_param.cpp
+++ b/src/ast/passes/named_param.cpp
@@ -15,7 +15,7 @@ public:
   void visit(Expression &expr);
 
   std::unordered_map<std::string, globalvars::GlobalVarInfo> used_args;
-  NamedParamDefaults defaults;
+  NamedParamInfo defaults;
 
 private:
   ASTContext &ast_;
@@ -71,29 +71,31 @@ void NamedParamPass::visit(Expression &expr)
   globalvars::GlobalVarValue np_default;
 
   auto *map_node = ast_.make_node<Map>(call->loc, arg_name->value);
-  map_node->key_type = CreateInt64();
 
+  SizedType val_type;
   if (call->vargs.size() == 1) {
     // boolean
-    map_node->value_type = CreateBool();
+    val_type = CreateBool();
     np_default = false;
   } else if (auto *default_value = call->vargs.at(1).as<Boolean>()) {
     // boolean
-    map_node->value_type = CreateBool();
+    val_type = CreateBool();
     np_default = default_value->value;
   } else if (auto *default_value = call->vargs.at(1).as<String>()) {
     // string
-    map_node->value_type = CreateString(bpftrace_.config_->max_strlen);
+    val_type = CreateString(bpftrace_.config_->max_strlen);
     np_default = default_value->value;
   } else if (auto *default_value = call->vargs.at(1).as<Integer>()) {
     // unsigned integer
-    map_node->value_type = CreateUInt64();
+    val_type = CreateUInt64();
     np_default = default_value->value;
   } else if (auto *default_value = call->vargs.at(1).as<NegativeInteger>()) {
     // signed integer
-    map_node->value_type = CreateInt64();
+    val_type = CreateInt64();
     np_default = default_value->value;
   }
+
+  defaults.map_val_types[arg_name->value] = std::move(val_type);
 
   if (used_args.contains(arg_name->value)) {
     if (used_args.at(arg_name->value).value != np_default) {
@@ -154,7 +156,7 @@ void NamedParamPass::visit(Expression &expr)
 
 Pass CreateNamedParamsPass()
 {
-  auto fn = [](ASTContext &ast, BPFtrace &b) -> Result<NamedParamDefaults> {
+  auto fn = [](ASTContext &ast, BPFtrace &b) -> Result<NamedParamInfo> {
     NamedParamPass np_pass(ast, b);
     np_pass.visit(ast.root);
 

--- a/src/ast/passes/named_param.h
+++ b/src/ast/passes/named_param.h
@@ -5,9 +5,10 @@
 
 namespace bpftrace::ast {
 
-class NamedParamDefaults : public ast::State<"named_params_defaults"> {
+class NamedParamInfo : public ast::State<"named_param_info"> {
 public:
   std::unordered_map<std::string, globalvars::GlobalVarInfo> defaults;
+  std::unordered_map<std::string, SizedType> map_val_types;
 };
 
 Pass CreateNamedParamsPass();

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -31,7 +31,7 @@ class ResourceAnalyser : public Visitor<ResourceAnalyser> {
 public:
   ResourceAnalyser(BPFtrace &bpftrace,
                    MapMetadata &mm,
-                   NamedParamDefaults &named_param_defaults,
+                   NamedParamInfo &named_param_info,
                    const TypeMap &type_map);
 
   using Visitor<ResourceAnalyser>::visit;
@@ -70,7 +70,7 @@ private:
   RequiredResources resources_;
   BPFtrace &bpftrace_;
   MapMetadata map_metadata_;
-  NamedParamDefaults &named_param_defaults_;
+  NamedParamInfo &named_param_info_;
   const TypeMap &type_map_;
 
   // Current probe we're analysing
@@ -84,11 +84,11 @@ private:
 
 ResourceAnalyser::ResourceAnalyser(BPFtrace &bpftrace,
                                    MapMetadata &mm,
-                                   NamedParamDefaults &named_param_defaults,
+                                   NamedParamInfo &named_param_info,
                                    const TypeMap &type_map)
     : bpftrace_(bpftrace),
       map_metadata_(mm),
-      named_param_defaults_(named_param_defaults),
+      named_param_info_(named_param_info),
       type_map_(type_map)
 {
 }
@@ -448,8 +448,8 @@ void ResourceAnalyser::visit(Map &map)
 {
   Visitor<ResourceAnalyser>::visit(map);
 
-  auto it = named_param_defaults_.defaults.find(map.ident);
-  if (it != named_param_defaults_.defaults.end()) {
+  auto it = named_param_info_.defaults.find(map.ident);
+  if (it != named_param_info_.defaults.end()) {
     resources_.global_vars.add_named_param(map.ident,
                                            it->second.value,
                                            it->second.description);
@@ -655,9 +655,9 @@ Pass CreateResourcePass()
   auto fn = [](ASTContext &ast,
                BPFtrace &b,
                MapMetadata &mm,
-               NamedParamDefaults &named_param_defaults,
+               NamedParamInfo &named_param_info,
                TypeMap &type_map) {
-    ResourceAnalyser analyser(b, mm, named_param_defaults, type_map);
+    ResourceAnalyser analyser(b, mm, named_param_info, type_map);
     analyser.visit(ast.root);
     b.resources = analyser.resources();
   };

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -258,7 +258,7 @@ public:
                              BPFtrace &bpftrace,
                              MapMetadata &map_metadata,
                              CDefinitions &c_definitions,
-                             NamedParamDefaults &named_param_defaults,
+                             NamedParamInfo &named_param_info,
                              TypeMetadata &type_metadata,
                              const MacroRegistry &macro_registry,
                              TypeResolver &resolver,
@@ -267,7 +267,7 @@ public:
         bpftrace_(bpftrace),
         map_metadata_(map_metadata),
         c_definitions_(c_definitions),
-        named_param_defaults_(named_param_defaults),
+        named_param_info_(named_param_info),
         type_metadata_(type_metadata),
         macro_registry_(macro_registry),
         resolver_(resolver),
@@ -331,7 +331,7 @@ private:
   BPFtrace &bpftrace_;
   MapMetadata &map_metadata_;
   CDefinitions &c_definitions_;
-  NamedParamDefaults &named_param_defaults_;
+  NamedParamInfo &named_param_info_;
   TypeMetadata &type_metadata_;
   const MacroRegistry &macro_registry_;
   TypeResolver &resolver_;
@@ -1807,12 +1807,10 @@ void TypeRuleCollector::visit(Map &map)
 
   // Named param maps (from getopt()) are read-only and have their types pre-set
   // by the NamedParamsPass.
-  // TODO: consider passing these values in NamedParamDefaults instead of
-  // setting them on the AST
-  if (named_param_defaults_.defaults.contains(map.ident) &&
-      !map.value_type.IsNoneTy()) {
-    resolver_.set_type(value_name, map.value_type);
-    resolver_.set_type(key_name, map.key_type);
+  auto it = named_param_info_.map_val_types.find(map.ident);
+  if (it != named_param_info_.map_val_types.end()) {
+    resolver_.set_type(value_name, it->second);
+    resolver_.set_type(key_name, CreateInt64());
   }
 
   if (introspection_level_ > 0) {
@@ -2630,7 +2628,7 @@ Pass CreateTypeResolverPass()
          BPFtrace &b,
          MapMetadata &mm,
          CDefinitions &c_definitions,
-         NamedParamDefaults &named_param_defaults,
+         NamedParamInfo &named_param_info,
          TypeMetadata &types,
          MacroRegistry &macro_registry) -> TypeMap {
         // Fold up front
@@ -2660,7 +2658,7 @@ Pass CreateTypeResolverPass()
                                                 b,
                                                 mm,
                                                 c_definitions,
-                                                named_param_defaults,
+                                                named_param_info,
                                                 types,
                                                 macro_registry,
                                                 resolver,
@@ -2723,7 +2721,7 @@ Pass CreateTypeResolverPass()
                                            b,
                                            mm,
                                            c_definitions,
-                                           named_param_defaults,
+                                           named_param_info,
                                            types,
                                            macro_registry,
                                            resolver,


### PR DESCRIPTION
Stacked PRs:
 * #5034
 * #5063
 * #5033
 * #5032
 * __->__#5029


--- --- ---

### [TypeMap] put types in NamedParamInfo


Instead of storing the types on the AST nodes, which we are trying to move
away from, store them in NamedParamInfo (formerly NamedParamDefaults).

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>