### PR TITLE
Don't strip module name for kprobes

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -489,7 +489,12 @@ Result<std::unique_ptr<AttachedKprobeProbe>> AttachedKprobeProbe::make(
   // additional checking here because this has already been verified during
   // attachpoint verification. We will automatically propagate any failures
   // to attach form the libbpf layer in the future.
-  std::string funcname = probe.attach_point;
+  std::string funcname;
+  if (!probe.path.empty() && probe.path != "vmlinux") {
+    funcname = probe.path + ":" + probe.attach_point;
+  } else {
+    funcname = probe.attach_point;
+  }
 
   // The kprobe can either be defined by a symbol+offset or an address:
   // For symbol+offset kprobe, we need to check the validity of the offset.


### PR DESCRIPTION
Kprobes symbol address resolution logic supports an optional module prefix. If specified, only that module is searched; otherwise both kernel symbols and all modules are considered. [1]

Bpftrace supports the same "module:function" syntax, but only the function name is currently passed to `bpf_program__attach_kprobe_opts()`. If multiple modules contain a function with the same name, the kernel will reject the probe (failed uniqueness check) even if the target module was specified by the user.

Fix it by also passing the module name to the kernel.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/trace/trace_kprobe.c?h=v6.12.74#n765

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
