### PR TITLE
IfExpr: Skip the ternary expression check for Type::none in CastCreator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
 ## [0.25.1] TBD
 
 #### Fixed
+- Fix crash for invalid if expressions
+  - [#5080](https://github.com/bpftrace/bpftrace/pull/5080)
 - Fix crash when scripts have a trailing new line and there are clang warnings
   - [#5074](https://github.com/bpftrace/bpftrace/pull/5074)
 

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -432,13 +432,13 @@ void CastCreator::visit(IfExpr &if_expr)
   const auto &left_type = type_map_.type(if_expr.left);
   const auto &right_type = type_map_.type(if_expr.right);
 
-  if (result_type != left_type) {
+  if (!left_type.IsNoneTy() && result_type != left_type) {
     if (!cast_expression(if_expr.left, left_type, result_type)) {
       LOG(BUG) << "IfExpr left should be castable";
     }
   }
 
-  if (result_type != right_type) {
+  if (!right_type.IsNoneTy() && result_type != right_type) {
     if (!cast_expression(if_expr.right, right_type, result_type)) {
       LOG(BUG) << "IfExpr right should be castable";
     }

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -525,6 +525,18 @@ stdin:1:17-57: ERROR: Branches must return the same type or compatible types: ha
 kprobe:f { @x = pid < 10000 ? kstack(raw) : kstack(perf) }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
+
+  test("kprobe:f { $x = nonsense; $y = true ? $x : 1; exit(); }", Error{ R"(
+stdin:1:17-25: ERROR: Unknown identifier: 'nonsense'
+kprobe:f { $x = nonsense; $y = true ? $x : 1; exit(); }
+                ~~~~~~~~
+stdin:1:12-25: ERROR: Invalid expression for assignment
+kprobe:f { $x = nonsense; $y = true ? $x : 1; exit(); }
+           ~~~~~~~~~~~~~
+stdin:1:39-41: ERROR: Could not resolve the type of this variable
+kprobe:f { $x = nonsense; $y = true ? $x : 1; exit(); }
+                                      ~~
+)" });
 }
 
 TEST_F(TypeCheckerTest, mismatched_call_types)


### PR DESCRIPTION
When Type::none exists in a ternary expression, the cast check should be skipped because it is meaningless, and the check of this variable should be left to subsequent passes.

For example:

    tracepoint:syscalls:sys_exit_openat {
      $ret = ret; /* nonsense */
      $fd = ($ret >= 0) ? $ret : (-1);
    }

  Fatal log:

    BUG: [.../bpftrace/src/ast/passes/types/cast_creator.cpp:437] IfExpr left should be castable
    Aborted

However, we should actually remind users that they have used an illegal nonsense `ret` identifier, rather than directly abort the program.

With this fix:

    a.bt:4:10-13: ERROR: Unknown identifier: 'ret'
