### PR TITLE
Remove extra spaces from arg when listing probes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -792,7 +792,9 @@ void list_probes(BPFtrace& bpftrace,
                  << search << "\' as a search pattern.";
   }
 
-  for (auto& probe : util::split_string(search, ',')) {
+  for (auto& rawprobe : util::split_string(search, ',')) {
+    std::string probe = util::normalize_whitespace(rawprobe);
+
     bool is_search_a_type = is_type_name(probe);
 
     // Ensure that BTF is loaded for all listing.

--- a/src/util/strings.cpp
+++ b/src/util/strings.cpp
@@ -119,4 +119,22 @@ bool is_str_bool_falsy(const std::string &value)
   return val == "0" || val == "false" || val == "off" || val == "no";
 }
 
+// Replace any number of consecutive spaces at any position in a string with a
+// single space, while removing all leading and trailing spaces.
+// This function will create a new string.
+std::string normalize_whitespace(const std::string &input)
+{
+  std::string copy = input;
+
+  trim(copy);
+
+  auto unique_end =
+      std::ranges::unique(copy.begin(), copy.end(), [](char l, char r) {
+        return std::isspace(l) && std::isspace(r);
+      }).begin();
+  copy.erase(unique_end, copy.end());
+
+  return copy;
+}
+
 } // namespace bpftrace::util

--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -44,4 +44,6 @@ std::string to_lower(const std::string &original);
 bool is_str_bool_truthy(const std::string &value);
 bool is_str_bool_falsy(const std::string &value);
 
+std::string normalize_whitespace(const std::string &input);
+
 } // namespace bpftrace::util


### PR DESCRIPTION
When listing probes, extra spaces will prevent any probes or structures from being matched. We should remove the extra spaces.

For example, the follow cmds works fine:

    $ sudo bpftrace -lv 'kprobe:vfs_read, kprobe:vfs_write'
    $ sudo bpftrace -lv '  struct   file ,   struct fd   '
    $ sudo bpftrace -lv "$(echo -e '  struct \t  file ,\tstruct fd\t')"

At the same time, printing a prompt message for probes that do not match, instead of remaining silent, is very helpful to users.

    $ sudo bpftrace -l 'kprobe:_nonsense_,kprobe:vfs_read'
    WARNING: No probe was matched for kprobe:_nonsense_
    kprobe:vfs_read
