### PR TITLE
Fix bug in Sizeof type resolution

### DIFF
--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1934,10 +1934,12 @@ void TypeRuleCollector::visit(Record &record)
 
 void TypeRuleCollector::visit(Sizeof &szof)
 {
+  // This type will change later depending on what integer literal it resolves
+  // to for now set it to the smallest uint
   if (std::holds_alternative<SizedType>(szof.record)) {
     auto &ty = std::get<SizedType>(szof.record);
     resolve_struct_type(ty, szof);
-    resolver_.set_type(&szof, ty);
+    resolver_.set_type(&szof, CreateUInt8());
   } else {
     auto &expr = std::get<Expression>(szof.record);
     ++introspection_level_;
@@ -1947,9 +1949,6 @@ void TypeRuleCollector::visit(Sizeof &szof)
         .output = &szof,
         .inputs = { &expr.node() },
         .resolve = [&szof](const std::vector<SizedType> &) -> SizedType {
-          // This will change later depending on
-          // what integer literal it resolves to
-          // for now set it to the smallest uint
           return CreateUInt8();
         },
     });

--- a/tests/type_resolver.cpp
+++ b/tests/type_resolver.cpp
@@ -1002,6 +1002,10 @@ TEST_F(TypeResolverTest, binop)
     EXPECT_EQ(var_type(ast, "$a"), CreateInt64());
   }
   {
+    auto ast = test(R"(begin { $a = (uint8)1 * sizeof(uint64 *); })");
+    EXPECT_EQ(var_type(ast, "$a"), CreateUInt64());
+  }
+  {
     auto ast = test(R"(begin { $a = ((uint32)1 == (uint32)2); })");
     EXPECT_EQ(var_type(ast, "$a"), CreateBool());
   }


### PR DESCRIPTION
Stacked PRs:
 * __->__#5037


--- --- ---

### Fix bug in Sizeof type resolution


Sizeof for SizedType should yield a Uint8 until we can resolve the actual
size.

Signed-off-by: Jordan Rome <linux@jordanrome.com>