### PR TITLE
Filter out the test causing soft lockups in the VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
           NIX_TARGET: .#bpftrace-llvm21
           NIX_TARGET_KERNEL: .#kernel-6_14
           TOOLS_TEST_DISABLE: runqlen.bt # Need host 6.14 kernel
+          # This test causes soft lockups in the VM
+          RUNTIME_TESTS_FILTER: "-basic.parallel map access"
         - NAME: AOT (LLVM 21 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm21


### PR DESCRIPTION
Stacked PRs:
 * __->__#5039
 * #5038


--- --- ---

### Filter out the test causing soft lockups in the VM


"basic.parallel map" access causes soft lockups in the Latest kernel (LLVM
21 Debug) CI configuration so let's filter it out.

Signed-off-by: Jordan Rome <linux@jordanrome.com>