### PR TITLE
stdlib: Fix `strerror` error caused by exceeding the BPF stack limit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#5085](https://github.com/bpftrace/bpftrace/pull/5085)
 - Attach watchpoint probes to all threads of a process
   - [#5088](https://github.com/bpftrace/bpftrace/pull/5088)
+- Fix stdlib `strerror` error caused by exceeding the BPF stack limit.
+  - [#5094](https://github.com/bpftrace/bpftrace/pull/5094)
 
 ## [0.25.0] 2026-03-13
 

--- a/src/stdlib/strings/errors.h
+++ b/src/stdlib/strings/errors.h
@@ -46,6 +46,7 @@ static err_str errors[] = {
   [ENOSYS] = "Invalid system call number",
   [ENOTEMPTY] = "Directory not empty",
   [ELOOP] = "Too many symbolic links encountered",
+  // errno 41 does not exist
   [ENOMSG] = "No message of desired type",
   [EIDRM] = "Identifier removed",
   [ECHRNG] = "Channel number out of range",
@@ -62,6 +63,7 @@ static err_str errors[] = {
   [ENOANO] = "No anode",
   [EBADRQC] = "Invalid request code",
   [EBADSLT] = "Invalid slot",
+  // errno 58 does not exist
   [EBFONT] = "Bad font file format",
   [ENOSTR] = "Device not a stream",
   [ENODATA] = "No data available",

--- a/src/stdlib/strings/strings.bpf.c
+++ b/src/stdlib/strings/strings.bpf.c
@@ -71,7 +71,22 @@ int __strerror(int errno, err_str *out) {
     errno = -errno;
   }
   if (errno >= 0 && errno <= EHWPOISON) {
-    __builtin_memcpy(out, &errors[errno], sizeof(*out));
+    // The array 'errors' is not fully populated, skip the empty 'errno'.
+    //
+    // There is another benefit to doing this. BPF 512-byte stack limit.
+    // 1. When the code has extremely simple control flow, LLVM will allocate a
+    //    64-byte temporary stack buffer, which can exceed the limit when
+    //    accumulated.
+    // 2. By increasing the complexity of the code control flow, the LLVM
+    //    optimization strategy for memcpy was changed, allowing it to avoid
+    //    using a temporary stack buffer and instead use more direct memory
+    //    access instructions, thereby keeping the stack frame size within
+    //    limits.
+    if (errors[errno][0] == '\0') {
+      __builtin_memcpy(out, &unknown_error, sizeof(*out));
+    } else {
+      __builtin_memcpy(out, &errors[errno], sizeof(*out));
+    }
   } else {
     __builtin_memcpy(out, &unknown_error, sizeof(*out));
   }


### PR DESCRIPTION
backports

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
