### PR TITLE
[btf] Fix handling of void ptr and function ptr

### DIFF
--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -343,8 +343,14 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype)
   else if (stype.IsTSeriesTy())
     return CreateTSeriesStructType(stype);
 
-  if (stype.IsPtrTy())
+  if (stype.IsPtrTy()) {
+    // We shouldn't need to handle bare void types as they can't be assigned to
+    // variables or be used as map keys/values
+    if (stype.GetPointeeTy().IsVoidTy()) {
+      return createPointerType(nullptr, 64);
+    }
     return createPointerType(GetType(stype.GetPointeeTy()), 64);
+  }
 
   // Integer types and builtin types represented by integers
   switch (stype.GetSize()) {

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -470,8 +470,13 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     id.id = t->type;
   }
 
-  if (!t)
+  if (!t) {
+    // BTF type id 0 represents void
+    if (id.id == 0) {
+      return CreateVoid();
+    }
     return CreateNone();
+  }
 
   auto stype = CreateNone();
 
@@ -531,6 +536,12 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     } else {
       stype = CreateArray(array->nelems, elem_type);
     }
+  } else if (btf_is_void(t) || btf_is_func_proto(t)) {
+    // We treat func_proto as void because there are no callable functions in
+    // bpftrace that can be assigned to scratch variables or maps, however
+    // bpftrace does support pointers to functions. Builtins like `ksym` can be
+    // used on these function pointers.
+    return CreateVoid();
   }
 
   return stype;
@@ -1320,6 +1331,9 @@ SizedType BTF::get_stype(std::string_view type_name)
     auto pos = type_name.rfind(" long");
     return get_stype("long " + std::string(type_name.substr(0, pos)));
   }
+
+  if (type_name == "void")
+    return CreateVoid();
 
   return CreateNone();
 }

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -99,3 +99,13 @@ PROG begin { if (curtask.comm == "bpftrace") { print(curtask.comm); printf("comm
 EXPECT bpftrace
 EXPECT comm bpftrace
 REQUIRES_FEATURE btf
+
+NAME void pointer types
+PROG tracepoint:workqueue:workqueue_execute_start { $workfn = args->function; $workfn = (void *)0; exit(); }
+EXPECT Attached 1 probe
+REQUIRES_FEATURE btf
+
+NAME function pointer types
+PROG tracepoint:workqueue:workqueue_execute_start { $workfn = (void *)0; $tl = (struct timer_list *)(args->work); $workfn = $tl->function; exit(); }
+EXPECT Attached 1 probe
+REQUIRES_FEATURE btf


### PR DESCRIPTION
Stacked PRs:
 * #5043
 * __->__#5042


--- --- ---

### [btf] Fix handling of void ptr and function ptr


We were previously treating both void ptrs and function ptrs as none types,
which is not correct. Both should be handled as void ptrs in SizedType.

This ensures both `args->void_ptr_field` and something like `$a = (struct btrfs_work
*)(args->work); $a->func` (which is a function ptr) are handled correctly.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>