### PR TITLE
Fix RUNTIME_TESTS_FILTER application in ci.py

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -293,7 +293,10 @@ def run_runtime_tests():
     """Runs runtime tests, under a controlled kernel if requested"""
     cmd = ["./tests/runtime-tests.sh"]
     if RUNTIME_TESTS_FILTER:
-        cmd.append(f"--filter=\"{RUNTIME_TESTS_FILTER}\"")
+        if NIX_TARGET_KERNEL:
+            cmd.append(f"--filter='{RUNTIME_TESTS_FILTER}'")
+        else:
+            cmd.append(f"--filter={RUNTIME_TESTS_FILTER}")
     run_with_kernel(cmd)
 
 


### PR DESCRIPTION
Stacked PRs:
 * #5039
 * __->__#5038


--- --- ---

### Fix RUNTIME_TESTS_FILTER application in ci.py


Remove the escaped quotes which was causing these quotes to be included in
the test name and making 0 runtime tests run in LLVM 21 + sanitizers.
However we need to add quotes for when we're running in a VM.

Signed-off-by: Jordan Rome <linux@jordanrome.com>