### PR TITLE
Add "--fmt" CLI arg to adoc

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -100,6 +100,10 @@ Valid values are::
 
 The JSON output is compatible with NDJSON and JSON Lines, meaning each line of the streamed output is a single blob of valid JSON.
 
+=== *--fmt* _FILENAME_
+
+Output standard format for the bpftrace file _FILENAME_.
+
 === *-h, --help*
 
 Print the help summary.


### PR DESCRIPTION
This was missing when "--fmt" was added.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
