### PR TITLE
Attach watchpoints to all existing threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Attach watchpoint probes to all threads of a process
+  - [#5088](https://github.com/bpftrace/bpftrace/pull/5088)
 #### Security
 #### Docs
 #### Tools

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -30,6 +30,7 @@
 #include "util/exceptions.h"
 #include "util/paths.h"
 #include "util/symbols.h"
+#include "util/system.h"
 
 namespace bpftrace {
 
@@ -1417,56 +1418,58 @@ Result<std::unique_ptr<AttachedWatchpointProbe>> AttachedWatchpointProbe::make(
   attr.bp_len = (attr.bp_type & HW_BREAKPOINT_X) ? sizeof(long) : probe.len;
   // Generate a notification every 1 event; we care about every event
   attr.sample_period = 1;
-  // Attach to threads.
-  //
-  // NB: this only works for threads created after attachment
-  // (limitation of perf_event_open)!
+  // Attach to threads created after attachment.
   attr.inherit = 1;
 
-  std::vector<int> cpus;
+  std::vector<int> cpus, tids;
   if (pid.has_value()) {
+    // when tracing a specific process, we need to create a separate perf event
+    // for each of its existing threads
+    auto res = util::get_process_tids(*pid);
+    if (!res) {
+      return res.takeError();
+    }
+    tids = *res;
     cpus = { -1 };
   } else {
     cpus = util::get_online_cpus();
+    tids = { -1 };
   }
 
   std::string err_msg;
-  bool has_error = false;
   std::vector<struct bpf_link *> links;
 
   for (int cpu : cpus) {
-    // We copy paste the code from bcc's bpf_attach_perf_event_raw here
-    // because we need to know the exact error codes (and also we don't
-    // want bcc's noisy error messages).
-    int perf_event_fd = syscall(__NR_perf_event_open,
-                                &attr,
-                                pid.has_value() ? *pid : -1,
-                                cpu,
-                                -1,
-                                PERF_FLAG_FD_CLOEXEC);
-    if (perf_event_fd < 0) {
-      if (errno == ENOSPC)
-        err_msg = "No more HW registers left";
+    for (int tid : tids) {
+      // We copy paste the code from bcc's bpf_attach_perf_event_raw here
+      // because we need to know the exact error codes (and also we don't
+      // want bcc's noisy error messages).
+      int perf_event_fd = syscall(
+          __NR_perf_event_open, &attr, tid, cpu, -1, PERF_FLAG_FD_CLOEXEC);
+      if (perf_event_fd < 0) {
+        if (errno == ENOSPC)
+          err_msg = "No more HW registers left";
 
-      has_error = true;
-      break;
+        LOG(WARNING) << "Failed to create a perf event for cpu " << cpu
+                     << " tid " << tid << ": " << strerror(errno);
+        continue;
+      }
+
+      auto *link = bpf_program__attach_perf_event(prog.bpf_prog(),
+                                                  perf_event_fd);
+      if (!link) {
+        close(perf_event_fd);
+        continue;
+      }
+
+      links.push_back(link);
     }
-
-    auto *link = bpf_program__attach_perf_event(prog.bpf_prog(), perf_event_fd);
-    if (!link) {
-      has_error = true;
-      break;
-    }
-
-    links.push_back(link);
   }
 
-  if (has_error) {
-    for (struct bpf_link *link : links) {
-      if (bpf_link__destroy(link))
-        LOG(WARNING) << "failed to destroy link for watchpoint probe: "
-                     << strerror(errno);
-    }
+  if (links.empty()) {
+    // Not all perf_event_open() calls will necessarily succeed -- threads may
+    // exit and CPUs may be offlined. Only return an error if we were unable to
+    // create any event.
     return make_error<AttachError>(std::move(err_msg));
   }
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1,16 +1,19 @@
 #include <algorithm>
 #include <climits>
 #include <cstring>
+#include <dirent.h>
 #include <filesystem>
 #include <fstream>
 #include <linux/limits.h>
 #include <map>
 #include <sstream>
 #include <sys/prctl.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <unordered_set>
 
+#include "util/int_parser.h"
 #include "util/system.h"
 
 namespace bpftrace::util {
@@ -287,6 +290,27 @@ Result<uint64_t> get_available_mem_kb()
   file.close();
 
   return memAvailable;
+}
+
+Result<std::vector<int>> get_process_tids(pid_t pid)
+{
+  char task_path[32];
+  snprintf(task_path, sizeof(task_path), "/proc/%d/task", pid);
+
+  std::vector<int> tids;
+  std::error_code ec;
+  for (const auto &task : std::filesystem::directory_iterator(task_path, ec)) {
+    std::string filename = task.path().filename().string();
+    if (!std::ranges::all_of(filename, ::isdigit))
+      continue;
+    tids.emplace_back(std::stoi(filename));
+  }
+
+  if (ec) {
+    return make_error<SystemError>("Unable to open " + std::string(task_path),
+                                   ec.value());
+  }
+  return tids;
 }
 
 } // namespace bpftrace::util

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -21,4 +21,6 @@ Result<std::vector<int>> get_pids_for_program(const std::string &program);
 Result<std::vector<int>> get_all_running_pids();
 Result<uint64_t> get_available_mem_kb();
 
+Result<std::vector<int>> get_process_tids(pid_t pid);
+
 } // namespace bpftrace::util

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -18,10 +18,18 @@ RUN {{BPFTRACE}} -e 'watchpoint:0x10000000:1:x { printf("hit!\n"); exit() }' -c 
 EXPECT hit!
 ARCH aarch64|x86_64
 
-NAME watchpoint absolute address threaded
+NAME watchpoint - created thread
 BEFORE ./testprogs/watchpoint_threaded
-RUN {{BPFTRACE}} -e 'watchpoint:0x10000000:1:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_threaded
+RUN {{BPFTRACE}} -e 'watchpoint:0x10000000:1:w { printf("hit!\n"); exit() }' -c './testprogs/watchpoint_threaded 1'
 EXPECT hit!
 # Not all archs support mmap to our specific address, so be conservative here.
 # See 08a47afa ("Fixing absolute address test issue across platforms")
+ARCH x86_64
+
+# Attaches a watchpoint probe to an existing multi-threaded process. Waits a bit before running
+# bpftrace to allow the test program to start the thread that triggers the watchpoint.
+NAME watchpoint - existing thread
+BEFORE ./testprogs/watchpoint_threaded
+RUN sleep 1; {{BPFTRACE}} -p {{BEFORE_PID}} -e 'watchpoint:0x10000000:1:w { printf("hit!\n"); exit() }'
+EXPECT hit!
 ARCH x86_64

--- a/tests/testprogs/watchpoint_exec.c
+++ b/tests/testprogs/watchpoint_exec.c
@@ -27,6 +27,7 @@ int main()
   memcpy(addr, insns, sizeof(insns));
   void (*func)(void);
   func = addr;
+  sleep(1); // wait a bit for bpftrace to attach
   (*func)();
 
   if (munmap(addr, len) == -1) {

--- a/tests/testprogs/watchpoint_threaded.c
+++ b/tests/testprogs/watchpoint_threaded.c
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -21,17 +22,22 @@ void *work(void *)
   }
 
   uint8_t i = 0;
-  while (i < 10) {
+  while (i < 100) {
     *((volatile uint8_t *)addr) = i++;
-    // 250ms*10 sleep, enough for watchpoint trigger
+    // 250ms*100 sleep, enough for watchpoint trigger
     usleep(250 * 1000);
   }
 
   return NULL;
 }
 
-int main()
+int main(int argc, char *argv[])
 {
+  if (argc > 1) {
+    // optionally wait before creating a new thread
+    sleep(atoi(argv[1]));
+  }
+
   pthread_t tid;
   if (pthread_create(&tid, NULL, work, 0)) {
     perror("pthread_create");


### PR DESCRIPTION
When attaching a watchpoint probe to a specific process via `-p`, we create just one perf event for that pid and set `attr.inherit` to 1. This is insufficient: it causes the probe to only be attached to the main thread (`tid == pid`) and those created by the main thread after attaching, but not to any of the other existing threads.

Fix this by enumerating all threads of the process via procfs and creating a separate perf event for each thread.

This closes #826.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
