### PR TITLE
tests: Handle big endian in bitfield tests

### DIFF
--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -508,7 +508,11 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("a").offset, 0);
   ASSERT_TRUE(foo->GetField("a").bitfield.has_value());
   EXPECT_EQ(foo->GetField("a").bitfield->read_bytes, 1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
+#else
+  EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 7U);
+#endif
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0x1U);
 
   EXPECT_TRUE(foo->GetField("b").type.IsIntTy());
@@ -516,7 +520,11 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("b").offset, 0);
   ASSERT_TRUE(foo->GetField("b").bitfield.has_value());
   EXPECT_EQ(foo->GetField("b").bitfield->read_bytes, 1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 1U);
+#else
+  EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 6U);
+#endif
   EXPECT_EQ(foo->GetField("b").bitfield->mask, 0x1U);
 
   EXPECT_TRUE(foo->GetField("c").type.IsIntTy());
@@ -524,7 +532,11 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("c").offset, 0);
   ASSERT_TRUE(foo->GetField("c").bitfield.has_value());
   EXPECT_EQ(foo->GetField("c").bitfield->read_bytes, 1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo->GetField("c").bitfield->access_rshift, 2U);
+#else
+  EXPECT_EQ(foo->GetField("c").bitfield->access_rshift, 3U);
+#endif
   EXPECT_EQ(foo->GetField("c").bitfield->mask, 0x7U);
 
   EXPECT_TRUE(foo->GetField("d").type.IsIntTy());
@@ -532,7 +544,11 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("d").offset, 0);
   ASSERT_TRUE(foo->GetField("d").bitfield.has_value());
   EXPECT_EQ(foo->GetField("d").bitfield->read_bytes, 4U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo->GetField("d").bitfield->access_rshift, 5U);
+#else
+  EXPECT_EQ(foo->GetField("d").bitfield->access_rshift, 7U);
+#endif
   EXPECT_EQ(foo->GetField("d").bitfield->mask, 0xFFFFFU);
 
   EXPECT_TRUE(foo->GetField("e").type.IsIntTy());
@@ -540,7 +556,11 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("e").offset, 3);
   ASSERT_TRUE(foo->GetField("e").bitfield.has_value());
   EXPECT_EQ(foo->GetField("e").bitfield->read_bytes, 1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo->GetField("e").bitfield->access_rshift, 1U);
+#else
+  EXPECT_EQ(foo->GetField("e").bitfield->access_rshift, 0U);
+#endif
   EXPECT_EQ(foo->GetField("e").bitfield->mask, 0x7FU);
   // NOLINTEND(bugprone-unchecked-optional-access)
 }
@@ -569,7 +589,11 @@ TEST(clang_parser, bitfields_with_padding)
   EXPECT_EQ(foo->GetField("a").offset, 4);
   ASSERT_TRUE(foo->GetField("a").bitfield.has_value());
   EXPECT_EQ(foo->GetField("a").bitfield->read_bytes, 4U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
+#else
+  EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 4U);
+#endif
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0xFFFFFFFU);
 
   EXPECT_TRUE(foo->GetField("b").type.IsIntTy());
@@ -577,7 +601,11 @@ TEST(clang_parser, bitfields_with_padding)
   EXPECT_EQ(foo->GetField("b").offset, 7);
   ASSERT_TRUE(foo->GetField("b").bitfield.has_value());
   EXPECT_EQ(foo->GetField("b").bitfield->read_bytes, 1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 4U);
+#else
+  EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 0U);
+#endif
   EXPECT_EQ(foo->GetField("b").bitfield->mask, 0xFU);
   // NOLINTEND(bugprone-unchecked-optional-access)
 }

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -376,7 +376,11 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_EQ(foo4->GetField("b").offset, 10);
   ASSERT_TRUE(foo4->GetField("b").bitfield.has_value());
   EXPECT_EQ(foo4->GetField("b").bitfield->read_bytes, 0x1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo4->GetField("b").bitfield->access_rshift, 4U);
+#else
+  EXPECT_EQ(foo4->GetField("b").bitfield->access_rshift, 3U);
+#endif
   EXPECT_EQ(foo4->GetField("b").bitfield->mask, 0x1U);
 
   ASSERT_TRUE(foo4->HasField("c"));
@@ -385,7 +389,11 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_EQ(foo4->GetField("c").offset, 10);
   ASSERT_TRUE(foo4->GetField("c").bitfield.has_value());
   EXPECT_EQ(foo4->GetField("c").bitfield->read_bytes, 0x1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo4->GetField("c").bitfield->access_rshift, 5U);
+#else
+  EXPECT_EQ(foo4->GetField("c").bitfield->access_rshift, 0U);
+#endif
   EXPECT_EQ(foo4->GetField("c").bitfield->mask, 0x7U);
 
   ASSERT_TRUE(foo4->HasField("d"));
@@ -394,7 +402,11 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_EQ(foo4->GetField("d").offset, 12);
   ASSERT_TRUE(foo4->GetField("d").bitfield.has_value());
   EXPECT_EQ(foo4->GetField("d").bitfield->read_bytes, 0x3U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo4->GetField("d").bitfield->access_rshift, 0U);
+#else
+  EXPECT_EQ(foo4->GetField("d").bitfield->access_rshift, 4U);
+#endif
   EXPECT_EQ(foo4->GetField("d").bitfield->mask, 0xFFFFFU);
   // NOLINTEND(bugprone-unchecked-optional-access)
 }
@@ -483,7 +495,11 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
               foo4->GetField("a").offset == 9);
   if (foo4->GetField("a").offset == 8) { // DWARF < 4
     EXPECT_EQ(foo4->GetField("a").bitfield->read_bytes, 0x3U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     EXPECT_EQ(foo4->GetField("a").bitfield->access_rshift, 12U);
+#else
+    EXPECT_EQ(foo4->GetField("a").bitfield->access_rshift, 4U);
+#endif
     EXPECT_EQ(foo4->GetField("a").bitfield->mask, 0xFFU);
   } else { // DWARF >= 4
     EXPECT_EQ(foo4->GetField("a").bitfield->read_bytes, 0x2U);
@@ -500,11 +516,19 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
               foo4->GetField("b").offset == 10);
   if (foo4->GetField("b").offset == 8) { // DWARF < 4
     EXPECT_EQ(foo4->GetField("b").bitfield->read_bytes, 0x3U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     EXPECT_EQ(foo4->GetField("b").bitfield->access_rshift, 20U);
+#else
+    EXPECT_EQ(foo4->GetField("b").bitfield->access_rshift, 3U);
+#endif
     EXPECT_EQ(foo4->GetField("b").bitfield->mask, 0x1U);
   } else { // DWARF >= 4
     EXPECT_EQ(foo4->GetField("b").bitfield->read_bytes, 0x1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     EXPECT_EQ(foo4->GetField("b").bitfield->access_rshift, 4U);
+#else
+    EXPECT_EQ(foo4->GetField("b").bitfield->access_rshift, 3U);
+#endif
     EXPECT_EQ(foo4->GetField("b").bitfield->mask, 0x1U);
   }
 
@@ -518,11 +542,19 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
 
   if (foo4->GetField("c").offset == 8) { // DWARF < 4
     EXPECT_EQ(foo4->GetField("c").bitfield->read_bytes, 0x3U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     EXPECT_EQ(foo4->GetField("c").bitfield->access_rshift, 21U);
+#else
+    EXPECT_EQ(foo4->GetField("c").bitfield->access_rshift, 0U);
+#endif
     EXPECT_EQ(foo4->GetField("c").bitfield->mask, 0x7U);
   } else { // DWARF >= 4
     EXPECT_EQ(foo4->GetField("c").bitfield->read_bytes, 0x1U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     EXPECT_EQ(foo4->GetField("c").bitfield->access_rshift, 5U);
+#else
+    EXPECT_EQ(foo4->GetField("c").bitfield->access_rshift, 0U);
+#endif
     EXPECT_EQ(foo4->GetField("c").bitfield->mask, 0x7U);
   }
 
@@ -532,7 +564,11 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   EXPECT_EQ(foo4->GetField("d").offset, 12);
   ASSERT_TRUE(foo4->GetField("d").bitfield.has_value());
   EXPECT_EQ(foo4->GetField("d").bitfield->read_bytes, 0x3U);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   EXPECT_EQ(foo4->GetField("d").bitfield->access_rshift, 0U);
+#else
+  EXPECT_EQ(foo4->GetField("d").bitfield->access_rshift, 4U);
+#endif
   EXPECT_EQ(foo4->GetField("d").bitfield->mask, 0xFFFFFU);
   // NOLINTEND(bugprone-unchecked-optional-access)
 }


### PR DESCRIPTION
Stacked PRs:
 * #5048
 * __->__#5047
 * #5046
 * #5045


--- --- ---

### tests: Handle big endian in bitfield tests


Bitfield packing in structures depends on the system endianness. Update
tests working with bitfields to handle both little and big endian.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
Co-developed-by: Claude Sonnet 4.5
