### PR TITLE
Fix casting negative literals to unsigned types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix casting negative literals to unsigned types
+  - [#000](https://github.com/bpftrace/bpftrace/issues/000)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2822,7 +2822,7 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
     } else {
       return ScopedExpr(b_.CreateIntCast(scoped_expr.value(),
                                          b_.getIntNTy(ty.GetIntBitWidth()),
-                                         ty.IsSigned(),
+                                         type_map_.type(cast.expr).IsSigned(),
                                          "cast"));
     }
   } else if (ty.IsArrayTy() && type_map_.type(cast.expr).IsIntTy()) {

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -31,6 +31,11 @@ PROG begin { @=sum(10); @=sum(-20);  }
 EXPECT @: -10
 TIMEOUT 1
 
+NAME cast negative to unsigned
+PROG begin { printf("%lu\n", (uint64)(-4095)); }
+EXPECT 18446744073709547521
+TIMEOUT 1
+
 NAME mixed values
 PROG begin { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100);  }
 EXPECT -10 -5555 -123 100


### PR DESCRIPTION
Stacked PRs:
 * #5084
 * __->__#5083


--- --- ---

### Fix casting negative literals to unsigned types


When extending an integer, CreateIntCast needs the cast type's signedness
to decide between sign-extension and zero-extension.

Signed-off-by: Jordan Rome <linux@jordanrome.com>