### PR TITLE
CI: Disable test timeouting with sanitizers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           BUILD_ASAN: 1
           BUILD_UBSAN: 1
           TOOLS_TEST_DISABLE: runqlen.bt
-          RUNTIME_TESTS_FILTER: "-btf.user_supplied_c_def_using_btf:-strcontains.path:-list probes by pid$"
+          RUNTIME_TESTS_FILTER: "-basic.it lists fentry params:-btf.user_supplied_c_def_using_btf:-strcontains.path:-list probes by pid$"
         - NAME: Fuzzing
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-fuzz


### PR DESCRIPTION
It looks like the recent commit 0a699908 ("Remove extra spaces from arg when listing probes (#5040)") caused the `basic.it lists fentry params` runtime test timeout on the job with enabled sanitizers.

Our timeout handling in runtime tests seems to be a bit broken so just disable the test for now.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
