### PR TITLE
tests: Handle different size of max_align_t

### DIFF
--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -852,25 +852,9 @@ TEST(clang_parser, struct_typedef)
   EXPECT_EQ(max_align_struct->GetField("x").offset, 0);
 
   // typedef'd struct (defined in __stddef_max_align_t.h builtin header)
-  EXPECT_EQ(max_align_typedef->size, 32);
   ASSERT_EQ(max_align_typedef->fields.size(), 2U);
   ASSERT_TRUE(max_align_typedef->HasField("__clang_max_align_nonce1"));
   ASSERT_TRUE(max_align_typedef->HasField("__clang_max_align_nonce2"));
-
-  EXPECT_TRUE(
-      max_align_typedef->GetField("__clang_max_align_nonce1").type.IsIntTy());
-  EXPECT_EQ(
-      max_align_typedef->GetField("__clang_max_align_nonce1").type.GetSize(),
-      8U);
-  EXPECT_EQ(max_align_typedef->GetField("__clang_max_align_nonce1").offset, 0);
-
-  // double are not parsed correctly yet so these fields are junk for now
-  EXPECT_TRUE(
-      max_align_typedef->GetField("__clang_max_align_nonce2").type.IsNoneTy());
-  EXPECT_EQ(
-      max_align_typedef->GetField("__clang_max_align_nonce2").type.GetSize(),
-      0U);
-  EXPECT_EQ(max_align_typedef->GetField("__clang_max_align_nonce2").offset, 16);
 }
 
 TEST(clang_parser, struct_qualifiers)


### PR DESCRIPTION
Stacked PRs:
 * __->__#5048
 * #5047
 * #5046
 * #5045


--- --- ---

### tests: Handle different size of max_align_t


The clang_parser.struct_typedef test checks if we can differentiate
between `struct max_align_t {}` and `typedef struct {} max_align_t`.
While the former is created manually, the latter is taken from
<__stddef_max_align_t.h> where it is defined as:

    typedef struct {
      long long __clang_max_align_nonce1
          __attribute__((__aligned__(__alignof__(long long))));
      long double __clang_max_align_nonce2
          __attribute__((__aligned__(__alignof__(long double))));
    } max_align_t;

Here, size and offset of `long double` are architecture and compiler
specific so do not check for the absolute size and offsets, just that
the type has expected fields.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
