### PR TITLE
CMake: Fix detection of compiler options

### DIFF
--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -1,13 +1,12 @@
 set_property(GLOBAL APPEND_STRING PROPERTY testprog_cflags "-g -O0")
 
 # Check and add CFLAG to testprog_cflags
+include(CheckCCompilerFlag)
 function(test_and_add_testprog_cflag flag)
-  try_compile(FLAG_AVAILABLE
-    ${CMAKE_CURRENT_BINARY_DIR}
-    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/simple_struct.c
-    LINK_OPTIONS ${flag}
-  )
-  if(${FLAG_AVAILABLE})
+  # We need unique variable name since check_c_compiler_flag caches results
+  string(MAKE_C_IDENTIFIER "HAVE_FLAG_${flag}" flag_var)
+  check_c_compiler_flag("${flag}" ${flag_var})
+  if(${${flag_var}})
     set_property(GLOBAL APPEND_STRING PROPERTY testprog_cflags " ${flag}")
   else()
     message(STATUS "${CMAKE_C_COMPILER} does not support ${flag}")


### PR DESCRIPTION
The detection of compiler options seems to be broken as I'm getting build failures on s390x:

    cc1: error: unrecognized command-line option ‘-mno-omit-leaf-frame-pointer’

I believe the problem is that we're passing a compiler (not linker) flag to `LINK_OPTIONS` of `try_compile`.

Fix the issue by using the dedicated `check_c_compiler_flag` function.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
