### PR TITLE
Add 'is_err' stdlib macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   - [#4832](https://github.com/bpftrace/bpftrace/issues/4832)
 - Add `write_user(dst, src, len)` function to write to user-space memory using `bpf_probe_write_user` (requires `--unsafe`)
   - [#3742](https://github.com/bpftrace/bpftrace/issues/3742)
+- Add `is_err` stdlib macro for detecting ERR_PTR return values
+  - [#000](https://github.com/bpftrace/bpftrace/issues/000)
 #### Changed
 #### Deprecated
 #### Removed

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -448,6 +448,27 @@ macro has_key(@map, key) {
   (bool)__lookup_elem((void *)&@map, (void *)&$key)
 }
 
+// :variant bool is_err(void * ptr)
+// Returns true if the pointer is an ERR_PTR, i.e. it encodes a kernel error code.
+//
+// In the Linux kernel, some functions return error codes encoded as pointers
+// using the `ERR_PTR` macro. These are pointer values in the range
+// `(unsigned long)(-4095)` to `(unsigned long)(-1)`.
+//
+// This is equivalent to the kernel's `IS_ERR()` macro.
+//
+// ```
+// fexit:do_filp_open {
+//   if (is_err(retval)) {
+//     printf("error: %ld\n", (int64)retval);
+//   }
+// }
+// ```
+macro is_err(ptr)
+{
+  (int64)ptr < 0 && (int64)ptr >= -4095
+}
+
 // :variant uint64 jiffies()
 // Jiffies of the kernel
 //

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -39,6 +39,13 @@ PROG begin { @a[1] = 1; $x = delete(@a, 2); $y = delete(@a, 1); if ($x == false 
 EXPECT SUCCESS
 TIMEOUT 1
 
+NAME is_err
+PROG fexit:do_filp_open { if (is_err(retval)) { printf("is_err: %ld\n", (int64)retval); exit(); } }
+EXPECT_REGEX is_err: -[0-9]{1,4}$
+AFTER cat /tmp/bpftrace_nonexistent_file
+REQUIRES_FEATURE btf
+TIMEOUT 5
+
 NAME strlen
 PROG begin { $a = "hello"; print(strlen($a)); }
 EXPECT 5


### PR DESCRIPTION
Stacked PRs:
 * __->__#5084
 * #5083


--- --- ---

### Add 'is_err' stdlib macro


This is for functions that return a possible ERR_PTR in the kernel.

Signed-off-by: Jordan Rome <linux@jordanrome.com>