### PR TITLE
Fix enum symbolication for BTF based types

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -487,7 +487,20 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     }
     stype = CreateInteger(btf_int_bits(t), encoding & BTF_INT_SIGNED);
   } else if (btf_is_enum(t)) {
-    stype = CreateInteger(t->size * 8, false);
+    std::string enum_name = btf_str(btf_id.btf, t->name_off);
+    if (!enum_name.empty()) {
+      stype = CreateEnum(t->size * 8, enum_name);
+      // Extract enum values from BTF for symbolication
+      auto [it, inserted] = enum_defs_.try_emplace(enum_name);
+      if (inserted) {
+        const auto *p = btf_enum(t);
+        for (__u16 e = 0, vlen = btf_vlen(t); e < vlen; ++e, ++p) {
+          it->second[p->val] = btf_str(btf_id.btf, p->name_off);
+        }
+      }
+    } else {
+      stype = CreateInteger(t->size * 8, false);
+    }
   } else if (btf_is_composite(t)) {
     bool is_anon = false;
     std::string recprefix = btf_is_struct(t) ? "struct " : "union ";

--- a/src/btf.h
+++ b/src/btf.h
@@ -176,6 +176,10 @@ private:
   mutable std::string all_funcs_;
   std::string all_rawtracepoints_;
   std::optional<bool> has_module_btf_;
+
+public:
+  // enum_name -> (value -> variant_name)
+  std::map<std::string, std::map<uint64_t, std::string>> enum_defs_;
 };
 
 inline bool BTF::has_data()

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -208,6 +208,15 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
             return output::Primitive::Symbolic(val_it->second, enum_val);
           }
         }
+        if (bpftrace.btf_) {
+          auto btf_it = bpftrace.btf_->enum_defs_.find(enum_name);
+          if (btf_it != bpftrace.btf_->enum_defs_.end()) {
+            auto val_it = btf_it->second.find(enum_val);
+            if (val_it != btf_it->second.end()) {
+              return output::Primitive::Symbolic(val_it->second, enum_val);
+            }
+          }
+        }
         // Fall back to something comprehensible in case user somehow
         // tricked the type system into accepting an invalid enum.
         return output::Primitive::Symbolic(std::to_string(enum_val), enum_val);

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -46,14 +46,12 @@ NAME printf_enum_symbolize_width
 PROG enum Foo { A, B, C, }; begin { printf("%-5s %5s %s\n", A, B, C); exit() }
 EXPECT A         B C
 
-# Temporarily disabled since enum symbolication is not enabled for BTF, yet
 NAME printf_enum_symbolize_tracepoint
 PROG tracepoint:skb:kfree_skb { $r = args.reason; printf("%d %s\n", args.reason, $r); exit() }
 EXPECT_REGEX ^\d+ [A-Z_]+$
 SETUP ip link set lo up
 AFTER ping localhost -c 5
 TIMEOUT 5
-REQUIRES bash -c "exit 1"
 
 NAME printf_enum_symbolize_cast
 PROG enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; begin { printf("%d %s\n", ONE, (enum Foo)1); exit() }


### PR DESCRIPTION
Stacked PRs:
 * __->__#5060


--- --- ---

### Fix enum symbolication for BTF based types


This fixes a known regression caused by: 9dd37ee03aa93f19bc396b6d8cdf7d7b4e9d97a4

The fix is to create a map of enum types which will be used for lookup in
types_format.cpp.

Signed-off-by: Jordan Rome <linux@jordanrome.com>