### PR TITLE
Fix ASTSource line collection bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to
 #### Docs
 #### Tools
 
+## [0.25.1] TBD
+
+#### Fixed
+- Fix crash when scripts have a trailing new line and there are clang warnings
+  - [#5074](https://github.com/bpftrace/bpftrace/pull/5074)
+
 ## [0.25.0] 2026-03-13
 
 #### Breaking Changes

--- a/src/ast/context.cpp
+++ b/src/ast/context.cpp
@@ -13,6 +13,12 @@ ASTSource::ASTSource(std::string &&filename, std::string &&input)
   while (std::getline(ss, line)) {
     lines_.emplace_back(std::move(line));
   }
+  // std::getline doesn't produce an entry for a trailing newline, but
+  // the lexer advances the line counter past it, so the END token (and
+  // thus the Program node) can reference a line beyond lines_.size().
+  if (!contents.empty() && contents.back() == '\n') {
+    lines_.emplace_back("");
+  }
 }
 
 std::string ASTSource::read(const SourceLocation &loc)

--- a/tests/location.cpp
+++ b/tests/location.cpp
@@ -50,4 +50,28 @@ TEST(Location, multi_line)
             }));
 }
 
+// https://github.com/bpftrace/bpftrace/issues/5073
+TEST(Location, multi_line_trailing_newline)
+{
+  std::string src = "i:s:1 {\n  print(1);\n}\n";
+  ast::ASTContext ast("testfile", src);
+
+  // Simulate a location spanning the entire program, including the line
+  // the END token would be on (line 4, but only 3 visible lines + 1 empty).
+  ast::SourceLocation loc(ast.source());
+  loc.begin = { .line = 1, .column = 1 };
+  loc.end = { .line = 4, .column = 1 };
+  auto &call = *ast.make_node<ast::Call>(loc, "foo", ast::ExpressionList({}));
+  auto &warn = call.addWarning();
+
+  EXPECT_EQ(warn.loc()->source_location(), "testfile:1-4");
+  EXPECT_EQ(warn.loc()->source_context(),
+            std::vector<std::string>({
+                "i:s:1 {",
+                "  print(1);",
+                "}",
+                "",
+            }));
+}
+
 } // namespace bpftrace::test::location


### PR DESCRIPTION
When collecting lines for an ASTSource object we use std::getline which skips the final empty line in a bpftrace script. This is problematic because for a script ending in a trailing new line the lexer advances line counter and the END token gets assigned this new line.

This becomes a real problem only in the case when we try to access this last line which happens when we set a warning (`addWarning`) or an error on the entire program node, which we do in the CreateClangBuildPass when there are clang warnings.

The access happens in location.cpp:
```
for (int i = begin.line; i <= end.line; i++) {
  assert(i <= static_cast<int>(source_->lines_.size()));
  result.push_back(source_->lines_[i - 1]);
}
```
As you can see there is an assert but these get stripped out in release builds.

The fix is to check if there is a trailing new line context.cpp when constructing the ASTSource object and emplace an empty new line into `lines_`.

Fixes: https://github.com/bpftrace/bpftrace/issues/5073

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
