### PR TITLE
tests: Remove hint with valid map types

### DIFF
--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -4973,7 +4973,6 @@ let @a = lruhash(2); begin { @a = count(); }
 stdin:1:1-20: ERROR: Invalid bpf map type: potato
 let @a = potato(2); begin { @a[1] = count(); }
 ~~~~~~~~~~~~~~~~~~~
-HINT: Valid map types: percpulruhash, percpuhash, lruhash, hash
 )" });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #5048
 * #5047
 * __->__#5046
 * #5045


--- --- ---

### tests: Remove hint with valid map types


The iteration order of std::unordered_map can differ across
architectures (e.g., s390x) due to different std::hash implementations.
This causes the `TypeCheckerTest::map_declarations` test to fail, as the
hint message it checks is generated from the BPF_PROG_TYPES map.

Just drop the hint from the test as its content is not that important.
This fixes the test on s390x.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
