### PR TITLE
Use bpf_probe_write_user to allow memory modification (#3742)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
   - [#4867](https://github.com/bpftrace/bpftrace/pull/4867)
 - Add printf specifier `%gr` to print GFP flags in human readable format
   - [#4832](https://github.com/bpftrace/bpftrace/issues/4832)
+- Add `write_user(dst, src, len)` function to write to user-space memory using `bpf_probe_write_user` (requires `--unsafe`)
+  - [#3742](https://github.com/bpftrace/bpftrace/issues/3742)
 #### Changed
 #### Deprecated
 #### Removed

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1557,6 +1557,31 @@ EXPECT stdin:1:9-62: WARNING: Something kinda bad with args: 10, arg2
 ```
 
 
+### write_user
+- `bool write_user(T * dst, T * src, uint32 len)`
+
+**unsafe**
+
+Writes `len` bytes from BPF program memory at `src` to user-space address
+`dst` using the BPF helper `bpf_probe_write_user`.
+
+Returns true on success, or false on failure.
+
+**Warning**: This can crash or corrupt the target process if used incorrectly.
+Only use on user-space memory addresses belonging to the current task.
+The kernel will print a warning to dmesg when this helper is used.
+
+```
+tracepoint:syscalls:sys_enter_openat
+/comm == "myapp"/ {
+  $new_path = "/tmp/redirected\0";
+  if (write_user(args.filename, $new_path, 16)) {
+    printf("redirected open for pid %d\n", pid);
+  }
+}
+```
+
+
 ### zero
 - `void zero(map m)`
 

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -798,6 +798,38 @@ macro override(expr)
   }
 }
 
+// :variant bool write_user(T * dst, T * src, uint32 len)
+//
+// **unsafe**
+//
+// Writes `len` bytes from BPF program memory at `src` to user-space address
+// `dst` using the BPF helper `bpf_probe_write_user`.
+//
+// Returns true on success, or false on failure.
+//
+// **Warning**: This can crash or corrupt the target process if used incorrectly.
+// Only use on user-space memory addresses belonging to the current task.
+// The kernel will print a warning to dmesg when this helper is used.
+//
+// ```
+// tracepoint:syscalls:sys_enter_openat
+// /comm == "myapp"/ {
+//   $new_path = "/tmp/redirected\0";
+//   if (write_user(args.filename, $new_path, 16)) {
+//     printf("redirected open for pid %d\n", pid);
+//   }
+// }
+// ```
+macro write_user(dst, src, len)
+{
+  import "stdlib/system/system.bpf.c";
+  if comptime __builtin_safe_mode {
+    fail("write_user() is unsafe. To use you need the --unsafe flag");
+  } else {
+    __probe_write_user((void *)dst, (void *)src, (uint32)len) == 0;
+  }
+}
+
 // :function path
 // :variant char * path(struct path * path [, int32 size])
 //

--- a/src/stdlib/system/system.bpf.c
+++ b/src/stdlib/system/system.bpf.c
@@ -13,3 +13,7 @@ long __get_numa_node_id() {
 void __override(void * ctx, __u64 rc) {
     bpf_override_return(ctx, rc);
 }
+
+long __probe_write_user(void *dst, const void *src, __u32 len) {
+    return bpf_probe_write_user(dst, src, len);
+}

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -835,3 +835,13 @@ AFTER ./testprogs/syscall nanosleep  1e8
 NAME block expression with map assignment
 PROG begin { @ = { let $a = 100; avg($a) };  }
 EXPECT @: 100
+
+NAME write_user_unsafe_required
+PROG tracepoint:syscalls:sys_enter_openat { write_user(args.filename, "x", 1); }
+EXPECT_REGEX .*ERROR: write_user\(\) is unsafe. To use you need the --unsafe flag
+WILL_FAIL
+
+NAME write_user_basic
+RUN {{BPFTRACE}} --unsafe -e 'tracepoint:syscalls:sys_enter_openat /pid == 0xffffffff/ { write_user(args.filename, "x", 1); }' -e 'BEGIN { exit(); }'
+EXPECT Attached 1 probe
+TIMEOUT 5


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Add write_user() function for writing to user-space memory

Add write_user(dst, src, len) built-in function that wraps the bpf_probe_write_user BPF helper, allowing bpftrace scripts to write data into user-space process memory. This is gated behind the --unsafe flag since it can crash or corrupt target processes.


##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
