### PR TITLE
Ternary operator supports an empty second operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Ternary operator supports an empty second operand.
+  - [#5077](https://github.com/bpftrace/bpftrace/pull/5077)
 - Add `uprobe` support for source location attach points.
   - [#4867](https://github.com/bpftrace/bpftrace/pull/4867)
 - Add printf specifier `%gr` to print GFP flags in human readable format

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -867,6 +867,7 @@ non_if_expr:
         |       unary_expr                { $$ = $1; }
         |       comptime_expr             { $$ = $1; }
         |       expr QUES expr COLON expr { $$ = driver.ctx.make_node<ast::IfExpr>(@$, $1, $3, $5); }
+        |       expr QUES COLON expr      { $$ = driver.ctx.make_node<ast::IfExpr>(@$, $1, $1, $4); }
         |       expr LOR expr             { $$ = driver.ctx.make_node<ast::Binop>(@2, $1, ast::Operator::LOR, $3); }
         |       expr LAND expr            { $$ = driver.ctx.make_node<ast::Binop>(@2, $1, ast::Operator::LAND, $3); }
         |       expr BOR expr             { $$ = driver.ctx.make_node<ast::Binop>(@2, $1, ast::Operator::BOR, $3); }

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -58,6 +58,10 @@ NAME ternary_tuple
 PROG i:ms:1 { $a = nsecs ? ("hellolongstr", "a") : ("b", "hellolongstr"); print($a); exit(); }
 EXPECT (hellolongstr, a)
 
+NAME ternary_empty_2nd_operand
+PROG begin { $x = 1; $a =$x ?: 10; $b = 0 ?: 20; print(($a, $b)); exit(); }
+EXPECT (1, 20)
+
 NAME unroll
 PROG i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}
 EXPECT a=11


### PR DESCRIPTION
Like in C, the ternary operator supports an empty second operand.

Usage: 'tracepoint:syscalls:sys_exit_kill { $ret = args.ret ?: (-1); }'
