### PR TITLE
[TypeResolver] fix get_probe call and probe_ use

### DIFF
--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1382,17 +1382,18 @@ void TypeRuleCollector::visit(Cast &cast)
 {
   visit(cast.expr);
 
+  auto *probe = get_probe();
   // Account for the race condition whereby the expression type may resolve
   // before the cast type even though they both need resolution to determine the
   // final cast type, e.g. `@ = (int8[])"hello"`
   resolver_.add_type_rule({
       .output = &cast,
       .inputs = { &cast.expr.node() },
-      .resolve = [this,
-                  &cast](const std::vector<SizedType> &inputs) -> SizedType {
+      .resolve = [this, &cast, probe](
+                     const std::vector<SizedType> &inputs) -> SizedType {
         const auto &expr_ty = inputs[0];
         const auto &cast_ty = resolver_.get_type(&cast);
-        return update_cast_expr(cast_ty, expr_ty, probe_);
+        return update_cast_expr(cast_ty, expr_ty, probe);
       },
   });
 
@@ -1403,7 +1404,7 @@ void TypeRuleCollector::visit(Cast &cast)
     }
     const auto &expr_ty = resolver_.get_type(&cast.expr.node());
     if (!expr_ty.IsNoneTy()) {
-      ty = update_cast_expr(ty, expr_ty, probe_);
+      ty = update_cast_expr(ty, expr_ty, probe);
     }
     resolver_.set_type(&cast, ty);
   } else {
@@ -1411,13 +1412,13 @@ void TypeRuleCollector::visit(Cast &cast)
     resolver_.add_type_rule({
         .output = &cast,
         .inputs = { cast.typeof },
-        .resolve = [this,
-                    &cast](const std::vector<SizedType> &inputs) -> SizedType {
+        .resolve = [this, &cast, probe](
+                       const std::vector<SizedType> &inputs) -> SizedType {
           const auto &cast_ty = inputs[0];
           const auto &expr_ty = resolver_.get_type(&cast.expr.node());
 
           if (!expr_ty.IsNoneTy()) {
-            return update_cast_expr(cast_ty, expr_ty, probe_);
+            return update_cast_expr(cast_ty, expr_ty, probe);
           }
           return cast_ty;
         },
@@ -1440,11 +1441,12 @@ void TypeRuleCollector::visit(FieldAccess &acc)
 {
   visit(acc.expr);
 
+  auto *probe = get_probe();
   resolver_.add_type_rule({
       .output = &acc,
       .inputs = { &acc.expr.node() },
-      .resolve = [this,
-                  &acc](const std::vector<SizedType> &inputs) -> SizedType {
+      .resolve = [this, &acc, probe](
+                     const std::vector<SizedType> &inputs) -> SizedType {
         const auto &expr_type_in = inputs[0];
         // FieldAccesses will automatically resolve through any number of
         // pointer dereferences. For now, we inject the `Unop` operator
@@ -1467,7 +1469,6 @@ void TypeRuleCollector::visit(FieldAccess &acc)
         }
 
         if (expr_type.is_funcarg) {
-          auto *probe = get_probe();
           if (probe == nullptr) {
             return CreateNone();
           }

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -154,3 +154,9 @@ NAME stack modes and size
 PROG begin { $a = (1, ustack); $b = (1, ustack(build_id)); $c = (1, ustack(build_id, 30)); $d = (1, kstack); $e = (1, kstack(raw)); $f = (1, kstack(raw, 30)); }
 EXPECT Attached 1 probe
 TIMEOUT 1
+
+# https://github.com/bpftrace/bpftrace/issues/5044
+NAME probe specific arguments
+PROG fentry:vmlinux:vfs_write { print(args.file); exit(); } t:syscalls:sys_enter_execve { print(args.filename); exit(); }
+EXPECT Attached 2 probes
+TIMEOUT 1


### PR DESCRIPTION
Stacked PRs:
 * __->__#5049


--- --- ---

### [TypeResolver] fix get_probe call and probe_ use


`get_probe` and `probe_` should not be use inside of a callback because it
will reference only the LAST probe after we visit the entire AST. Instead
call `get_probe` outside the callback and pass the pointer by value into
the lamda.

This fixes: https://github.com/bpftrace/bpftrace/issues/5044

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>