### PR TITLE
Add support for address kprobes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to
   - [#4984](https://github.com/bpftrace/bpftrace/pull/4984)
 - Add `--traceable-functions` to allow the user to provide the list of kernel functions that can be probed
   - [#5014](https://github.com/bpftrace/bpftrace/pull/5014)
+- Add support for address kprobes
+  - [#5041](https://github.com/bpftrace/bpftrace/pull/5041)
 #### Changed
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)

--- a/docs/language.md
+++ b/docs/language.md
@@ -1235,7 +1235,9 @@ fexit:fget {
 
 * `kprobe[:module]:fn`
 * `kprobe[:module]:fn+offset`
+* `kprobe:addr`
 * `kretprobe[:module]:fn`
+* `kretprobe:addr`
 
 **short names**
 
@@ -1299,7 +1301,7 @@ kprobe:kvm:x86_emulate_insn
 
 See [BTF Support](#btf-support) for more details.
 
-`kprobe` s are not limited to function entry, they can be attached to any instruction in a function by specifying an offset from the start of the function.
+`kprobe` s are not limited to function entry, they can be attached to any instruction in a function by specifying an offset from the start of the function or by providing the bare address of the function, which is useful if there are multiple functions with the same name. The bare address variant `kprobe:addr` requires the `--unsafe` flag.
 
 `kretprobe` s trigger on the return from a kernel function.
 Return probes do not have access to the function (input) arguments, only to the return value (through `retval`).

--- a/src/ast/passes/ap_probe_expansion.cpp
+++ b/src/ast/passes/ap_probe_expansion.cpp
@@ -348,6 +348,11 @@ void ProbeAndApExpander::visit(AttachPointList &aps)
                                     funcname + " is not loaded.";
             }
           }
+
+          if (ap->address != 0) {
+            new_aps.push_back(ap); // skip pre-filtering if probing by address
+            break;
+          }
         }
 
         // We do this pre-filtering primarily for probes where we have to look

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -39,11 +39,11 @@ private:
 void AttachPointChecker::visit(AttachPoint &ap)
 {
   if (ap.provider == "kprobe" || ap.provider == "kretprobe") {
-    if (ap.func.empty())
-      ap.addError() << "kprobes should be attached to a function";
+    if (ap.func.empty() && ap.address == 0)
+      ap.addError() << "kprobes should be attached to a function or an address";
     // Warn if user tries to attach to a non-traceable function
     if (bpftrace_.config_->missing_probes != ConfigMissingProbes::ignore &&
-        !util::has_wildcard(ap.func) &&
+        !util::has_wildcard(ap.func) && !ap.func.empty() &&
         !func_info_state_.kernel_info().is_traceable(ap.func)) {
       ap.addWarning() << ap.func
                       << " is not traceable (either non-existing, inlined, "
@@ -677,9 +677,21 @@ AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset)
     }
     ap_->func_offset = *res;
   }
-  // Default case (eg kprobe:func)
+  // Default case (eg "kprobe:(addr|func)")
   else {
-    ap_->func = parts_[func_idx];
+    auto res = util::to_uint(parts_[func_idx]);
+    if (res) {
+      // We don't check whether the address is valid (it's passed directly to
+      // the kernel), so allow this only in unsafe mode.
+      if (bpftrace_.safe_mode_) {
+        errs_ << "Probing by address requires --unsafe" << std::endl;
+        return INVALID;
+      }
+      ap_->address = *res;
+    } else {
+      ap_->func = parts_[func_idx];
+      consumeError(std::move(res)); // ignore the parse error
+    }
   }
 
   return OK;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -142,40 +142,22 @@ Result<uint64_t> resolve_offset_kprobe(Probe &probe)
   if (is_symbol_kprobe && probe.func_offset == 0)
     return offset;
 
-  // Setup the symbol to resolve, either using the address or the name.
+  // To validate an arbitrary address, we'd need to check symtabs of vmlinux
+  // and all modules, as well as know their load addresses. Since we support
+  // address probes only in unsafe mode anyway, validation is deferred to the
+  // kernel. This function is only called for sym+offset kprobes.
+  assert(is_symbol_kprobe);
+
   struct symbol sym = {};
-  if (is_symbol_kprobe)
-    sym.name = probe.attach_point;
-  else
-    sym.address = probe.address;
+  sym.name = probe.attach_point;
 
   auto path = symbols::find_vmlinux(&sym);
   if (!path.has_value()) {
-    if (!is_symbol_kprobe) {
-      return make_error<AttachError>("Could not resolve address: " +
-                                     std::to_string(probe.address));
-    }
-
     LOG(V1) << "Could not resolve symbol " << probe.attach_point
             << ". Skipping usermode offset checking.";
     LOG(V1) << "The kernel will verify the safety of the location but "
                "will also allow the offset to be in a different symbol.";
     return offset;
-  }
-
-  // Populate probe_ fields according to the resolved symbol.
-  if (is_symbol_kprobe) {
-    probe.address = sym.start + probe.func_offset;
-  } else {
-    probe.attach_point = std::move(sym.name);
-    if (__builtin_sub_overflow(probe.address, sym.start, &probe.func_offset))
-      LOG(BUG) << "Offset before the function bounds ('" << probe.attach_point
-               << "' address is " << std::to_string(sym.start) << ")";
-    offset = probe.func_offset;
-    // Set the name of the probe to the resolved symbol+offset, so that failure
-    // to attach can be ignored if the user set ConfigMissingProbes::warn.
-    probe.name = "kprobe:" + probe.attach_point + "+" +
-                 std::to_string(probe.func_offset);
   }
 
   if (probe.func_offset >= sym.size) {
@@ -496,25 +478,37 @@ Result<std::unique_ptr<AttachedKprobeProbe>> AttachedKprobeProbe::make(
     funcname = probe.attach_point;
   }
 
+  const char *kprobe_func;
+  uint64_t offset;
+
   // The kprobe can either be defined by a symbol+offset or an address:
   // For symbol+offset kprobe, we need to check the validity of the offset.
-  // For address kprobe, we need to resolve into the symbol+offset and
-  // populate `funcname` with the results stored back in the probe.
+  // Address kprobes are only allowed in unsafe mode so no validation is
+  // performed -- the kernel will reject invalid probes.
   bool is_symbol_kprobe = !probe.attach_point.empty();
-  auto offset_res = resolve_offset_kprobe(probe);
-  if (!offset_res) {
-    return offset_res.takeError();
+  if (is_symbol_kprobe) {
+    auto offset_res = resolve_offset_kprobe(probe);
+    if (!offset_res) {
+      return offset_res.takeError();
+    }
+    kprobe_func = funcname.c_str();
+    offset = *offset_res;
+  } else {
+    if (probe.address == 0) {
+      return make_error<AttachError>("Probe address not set");
+    }
+    // The kernel interprets the offset as the absolute address if the symbol
+    // name is null; see alloc_trace_kprobe() in kernel/trace/trace_kprobe.c
+    kprobe_func = nullptr;
+    offset = probe.address;
   }
-  uint64_t offset = *offset_res;
-  if (!is_symbol_kprobe)
-    funcname += probe.attach_point;
 
   DECLARE_LIBBPF_OPTS(bpf_kprobe_opts, opts);
   opts.offset = offset;
   opts.retprobe = probe.type == ProbeType::kretprobe;
 
   auto *link = bpf_program__attach_kprobe_opts(prog.bpf_prog(),
-                                               funcname.c_str(),
+                                               kprobe_func,
                                                &opts);
   if (!link) {
     if (errno == EILSEQ)

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -195,6 +195,16 @@ TEST(attachpoint_checker, kprobe)
   test("kretprobe:f { 1 }");
 }
 
+TEST(attachpoint_checker, kprobe_addr)
+{
+  test_error("kprobe:0x12345678 { 1 }",
+             "ERROR: Probing by address requires --unsafe");
+
+  auto unsafe_bpftrace = get_mock_bpftrace();
+  unsafe_bpftrace->safe_mode_ = false;
+  test(*unsafe_bpftrace, "kprobe:0x12345678 { 1 }");
+}
+
 TEST(attachpoint_checker, usdt)
 {
   test("usdt:/bin/sh:probe { 1 }");

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -695,3 +695,9 @@ RUN {{BPFTRACE}} --unsafe --traceable-functions /dev/null -e 'begin { exit(); } 
 EXPECT_REGEX .*WARNING: vfs_read is not traceable
 EXPECT Attached 2 probes
 TIMEOUT 1
+
+NAME kprobe_addr_invalid
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:0x12345678 {}'
+EXPECT_REGEX .*ERROR: Unable to attach probe: kprobe:305419896.*
+TIMEOUT 5
+WILL_FAIL


### PR DESCRIPTION
Kprobes can be specified using either an address or a symbol name (with an optional offset). The latter is more common, but the kernel requires the name to be unique to prevent probing the wrong function [1]. Providing an address (which can be obtained from `/proc/kallsyms`) solves that case.

Update the kprobe parser to support the `kprobe:0x<addr>` syntax. This is gated on `--unsafe` since we don't perform any validation -- the address is passed to the kernel directly. This is implemented by using NULL as the function name, in which case the offset is interpreted as the address.

This patch also simplifies `resolve_offset_kprobe()` by removing support for the `!is_symbol_kprobe` case. It used to work by translating the address back to the symbol name plus offset, which suffers from the same uniqueness problem; it also didn't support module functions and produced wrong results on kernels with KASLR enabled.

[1] https://github.com/torvalds/linux/commit/b022f0c7e4

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
