### PR TITLE
Don't read symbols for watchpoint probes

### DIFF
--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -112,8 +112,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
       break;
     }
     case ProbeType::uprobe:
-    case ProbeType::uretprobe:
-    case ProbeType::watchpoint: {
+    case ProbeType::uretprobe: {
       auto result = [&]() {
         if (bpftrace_->pid()) {
           auto pid_symbols = user_func_info_.func_symbols_for_pid(


### PR DESCRIPTION
As of ed1a615b5 ("feature: drop asyncwatchpoint and watchpoint:func+arg1"), watchpoint probes can only be set on absolute addresses and not on function arguments, so loading all symbols for the target process is unnecessary and only slows down startup.

Probing a fairly large Android app:
```
# time bpftrace -p $PID -e "watchpoint:$ADDR:4:x {} begin {exit()}"
Attached 2 probes
    0m02.78s real     0m01.91s user     0m00.46s system  <- before
    0m00.52s real     0m00.18s user     0m00.11s system  <- after
```
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
