### PR TITLE
[LLVM 22] Clang-tidy fixes to prepare for LLVM 22

### DIFF
--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -88,11 +88,11 @@ int main(int argc, char* argv[])
         bt_verbose = true;
         break;
       case 'd':
-        if (std::string(optarg) == "libbpf")
+        if (std::string(optarg) == "libbpf") {
           bt_debug.insert(DebugStage::Libbpf);
-        else if (std::string(optarg) == "verifier")
+        } else if (std::string(optarg) == "verifier") {
           bt_debug.insert(DebugStage::Verifier);
-        else if (std::string(optarg) == "all") {
+        } else if (std::string(optarg) == "all") {
           bt_debug.insert({ DebugStage::Libbpf, DebugStage::Verifier });
         } else {
           LOG(ERROR) << "USAGE: invalid option for -d: " << optarg;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -235,6 +235,12 @@ void IRBuilderBPF::hoist(const std::function<void()> &functor)
   restoreIP(ip);
 }
 
+void IRBuilderBPF::CreateLifetimeEnd(Value *val)
+{
+  if (isa<AllocaInst>(val))
+    IRBuilder::CreateLifetimeEnd(val);
+}
+
 AllocaInst *IRBuilderBPF::CreateAllocaBPF(llvm::Type *ty,
                                           const std::string &name)
 {
@@ -754,9 +760,9 @@ Value *IRBuilderBPF::CreateMapLookupElem(const std::string &map_name,
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);
-  if (needMemcpy(type))
+  if (needMemcpy(type)) {
     CreateMemcpyBPF(value, call, type.GetSize());
-  else {
+  } else {
     CreateStore(CreateLoad(GetType(type), call), value);
   }
   CreateBr(lookup_merge_block);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -23,6 +23,11 @@ public:
                BPFtrace &bpftrace,
                AsyncIds &async_ids);
 
+  // LLVM 22+ requires lifetime intrinsics only on alloca or poison.
+  // Since createAllocation() may return a GEP into a global scratch buffer,
+  // this wrapper guards against calling lifetime.end on non-alloca values.
+  void CreateLifetimeEnd(Value *val);
+
   AllocaInst *CreateAllocaBPF(llvm::Type *ty, const std::string &name = "");
   AllocaInst *CreateAllocaBPF(const SizedType &stype,
                               const std::string &name = "");

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -171,9 +171,9 @@ void AttachPointChecker::visit(AttachPoint &ap)
     }
 
   } else if (ap.provider == "profile") {
-    if (ap.target.empty())
+    if (ap.target.empty()) {
       ap.addError() << "profile probe must have unit of time";
-    else {
+    } else {
       if (!TIME_UNITS.contains(ap.target))
         ap.addError() << ap.target << " is not an accepted unit of time";
       if (!ap.func.empty())
@@ -182,9 +182,9 @@ void AttachPointChecker::visit(AttachPoint &ap)
         ap.addError() << "profile frequency should be a positive integer";
     }
   } else if (ap.provider == "interval") {
-    if (ap.target.empty())
+    if (ap.target.empty()) {
       ap.addError() << "interval probe must have unit of time";
-    else {
+    } else {
       if (!TIME_UNITS.contains(ap.target))
         ap.addError() << ap.target << " is not an accepted unit of time";
       if (!ap.func.empty())
@@ -447,8 +447,9 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
     } else {
       probe_types = probe_matcher.expand_probetype_kernel(probetype_query);
     }
-  } else
+  } else {
     probe_types = { front };
+  }
 
   if (probe_types.empty()) {
     if (util::has_wildcard(front))
@@ -537,10 +538,10 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
       if (raw[idx] == '@') {
         parts_.emplace_back("@");
       }
-    } else if (raw[idx] == '"')
+    } else if (raw[idx] == '"') {
       in_quotes = !in_quotes;
     // Handle escaped characters in a string
-    else if (in_quotes && raw[idx] == '\\' && (idx + 1 < raw.size())) {
+    } else if (in_quotes && raw[idx] == '\\' && (idx + 1 < raw.size())) {
       argument += raw[idx + 1];
       ++idx;
     } else if (!in_quotes && raw[idx] == '$') {
@@ -579,8 +580,9 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
       raw = raw.substr(0, idx) + bpftrace_.get_param(*param_idx) +
             raw.substr(i);
       idx--;
-    } else
+    } else {
       argument += raw[idx];
+    }
   }
 
   // Add final argument
@@ -1091,9 +1093,9 @@ AttachPointParser::State AttachPointParser::fentry_parser()
     if (!util::has_wildcard(ap_->func)) {
       auto func_modules = func_info_state_.kernel_info().get_func_modules(
           ap_->func);
-      if (func_modules.size() == 1)
+      if (func_modules.size() == 1) {
         ap_->target = *func_modules.begin();
-      else if (func_modules.size() > 1) {
+      } else if (func_modules.size() > 1) {
         // Attaching to multiple functions of the same name is currently
         // broken, ask the user to specify a module explicitly.
         errs_ << "ambiguous attach point, please specify module containing "
@@ -1101,8 +1103,9 @@ AttachPointParser::State AttachPointParser::fentry_parser()
               << ap_->func << "\'";
         return INVALID;
       }
-    } else // leave the module empty for now
+    } else { // leave the module empty for now
       ap_->target = "*";
+    }
   }
 
   return OK;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2564,11 +2564,11 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
   if (type.is_funcarg) {
     auto probe_type = probetype(current_attach_point_->provider);
     if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit ||
-        probe_type == ProbeType::rawtracepoint)
+        probe_type == ProbeType::rawtracepoint) {
       return ScopedExpr(
           b_.CreateKFuncArg(ctx_, type_map_.type(&acc), acc.field),
           std::move(scoped_arg));
-    else if (probe_type == ProbeType::uprobe) {
+    } else if (probe_type == ProbeType::uprobe) {
       llvm::Type *args_type = b_.UprobeArgsType(type);
       return readDatastructElemFromStack(std::move(scoped_arg),
                                          b_.getInt32(
@@ -2699,12 +2699,12 @@ ScopedExpr CodegenLLVM::visit(ArrayAccess &arr)
     b_.SetInsertPoint(merge);
   }
 
-  if (inBpfMemory(type_map_.type(&arr)) && !type.IsPtrTy())
+  if (inBpfMemory(type_map_.type(&arr)) && !type.IsPtrTy()) {
     return readDatastructElemFromStack(std::move(scoped_expr),
                                        scoped_index.value(),
                                        type,
                                        type_map_.type(&arr));
-  else {
+  } else {
     Value *array = scoped_expr.value();
     if (array->getType()->isPointerTy()) {
       scoped_expr = ScopedExpr(b_.CreatePtrToInt(array, b_.getInt64Ty()),
@@ -2793,10 +2793,7 @@ ScopedExpr CodegenLLVM::visit(MapAccess &acc)
         acc.map->ident, scoped_key.value(), val_type, acc.loc);
   }
 
-  return ScopedExpr(value, [this, value] {
-    if (dyn_cast<AllocaInst>(value))
-      b_.CreateLifetimeEnd(value);
-  });
+  return ScopedExpr(value, [this, value] { b_.CreateLifetimeEnd(value); });
 }
 
 ScopedExpr CodegenLLVM::visit(Cast &cast)
@@ -3181,8 +3178,9 @@ ScopedExpr CodegenLLVM::visit(Jump &jump)
       if (jump.return_value) {
         auto scoped_return = visit(jump.return_value);
         createRet(scoped_return.value());
-      } else
+      } else {
         createRet();
+      }
       break;
     case JumpType::BREAK:
       b_.CreateBr(std::get<1>(loops_.back())());
@@ -4670,7 +4668,11 @@ ScopedExpr CodegenLLVM::visit(For &f, Range &range)
         // declaration that points there.
         auto *ctx = callback->getArg(1);
         auto *start_field_ptr = b_.CreateSafeGEP(
-            ctx_t, ctx, { b_.getInt64(0), b_.getInt32(sz) }, "start");
+            // NOLINTNEXTLINE(modernize-type-traits): false positive on var
+            ctx_t,
+            ctx,
+            { b_.getInt64(0), b_.getInt32(sz) },
+            "start");
         auto *current_field_ptr = b_.CreateSafeGEP(
             ctx_t, ctx, { b_.getInt64(0), b_.getInt32(sz + 1) }, "current");
 

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -973,9 +973,9 @@ void TypeChecker::visit(Cast &cast)
 
   if (ty.IsArrayTy()) {
     if (ty.GetNumElements() == 0) {
-      if (ty.GetElementTy().GetSize() == 0)
+      if (ty.GetElementTy().GetSize() == 0) {
         cast.addError() << "Could not determine size of the array";
-      else {
+      } else {
         if (rhs.GetSize() % ty.GetElementTy().GetSize() != 0) {
           cast.addError() << "Cannot determine array size: the element size is "
                              "incompatible with the cast integer size";

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -856,8 +856,9 @@ void TypeRuleCollector::visit(Builtin &builtin)
                                                       RETVAL_FIELD_NAME);
       if (arg) {
         builtin_type = arg->type;
-      } else
+      } else {
         builtin.addError() << "Can't find a field " << RETVAL_FIELD_NAME;
+      }
     } else {
       builtin_type = CreateUInt64();
     }
@@ -2232,9 +2233,9 @@ void TypeRuleCollector::visit(Unop &unop)
           } else if (type.IsCStructTy()) {
             // We allow dereferencing "args" with no effect (for backwards
             // compat)
-            if (type.IsCtxAccess())
+            if (type.IsCtxAccess()) {
               result = type;
-            else {
+            } else {
               unop.addError() << "Can not dereference struct/union of type '"
                               << type.GetName() << "'. It is not a pointer.";
             }

--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -36,6 +36,7 @@ BfdDisasm::~BfdDisasm()
     close(fd_);
 }
 
+// NOLINTNEXTLINE(modernize-avoid-variadic-functions): required by libbfd API
 static int fprintf_nop(void *out __attribute__((unused)),
                        const char *fmt __attribute__((unused)),
                        ...)
@@ -44,6 +45,7 @@ static int fprintf_nop(void *out __attribute__((unused)),
 }
 
 #ifdef LIBBFD_INIT_DISASM_INFO_FOUR_ARGS_SIGNATURE
+// NOLINTNEXTLINE(modernize-avoid-variadic-functions): required by libbfd API
 static int fprintf_styled_nop(void *out __attribute__((unused)),
                               enum disassembler_style s __attribute__((unused)),
                               const char *fmt __attribute__((unused)),

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1007,9 +1007,9 @@ std::optional<std::string> BPFtrace::get_watchpoint_binary_path() const
     auto args = util::split_string(cmd_, ' ', /* remove_empty */ true);
     assert(!args.empty());
     return util::resolve_binary_path(args[0]).front();
-  } else if (pid().has_value())
+  } else if (pid().has_value()) {
     return "/proc/" + std::to_string(pid().value_or(0)) + "/exe";
-  else {
+  } else {
     return std::nullopt;
   }
 }

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -1218,9 +1218,9 @@ void BTF::resolve_fields(const SizedType &type)
   if (record->HasFields())
     return;
 
-  if (type.IsAnonTy())
+  if (type.IsAnonTy()) {
     type_id = parse_anon_btf_name(name);
-  else {
+  } else {
     __u32 kind = name.starts_with("struct") ? BTF_KIND_STRUCT : BTF_KIND_UNION;
     auto type_name = btf_type_str(name);
 

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -435,9 +435,9 @@ FuncParamLists ProbeMatcher::get_uprobe_params(
     std::string fun = match;
     std::string path = util::erase_prefix(fun);
     auto dwarf = Dwarf::GetFromBinary(nullptr, path);
-    if (dwarf)
+    if (dwarf) {
       params.emplace(match, dwarf->get_function_params(fun));
-    else {
+    } else {
       if (warned_paths.insert(path).second)
         LOG(WARNING) << "No DWARF found for \"" << path << "\""
                      << ", cannot show parameter info";
@@ -701,8 +701,9 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
         if (!target.empty()) {
           if (auto abs_target = util::abs_path(target))
             target = "*" + abs_target.value();
-        } else
+        } else {
           target = "*";
+        }
       }
       auto ns = attach_point.ns.empty() ? "*" : attach_point.ns;
       search_input = target + ":" + ns + ":" + attach_point.func;

--- a/src/symbols/kernel.cpp
+++ b/src/symbols/kernel.cpp
@@ -348,9 +348,9 @@ KConfig::KConfig()
   // Try to get the config from BPFTRACE_KCONFIG_TEST env
   // If not set, use the set of default locations
   const char *path_env = std::getenv("BPFTRACE_KCONFIG_TEST");
-  if (path_env)
+  if (path_env) {
     config_locs = { std::string(path_env) };
-  else {
+  } else {
     struct utsname utsname;
     if (uname(&utsname) < 0)
       return;

--- a/src/util/env.cpp
+++ b/src/util/env.cpp
@@ -27,11 +27,11 @@ void get_bool_env_var(const ::std::string &str,
   if (const char *env_p = std::getenv(str.c_str())) {
     bool dest;
     std::string s(env_p);
-    if (s == "1")
+    if (s == "1") {
       dest = true;
-    else if (s == "0")
+    } else if (s == "0") {
       dest = false;
-    else {
+    } else {
       throw FatalUserException("Env var '" + str +
                                "' did not contain a valid value (0 or 1).");
     }

--- a/src/util/gfp_flags.h
+++ b/src/util/gfp_flags.h
@@ -88,8 +88,8 @@ private:
   static constexpr uint64_t GFP_NOIO = (__GFP_DIRECT_RECLAIM | __GFP_KSWAPD_RECLAIM);
   static constexpr uint64_t GFP_NOFS = (GFP_NOIO | __GFP_IO);
   static constexpr uint64_t GFP_USER = (GFP_NOFS | __GFP_FS | __GFP_HARDWALL);
-  static constexpr uint64_t GFP_DMA = (__GFP_DMA);
-  static constexpr uint64_t GFP_DMA32 = (__GFP_DMA32);
+  static constexpr uint64_t GFP_DMA = __GFP_DMA;
+  static constexpr uint64_t GFP_DMA32 = __GFP_DMA32;
   static constexpr uint64_t GFP_HIGHUSER = (GFP_USER | __GFP_HIGHMEM);
   static constexpr uint64_t GFP_HIGHUSER_MOVABLE = (GFP_HIGHUSER | __GFP_MOVABLE | __GFP_SKIP_KASAN);
   static constexpr uint64_t GFP_TRANSHUGE_LIGHT = (GFP_HIGHUSER_MOVABLE | __GFP_COMP | __GFP_NOMEMALLOC | __GFP_NOWARN) & ~__GFP_RECLAIM;

--- a/src/util/paths.cpp
+++ b/src/util/paths.cpp
@@ -214,7 +214,7 @@ std::vector<std::string> resolve_binary_path(const std::string &cmd,
 
     if (environ) {
       std::string env_var;
-      std::string pathstr = ("PATH=");
+      std::string pathstr = "PATH=";
       while (std::getline(environ, env_var, '\0')) {
         if (env_var.find(pathstr) != std::string::npos) {
           env_paths = env_var.substr(pathstr.length());


### PR DESCRIPTION
Stacked PRs:
 * #5064
 * __->__#5065


--- --- ---

### [LLVM 22] Clang-tidy fixes to prepare for LLVM 22


Also a minor change to make sure we only call CreateLifetimeEnd on
AllocaInst, which is a hardened check in LLVM 22.

Signed-off-by: Jordan Rome <linux@jordanrome.com>