### PR TITLE
dwarf: extend support for DWARF formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Extend support for DWARF formats
+  - [#5095](https://github.com/bpftrace/bpftrace/pull/5095)
 - Ternary operator supports an empty second operand.
   - [#5077](https://github.com/bpftrace/bpftrace/pull/5077)
 - Add `uprobe` support for source location attach points.

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -80,6 +80,18 @@ For example, you could add the predicate `/pid == cpid/` to probes with userspac
 Enable debug mode.
 For more details see the <<Debug Output>> section.
 
+=== *--debuginfo* _DIR_
+
+Add the directory DIR to the search path for DWARF debug information.
+Paths may be absolute or relative to the traced binary's location.
+Multiple paths can be specified by separating them with a colon (`:`), for example `--debuginfo=/bin/debug:./debug:..`.
+Files found in these paths are validated using the build ID.
+Alternatively, CRC32 checksum validation can be enabled by prefixing a path with `+`.
+Files that do not match are skipped.
+By default, bpftrace searches standard debug paths or attempts to query available debuginfod servers.
+
+Split debuginfo format (`.dwo`, `.dwp`) is not yet supported for this option, but continues to work with the default probe binary path.
+
 === *--dry-run*
 
 Terminate execution right after attaching all the probes. Useful for testing

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1446,8 +1446,10 @@ Dwarf *BPFtrace::get_dwarf(const std::string &filename)
 {
   auto dwarf = dwarves_.find(filename);
   if (dwarf == dwarves_.end()) {
-    dwarf =
-        dwarves_.emplace(filename, Dwarf::GetFromBinary(this, filename)).first;
+    dwarf = dwarves_
+                .emplace(filename,
+                         Dwarf::GetFromBinary(this, filename, debuginfo_path_))
+                .first;
   }
   return dwarf->second.get();
 }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -31,10 +31,10 @@
 #include "probe_matcher.h"
 #include "required_resources.h"
 #include "struct.h"
+#include "symbols/kernel.h"
 #include "types.h"
 #include "usyms.h"
 #include "util/cpus.h"
-#include "symbols/kernel.h"
 #include "util/proc.h"
 #include "util/result.h"
 
@@ -226,6 +226,7 @@ public:
   bool run_tests_ = false;
   bool run_benchmarks_ = false;
   std::string probe_filter_;
+  std::string debuginfo_path_;
 
 private:
   Ksyms ksyms_;

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -19,6 +19,7 @@ void DwarfParseError::log(llvm::raw_ostream &OS) const
 
 #include <dwarf.h>
 #include <elfutils/libdw.h>
+#include <elfutils/libdwelf.h>
 
 namespace bpftrace {
 
@@ -27,24 +28,49 @@ struct FuncInfo {
   Dwarf_Die die;
 };
 
-Dwarf::Dwarf(BPFtrace *bpftrace, const std::string &file_path)
-    : bpftrace_(bpftrace), file_path_(file_path)
+Dwarf::Dwarf(BPFtrace *bpftrace,
+             const std::string &file_path,
+             std::string debuginfo_path)
+    : bpftrace_(bpftrace),
+      file_path_(file_path),
+      debuginfo_path_(std::move(debuginfo_path))
 {
+  debuginfo_path_cstr_ = debuginfo_path_.c_str();
   callbacks.find_debuginfo = dwfl_standard_find_debuginfo;
   callbacks.section_address = dwfl_offline_section_address;
-  callbacks.debuginfo_path = nullptr;
+  callbacks.debuginfo_path = const_cast<char **>(&debuginfo_path_cstr_);
   dwfl = dwfl_begin(&callbacks);
   dwfl_report_offline(dwfl, file_path.c_str(), file_path.c_str(), -1);
   dwfl_report_end(dwfl, nullptr, nullptr);
 }
 
-std::unique_ptr<Dwarf> Dwarf::GetFromBinary(BPFtrace *bpftrace,
-                                            const std::string &file_path)
+static bool debug_alt_link_missing(::Dwarf *dwarf)
 {
-  std::unique_ptr<Dwarf> dwarf(new Dwarf(bpftrace, file_path));
+  const char *alt_name = nullptr;
+  const void *build_id = nullptr;
+  return dwelf_dwarf_gnu_debugaltlink(dwarf, &alt_name, &build_id) > 0 &&
+         dwarf_getalt(dwarf) == nullptr;
+}
+
+std::unique_ptr<Dwarf> Dwarf::GetFromBinary(BPFtrace *bpftrace,
+                                            const std::string &file_path,
+                                            const std::string &debuginfo_path)
+{
+  std::unique_ptr<Dwarf> dwarf(new Dwarf(bpftrace, file_path, debuginfo_path));
   Dwarf_Addr bias;
-  if (dwfl_nextcu(dwarf->dwfl, nullptr, &bias) == nullptr)
+  Dwarf_Die *cudie = dwfl_nextcu(dwarf->dwfl, nullptr, &bias);
+  if (cudie == nullptr)
     return nullptr;
+
+  // If the compilation units reference a separate partial type unit via
+  // debugaltlink, perform an early check to ensure that the corresponding
+  // shared file exists. This prevents unexpected nullptrs caused by missing
+  // data from crashing the runtime.
+  Dwfl_Module *mod = dwfl_cumodule(cudie);
+  ::Dwarf *dw = dwfl_module_getdwarf(mod, &bias);
+  if (debug_alt_link_missing(dw)) {
+    return nullptr;
+  }
 
   return dwarf;
 }
@@ -54,11 +80,69 @@ Dwarf::~Dwarf()
   dwfl_end(dwfl);
 }
 
+bool Dwarf::next_cu_info(CuInfo *cu_info) const
+{
+  Dwarf_Addr cubias;
+  cu_info->cudie = dwfl_nextcu(dwfl, cu_info->cudie, &cubias);
+  if (cu_info->cudie == nullptr)
+    return false;
+
+  cu_info->split_cudie = std::nullopt;
+
+  // Try to find split debug info for skeleton CU's .
+  uint8_t unit_type = 0;
+  Dwarf_Die subdie = {};
+  if (dwarf_cu_info(cu_info->cudie->cu,
+                    nullptr,
+                    &unit_type,
+                    nullptr,
+                    &subdie,
+                    nullptr,
+                    nullptr,
+                    nullptr) == 0 &&
+      unit_type == DW_UT_skeleton) {
+    // libdw sets subdie to zero, if split CU is not found.
+    const Dwarf_Die zero = {};
+    if (std::memcmp(&subdie, &zero, sizeof(Dwarf_Die)) != 0) {
+      cu_info->split_cudie = subdie;
+    } else {
+      const char *dwo_name = nullptr;
+      Dwarf_Attribute attr;
+      if (dwarf_attr(cu_info->cudie, DW_AT_dwo_name, &attr) ||
+          dwarf_attr(cu_info->cudie, DW_AT_GNU_dwo_name, &attr)) {
+        dwo_name = dwarf_formstring(&attr);
+      }
+      const std::string binary =
+          std::filesystem::path(file_path_).stem().string();
+      // Fall back to binary.dwo, if the attribute is missing
+      const std::string dwo =
+          dwo_name ? std::filesystem::path(dwo_name).filename().string()
+                   : binary + ".dwo";
+      // Emit a warning instead of an error, since skeleton CU's do contain
+      // minimal debug info (e.g. lines, address ranges).
+      LOG(WARNING) << "Unable to find split debug file '" << dwo << "' or '"
+                   << binary << ".dwp' for '" << file_path_
+                   << "', debugging information may be incomplete!";
+    }
+  }
+
+  return true;
+}
+
+static std::string get_die_name(Dwarf_Die *die)
+{
+  // If the DWARF section containing the DIE name string is malformed or
+  // missing, dwarf_diename() will return nullptr, so we wrap it to prevent
+  // undefined behaviour.
+  const char *name = dwarf_diename(die);
+  return name ?: "";
+}
+
 static int get_func_die_cb(Dwarf_Die *func_die, void *arg)
 {
   auto *func_info = static_cast<struct FuncInfo *>(arg);
-  if (dwarf_hasattr(func_die, DW_AT_name) &&
-      dwarf_diename(func_die) == func_info->name) {
+  if (dwarf_hasattr_integrate(func_die, DW_AT_name) &&
+      get_die_name(func_die) == func_info->name) {
     func_info->die = *func_die;
     return DWARF_CB_ABORT;
   }
@@ -69,10 +153,9 @@ std::optional<Dwarf_Die> Dwarf::get_func_die(const std::string &function) const
 {
   struct FuncInfo func_info = { .name = function, .die = {} };
 
-  Dwarf_Die *cudie = nullptr;
-  Dwarf_Addr cubias;
-  while ((cudie = dwfl_nextcu(dwfl, cudie, &cubias)) != nullptr) {
-    if (dwarf_getfuncs(cudie, get_func_die_cb, &func_info, 0) > 0)
+  CuInfo cu_info = {};
+  while (next_cu_info(&cu_info)) {
+    if (dwarf_getfuncs(cu_info.cu_die(), get_func_die_cb, &func_info, 0) > 0)
       return func_info.die;
   }
 
@@ -103,7 +186,7 @@ std::string Dwarf::get_type_name(Dwarf_Die &type_die) const
   switch (tag) {
     case DW_TAG_base_type:
     case DW_TAG_typedef:
-      return dwarf_diename(&type_die);
+      return get_die_name(&type_die);
     case DW_TAG_pointer_type: {
       if (dwarf_hasattr(&type_die, DW_AT_type)) {
         Dwarf_Die inner_type = type_of(type_die);
@@ -123,7 +206,7 @@ std::string Dwarf::get_type_name(Dwarf_Die &type_die) const
         prefix = "enum ";
 
       if (dwarf_hasattr(&type_die, DW_AT_name))
-        return prefix + dwarf_diename(&type_die);
+        return prefix + get_die_name(&type_die);
       else
         return prefix + "<anonymous>";
     }
@@ -185,7 +268,7 @@ SizedType Dwarf::get_stype(Dwarf_Die &type_die, bool resolve_structs) const
     }
     case DW_TAG_structure_type:
     case DW_TAG_union_type: {
-      std::string name = dwarf_diename(&type_die);
+      std::string name = get_die_name(&type_die);
       name = (tag == DW_TAG_structure_type ? "struct " : "union ") + name;
       auto result = CreateCStruct(
           name, bpftrace_->structs.LookupOrAdd(name, bit_size / 8));
@@ -277,7 +360,7 @@ void Dwarf::resolve_fields(const SizedType &type) const
   for (auto &field_die :
        get_all_children_with_tag(&type_die.value(), DW_TAG_member)) {
     Dwarf_Die field_type = type_of(field_die);
-    str->AddField(dwarf_diename(&field_die),
+    str->AddField(get_die_name(&field_die),
                   get_stype(field_type),
                   get_field_byte_offset(field_die),
                   resolve_bitfield(field_die));
@@ -292,7 +375,7 @@ std::vector<std::string> Dwarf::get_function_params(
     Dwarf_Die type_die = type_of(param_die);
     const std::string type_name = get_type_name(type_die);
     if (dwarf_hasattr(&param_die, DW_AT_name))
-      result.push_back(type_name + " " + dwarf_diename(&param_die));
+      result.push_back(type_name + " " + get_die_name(&param_die));
     else
       result.push_back(type_name);
   }
@@ -309,7 +392,7 @@ std::shared_ptr<Struct> Dwarf::resolve_args(const std::string &function)
     arg_type.is_funcarg = true;
     arg_type.funcarg_idx = i++;
     const std::string name = dwarf_hasattr(&param_die, DW_AT_name)
-                                 ? dwarf_diename(&param_die)
+                                 ? get_die_name(&param_die)
                                  : "";
     result->AddField(name, arg_type, result->size);
     result->size += arg_type.GetSize();
@@ -319,10 +402,9 @@ std::shared_ptr<Struct> Dwarf::resolve_args(const std::string &function)
 
 std::optional<Dwarf_Die> Dwarf::find_type(const std::string &name) const
 {
-  Dwarf_Die *cudie = nullptr;
-  Dwarf_Addr cubias;
-  while ((cudie = dwfl_nextcu(dwfl, cudie, &cubias)) != nullptr) {
-    if (auto type_die = get_child_with_tagname(cudie,
+  CuInfo cu_info = {};
+  while (next_cu_info(&cu_info)) {
+    if (auto type_die = get_child_with_tagname(cu_info.cu_die(),
                                                DW_TAG_structure_type,
                                                name))
       return type_die;
@@ -341,7 +423,7 @@ std::optional<Dwarf_Die> Dwarf::get_child_with_tagname(Dwarf_Die *die,
 
   do {
     if (dwarf_tag(&child_die) == tag && dwarf_hasattr(&child_die, DW_AT_name) &&
-        dwarf_diename(&child_die) == name)
+        get_die_name(&child_die) == name)
       return child_die;
   } while (dwarf_siblingof(child_iter, &child_die) == 0);
 
@@ -427,84 +509,74 @@ ssize_t Dwarf::get_bitfield_size(Dwarf_Die &field_die)
   return 0;
 }
 
-std::optional<std::filesystem::path> Dwarf::resolve_cu_path(
-    std::string_view cu_name,
-    std::string_view cu_comp_dir)
+std::optional<std::filesystem::path> Dwarf::get_cu_src_path(Dwarf_Die *cudie)
 {
-  if (cu_name.empty())
-    return std::nullopt;
+  Dwarf_Files *files;
+  size_t nfiles;
+  if (dwarf_getsrcfiles(cudie, &files, &nfiles) == 0 && nfiles > 0) {
+    // The returned source file path may either be absolute or relative.
+    // According to the DWARF standard, source file paths should be locatable by
+    // combining DW_AT_comp_dir with the CU's file name. However, DW_AT_comp_dir
+    // may be missing or empty, therefore callers should not assume the path is
+    // always absolute. https://wiki.dwarfstd.org/Best_Practices.md
+    const char *src = dwarf_filesrc(files, 0, nullptr, nullptr);
+    if (src) {
+      return std::filesystem::path(src);
+    }
+  }
 
-  // If CU name is relative. According to the DWARF standard, source
-  // file path name should be locatable by combining DW_AT_comp_dir with the
-  // relative CU path name. https://wiki.dwarfstd.org/Best_Practices.md
-  if (cu_name[0] != '/' && !cu_comp_dir.empty())
-    return std::filesystem::path(cu_comp_dir) / std::filesystem::path(cu_name);
-
-  // If CU name is already an absolute path to the source file. Also used as
-  // a fallback, when DW_AT_comp_dir string is empty.
-  return std::filesystem::path(cu_name);
+  return std::nullopt;
 }
 
-Result<Dwarf::CuInfo> Dwarf::get_cu_info(const std::string &source_file) const
+Result<Dwarf::CuInfo> Dwarf::get_cu_by_src(const std::string &source_file) const
 {
-  Dwarf_Die *cudie = nullptr;
-  Dwarf_Die *matched_cu = nullptr;
-  std::filesystem::path matched_cu_path;
-  Dwarf_Addr cubias;
+  std::optional<CuInfo> matched_cu;
+  std::filesystem::path matched_src_path;
 
-  while ((cudie = dwfl_nextcu(dwfl, cudie, &cubias)) != nullptr) {
-    const char *cu_name = dwarf_diename(cudie);
-    if (!cu_name) {
+  CuInfo cu_info = {};
+  while (next_cu_info(&cu_info)) {
+    auto src_path = get_cu_src_path(cu_info.cu_die());
+    if (!src_path)
       continue;
-    }
 
-    std::string_view cu_comp_dir;
-    Dwarf_Attribute attr;
-    if (dwarf_attr(cudie, DW_AT_comp_dir, &attr)) {
-      if (const char *dir_str = dwarf_formstring(&attr)) {
-        cu_comp_dir = dir_str;
-      }
-    }
-
-    // Resolve the CU's source file location path.
-    auto cu_path = resolve_cu_path(cu_name, cu_comp_dir);
-    if (!cu_path) {
-      continue;
-    }
-
-    if (util::path_ends_with(*cu_path, source_file)) {
+    if (util::path_ends_with(*src_path, source_file)) {
       if (!matched_cu) {
-        matched_cu = cudie;
-        matched_cu_path = *cu_path;
+        matched_cu = cu_info;
+        matched_src_path = *src_path;
       } else {
         return make_error<DwarfParseError>(
             "Ambiguous source path, matches multiple files: " +
-            matched_cu_path.string() + ", " + cu_path->string());
+            matched_src_path.string() + ", " + src_path->string());
       }
     }
   }
 
-  if (!matched_cu) {
+  if (!matched_cu)
     return make_error<DwarfParseError>("No compilation unit matches " +
                                        source_file);
-  }
 
-  return CuInfo{ .source = std::move(matched_cu_path), .die = matched_cu };
+  return std::move(*matched_cu);
 }
 
 Result<uint64_t> Dwarf::line_to_addr(const std::string &source_file,
                                      size_t line_num,
                                      size_t col_num) const
 {
-  auto cu = get_cu_info(source_file);
+  auto cu = get_cu_by_src(source_file);
   if (!cu) {
     return cu.takeError();
+  }
+
+  auto src_path = get_cu_src_path(cu->cu_die());
+  if (!src_path) {
+    return make_error<DwarfParseError>(
+        "Failed to get compilation unit source path");
   }
 
   Dwarf_Lines *lines = nullptr;
   size_t num_lines = 0;
 
-  if (dwarf_getsrclines(cu->die, &lines, &num_lines) != 0) {
+  if (dwarf_getsrclines(cu->cu_die(), &lines, &num_lines) != 0) {
     return make_error<DwarfParseError>(
         "Failed to get compilation unit source lines");
   }
@@ -528,7 +600,7 @@ Result<uint64_t> Dwarf::line_to_addr(const std::string &source_file,
 
     // Check if the line source matches the CU's source path, to avoid
     // unintentionally accessing statements from included files.
-    if (util::path_ends_with(linesrc, cu->source) &&
+    if (util::path_ends_with(linesrc, *src_path) &&
         line_num == static_cast<size_t>(lineno) &&
         (col_num == 0 || col_num == static_cast<size_t>(linecol))) {
       Dwarf_Addr addr;

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -43,8 +43,16 @@ class Dwarf {
 public:
   virtual ~Dwarf();
 
-  static std::unique_ptr<Dwarf> GetFromBinary(BPFtrace *bpftrace,
-                                              const std::string &file_path);
+  Dwarf(const Dwarf &) = delete;
+  Dwarf &operator=(const Dwarf &) = delete;
+
+  Dwarf(Dwarf &&) = delete;
+  Dwarf &operator=(Dwarf &&) = delete;
+
+  static std::unique_ptr<Dwarf> GetFromBinary(
+      BPFtrace *bpftrace,
+      const std::string &file_path,
+      const std::string &debuginfo_path);
 
   std::vector<std::string> get_function_params(
       const std::string &function) const;
@@ -58,13 +66,34 @@ public:
                                 size_t col_num = 0) const;
 
 private:
-  struct CuInfo {
-    std::filesystem::path source;
-    Dwarf_Die *die;
+  // Compilation unit wrapper, abstracting over regular and split (DWO/DWP)
+  // CU DIEs.
+  class CuInfo {
+  public:
+    // Standard CU DIE, managed by the libdw session.
+    Dwarf_Die *cudie = nullptr;
+
+    // Split CU DIE loaded from a dwo/dwp file. Must be owned and managed
+    // manually per the libdw API, and is valid for the lifetime of the CuInfo
+    // instance.
+    //
+    // Present when cudie is a DW_UT_skeleton unit. In that case, this should
+    // be used instead, as it holds vast majority of the debug info. libdw
+    // automatically resolves references between the skeleton and split CU.
+    std::optional<Dwarf_Die> split_cudie;
+
+    // Returns split CU DIE if present (skeleton CU), otherwise cudie.
+    Dwarf_Die *cu_die()
+    {
+      return split_cudie ? &split_cudie.value() : cudie;
+    }
   };
 
-  Dwarf(BPFtrace *bpftrace, const std::string &file_path);
+  Dwarf(BPFtrace *bpftrace,
+        const std::string &file_path,
+        std::string debuginfo_path);
 
+  bool next_cu_info(CuInfo *cu_info) const;
   std::vector<Dwarf_Die> function_param_dies(const std::string &function) const;
   std::optional<Dwarf_Die> get_func_die(const std::string &function) const;
   std::string get_type_name(Dwarf_Die &type_die) const;
@@ -78,7 +107,7 @@ private:
 
   SizedType get_stype(Dwarf_Die &type_die, bool resolve_structs = true) const;
 
-  Result<CuInfo> get_cu_info(const std::string &source_file) const;
+  Result<CuInfo> get_cu_by_src(const std::string &source_file) const;
 
   static std::optional<Dwarf_Die> get_child_with_tagname(
       Dwarf_Die *die,
@@ -87,15 +116,23 @@ private:
   static std::vector<Dwarf_Die> get_all_children_with_tag(Dwarf_Die *die,
                                                           int tag);
 
-  static std::optional<std::filesystem::path> resolve_cu_path(
-      std::string_view cu_name,
-      std::string_view cu_comp_dir);
+  static std::optional<std::filesystem::path> get_cu_src_path(Dwarf_Die *cudie);
 
   Dwfl *dwfl = nullptr;
   Dwfl_Callbacks callbacks;
 
   BPFtrace *bpftrace_;
   std::string file_path_;
+  // Dwfl_Callbacks struct takes a char** pointing to a debuginfo path which has
+  // to remain valid for the lifetime of the dwfl session, because debug info is
+  // loaded lazily; e.g. dwfl_nextcu triggers the find_debuginfo callback on
+  // first use for *each* module and dereferences the pointer.
+  //
+  // Each instance of this class owns a copy of the path string and keeps
+  // debuginfo_path_cstr_ pointing to its internal buffer to pass a stable
+  // char** to Dwfl_Callbacks.
+  std::string debuginfo_path_;
+  const char *debuginfo_path_cstr_;
 };
 
 } // namespace bpftrace
@@ -113,6 +150,8 @@ public:
   static std::unique_ptr<Dwarf> GetFromBinary(BPFtrace *bpftrace
                                               __attribute__((unused)),
                                               const std::string &file_path_
+                                              __attribute__((unused)),
+                                              const std::string &debuginfo_path
                                               __attribute__((unused)))
   {
     return nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,7 @@ enum Options {
   BTF,
   CMD,
   DEBUG,
+  DEBUGINFO,
   DRY_RUN,
   EMIT_ELF,
   EMIT_LLVM,
@@ -149,6 +150,8 @@ void usage(std::ostream& out)
   out << "                   only run probes whose name matches REGEX" << std::endl;
   out << "    --traceable-functions FILE" << std::endl;
   out << "                   load the list of traceable kernel functions from FILE" << std::endl;
+  out << "    --debuginfo DIR" << std::endl;
+  out << "                   add one or more directory to the debug info search path" << std::endl;
   out << std::endl;
   out << "TROUBLESHOOTING OPTIONS:" << std::endl;
   out << "    -v, --verbose           verbose messages" << std::endl;
@@ -330,6 +333,7 @@ struct Args {
   std::string script;
   std::string search;
   std::string filename;
+  std::string debuginfo_path;
   std::string output_file;
   std::string output_format;
   std::string output_elf;
@@ -422,6 +426,10 @@ Args parse_args(int argc, char* argv[])
             .has_arg = required_argument,
             .flag = nullptr,
             .val = Options::DEBUG },
+    option{ .name = "debuginfo",
+            .has_arg = required_argument,
+            .flag = nullptr,
+            .val = Options::DEBUGINFO },
     option{ .name = "dry-run",
             .has_arg = no_argument,
             .flag = nullptr,
@@ -663,6 +671,9 @@ Args parse_args(int argc, char* argv[])
       case 'b':
       case Options::BTF:
         break;
+      case Options::DEBUGINFO:
+        args.debuginfo_path = optarg;
+        break;
       case 'h':
       case Options::HELP:
         usage(std::cout);
@@ -870,6 +881,7 @@ int main(int argc, char* argv[])
   bpftrace.run_tests_ = args.mode == Mode::BPF_TEST;
   bpftrace.run_benchmarks_ = args.mode == Mode::BPF_BENCHMARK;
   bpftrace.probe_filter_ = args.probe_filter;
+  bpftrace.debuginfo_path_ = args.debuginfo_path;
 
   if (!args.pid_str.empty()) {
     auto maybe_pid = util::to_uint(args.pid_str);

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -433,7 +433,9 @@ FuncParamLists ProbeMatcher::get_uprobe_params(
   for (const auto& match : uprobes) {
     std::string fun = match;
     std::string path = util::erase_prefix(fun);
-    auto dwarf = Dwarf::GetFromBinary(nullptr, path);
+    auto dwarf = Dwarf::GetFromBinary(nullptr,
+                                      path,
+                                      bpftrace_->debuginfo_path_);
     if (dwarf) {
       params.emplace(match, dwarf->get_function_params(fun));
     } else {

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -98,3 +98,62 @@ REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
+NAME parse stripped debuginfo - list args
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test-stripped:main' --debuginfo=./debug
+EXPECT int argc
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
+NAME parse stripped debuginfo - arg by name
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped:uprobeFunction1 { printf("%c\n", args.c); exit(); }' --debuginfo=./debug
+EXPECT x
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test-stripped
+
+NAME parse stripped debuginfo - attach by source line
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped@uprobe_test.c:16 { print("ok"); exit(); }' --debuginfo=./debug
+EXPECT ok
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test-stripped
+
+NAME parse DWO debuginfo - list args
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/debug/dwo/uprobe_test-split:main'
+EXPECT int argc
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
+NAME parse DWO debuginfo - arg by name
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwo/uprobe_test-split:uprobeFunction1 { printf("%c\n", args.c); exit(); }'
+EXPECT x
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/debug/dwo/uprobe_test-split
+
+NAME parse DWO debuginfo - attach by source line
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwo/uprobe_test-split@uprobe_test.c:16 { printf("ok"); exit(); }'
+EXPECT ok
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/debug/dwo/uprobe_test-split
+
+NAME parse DWP debuginfo - list args
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/debug/dwp/uprobe_test-split:main'
+EXPECT int argc
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
+NAME parse DWP debuginfo - arg by name
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwp/uprobe_test-split:uprobeFunction1 { printf("%c\n", args.c); exit(); }'
+EXPECT x
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/debug/dwp/uprobe_test-split
+
+NAME parse DWP debuginfo - attach by source line
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwp/uprobe_test-split@uprobe_test.c:16 { printf("ok"); exit(); }'
+EXPECT ok
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/debug/dwp/uprobe_test-split

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -96,6 +96,53 @@ add_custom_command(
 )
 list(APPEND testprogtargets archive.zip)
 
+# Make debug subdirs to test parsing of external DWARF debug formats. 
+file(MAKE_DIRECTORY
+  ${CMAKE_CURRENT_BINARY_DIR}/debug
+  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo
+  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp
+)
+
+# Create a stripped binary with a separate .debug file, placed in a subdir; used to verify
+# loading and parsing of external debuginfo.
+add_custom_command(
+  OUTPUT 
+    ${CMAKE_CURRENT_BINARY_DIR}/uprobe_test-stripped
+    ${CMAKE_CURRENT_BINARY_DIR}/debug/uprobe_test-stripped.debug
+  COMMAND ${LLVM_OBJCOPY} --only-keep-debug $<TARGET_FILE:uprobe_test> ${CMAKE_CURRENT_BINARY_DIR}/debug/uprobe_test-stripped.debug
+  COMMAND ${LLVM_OBJCOPY} --strip-debug $<TARGET_FILE:uprobe_test> ${CMAKE_CURRENT_BINARY_DIR}/uprobe_test-stripped
+  DEPENDS uprobe_test
+)
+list(APPEND testprogtargets
+  ${CMAKE_CURRENT_BINARY_DIR}/uprobe_test-stripped
+  ${CMAKE_CURRENT_BINARY_DIR}/debug/uprobe_test-stripped.debug)
+
+# Build a binary with split DWARF (.dwo files) to verify parsing of the split debug info format.
+add_custom_command(
+  OUTPUT
+    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split
+    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split-uprobe_test.dwo
+  COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c
+)
+list(APPEND testprogtargets ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split)
+
+# Build a binary with split debuginfo and bundle the .dwo files into a DWARF Package (.dwp)
+# archive; to verify parsing of the packaged format.
+find_program(LLVM_DWP llvm-dwp REQUIRED)
+add_custom_command(
+  OUTPUT
+    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split
+    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split.dwp
+  COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split
+  COMMAND ${LLVM_DWP} -e ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split -o ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split.dwp
+  COMMAND ${CMAKE_COMMAND} -E rm -f ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/*.dwo
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c
+)
+list(APPEND testprogtargets
+  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split
+  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split.dwp)
+
 add_custom_target(testprogs ALL DEPENDS ${testprogtargets})
 
 foreach(prog usdt_lib usdt_lib-pie)


### PR DESCRIPTION
DWARF debug information may be stored in various external formats, including:
 - stripped `.debug` files
 - split DWARF object files and packages (`.dwo`, `.dwp`)
 - deduplicated shared `.dwz` files

In some cases, it is also necessary to have the external debug files outside the standard search paths, e.g. when running inside a container.

This commit enables the parser to handle these formats by adding support for dwo/dwp parsing and introducing a `debuginfo` option to extend the debug info search paths.

The `debuginfo` option does not yet support dwo/dwp files due to limitations in the libdw API. Support via debuginfod is currently under development in elfutils (as of 2026).

Additionally, fix a bug where a missing .dwz file could cause a crash by checking for file existence before parsing. This is not covered in tests on purpose, as the DWZ tool is very unstable and therefore difficult to test properly.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
