### PR TITLE
Fix list_modules check

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1534,9 +1534,13 @@ std::set<std::string> BPFtrace::list_modules(const ast::ASTContext &ctx,
           clear_target = false;
         }
 
-        for (std::string match : probe_matcher.get_matches_for_ap(*ap)) {
-          auto module = util::erase_prefix(match);
-          modules.insert(module);
+        if (util::has_wildcard(ap->target)) {
+          for (std::string match : probe_matcher.get_matches_for_ap(*ap)) {
+            auto module = util::erase_prefix(match);
+            modules.insert(module);
+          }
+        } else {
+          modules.insert(ap->target);
         }
 
         if (clear_target)

--- a/src/symbols/kernel.cpp
+++ b/src/symbols/kernel.cpp
@@ -656,10 +656,13 @@ ModuleSet KernelInfoImpl::get_modules(
     // Add everything that is loaded.
     return modules_loaded_;
   } else if (!util::has_wildcard(*mod_name)) {
-    // Just return the single module.
-    ModuleSet single;
-    single.emplace(*mod_name);
-    return single;
+    ModuleSet filtered;
+    for (const auto &mod : modules_loaded_) {
+      if (mod == *mod_name) {
+        filtered.emplace(mod);
+      }
+    }
+    return filtered;
   } else {
     // Match all loaded modules that are not yet in the populated list.
     ModuleSet filtered;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -133,7 +133,7 @@ AFTER ./testprogs/syscall read
 
 NAME kprobe_module_missing
 PROG kprobe:nonsense:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT_REGEX .* ERROR: No matches for kprobe nonsense:vfs_read.
+EXPECT_REGEX .* ERROR: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
 WILL_FAIL
 
 NAME kprobe_wildcard_all_leading_underscore


### PR DESCRIPTION
Stacked PRs:
 * #5017
 * __->__#5030


--- --- ---

### Fix list_modules check


If the probe module is provided in full we should check if it's loaded.

Updated the runtime test.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>