### PR TITLE
dwarf user mode stack unwinding

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(runtime STATIC
   types_format.cpp
   ksyms.cpp
   usyms.cpp
+  dwunwind_table.cpp
+  dwunwind.cpp
   ${BFD_DISASM_SRC}
 )
 # Ensure flex+bison outputs are built first

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -328,6 +328,7 @@ private:
 
   ScopedExpr kstack(const SizedType &stype, const Location &loc);
   ScopedExpr ustack(const SizedType &stype, const Location &loc);
+  ScopedExpr dw_ustack(const SizedType &stype, const Location &loc);
 
   int get_probe_id();
 
@@ -397,6 +398,12 @@ private:
   VariableLLVM &getVariable(const std::string &var_ident);
 
   GlobalVariable *DeclareKernelVar(const std::string &name);
+
+  ScopedExpr createExternFuncCall(const std::string &name,
+                                  llvm::Type *return_type,
+                                  llvm::ArrayRef<llvm::Type *> arg_types,
+                                  llvm::ArrayRef<llvm::Value *> arg_values,
+                                  const Location &loc);
 
   ASTContext &ast_;
   BPFtrace &bpftrace_;
@@ -643,6 +650,81 @@ ScopedExpr CodegenLLVM::ustack(const SizedType &stype, const Location &loc)
                                                        b_.getInt32(3) }),
                                         stype.stack_type,
                                         loc);
+
+  Value *condition = b_.CreateICmpSGE(stack_size, b_.getInt64(0));
+  b_.CreateCondBr(condition, get_stack_success, get_stack_fail);
+
+  b_.SetInsertPoint(get_stack_fail);
+  b_.CreateRuntimeError(RuntimeErrorId::USTACK, loc);
+  b_.CreateBr(merge_block);
+
+  b_.SetInsertPoint(get_stack_success);
+
+  Value *num_frames = b_.CreateUDiv(stack_size,
+                                    b_.getInt64(stype.stack_type.elem_size()));
+  b_.CreateStore(num_frames,
+                 b_.CreateGEP(stack_struct_type,
+                              stack,
+                              { b_.getInt64(0), b_.getInt32(2) }));
+  // store pid
+  b_.CreateStore(b_.CreateGetPid(loc, false),
+                 b_.CreateGEP(stack_struct_type,
+                              stack,
+                              { b_.getInt64(0), b_.getInt32(0) }));
+  // store probe id
+  b_.CreateStore(b_.GetIntSameSize(get_probe_id(),
+                                   stack_struct_type->getTypeAtIndex(1)),
+                 b_.CreateGEP(stack_struct_type,
+                              stack,
+                              { b_.getInt64(0), b_.getInt32(1) }));
+  b_.CreateBr(merge_block);
+  b_.SetInsertPoint(merge_block);
+
+  return ScopedExpr(stack);
+}
+
+ScopedExpr CodegenLLVM::dw_ustack(const SizedType &stype, const Location &loc)
+{
+  StructType *stack_struct_type = b_.GetStackStructType(stype.stack_type);
+
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
+
+  BasicBlock *merge_block = BasicBlock::Create(module_->getContext(),
+                                               "merge_block",
+                                               parent);
+
+  auto *stack = b_.CreateCallStackAllocation(stype,
+                                             stype.stack_type.name(),
+                                             loc);
+  b_.CreateMemsetBPF(stack,
+                     b_.getInt8(0),
+                     datalayout().getTypeStoreSize(stack_struct_type));
+
+  BasicBlock *get_stack_success = BasicBlock::Create(module_->getContext(),
+                                                     "get_stack_success",
+                                                     parent);
+  BasicBlock *get_stack_fail = BasicBlock::Create(module_->getContext(),
+                                                  "get_stack_fail",
+                                                  parent);
+  Value *stack_trace = b_.CreateGEP(stack_struct_type,
+                                    stack,
+                                    { b_.getInt64(0), b_.getInt32(3) });
+  Value *p_stack_size = b_.getInt32(stype.stack_type.limit *
+                                    stype.stack_type.elem_size());
+  Value *tgid = b_.CreateGetPid(loc, false);
+  std::array<llvm::Type *, 4> arg_types = {
+    b_.getPtrTy(), b_.getPtrTy(), b_.getInt32Ty(), b_.getInt32Ty()
+  };
+  std::array<llvm::Value *, 4> arg_values = {
+    ctx_, stack_trace, p_stack_size, tgid
+  };
+  Value *stack_size = createExternFuncCall("__ustack_dwunwind",
+                                           b_.getInt64Ty(),
+                                           arg_types,
+                                           arg_values,
+                                           loc)
+                          .value();
+
   Value *condition = b_.CreateICmpSGE(stack_size, b_.getInt64(0));
   b_.CreateCondBr(condition, get_stack_success, get_stack_fail);
 
@@ -706,6 +788,8 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
     return kstack(type_map_.type(&builtin), builtin.loc);
   } else if (builtin.ident == "ustack") {
     return ustack(type_map_.type(&builtin), builtin.loc);
+  } else if (builtin.ident == "__builtin_dw_ustack") {
+    return dw_ustack(type_map_.type(&builtin), builtin.loc);
   } else if (builtin.ident == "pid") {
     return ScopedExpr(b_.CreateGetPid(builtin.loc, false));
   } else if (builtin.ident == "tid") {
@@ -1893,6 +1977,8 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     return kstack(type_map_.type(&call), call.loc);
   } else if (call.func == "ustack") {
     return ustack(type_map_.type(&call), call.loc);
+  } else if (call.func == "__builtin_dw_ustack") {
+    return dw_ustack(type_map_.type(&call), call.loc);
   } else if (call.func == "strncmp") {
     auto &left_arg = call.vargs.at(0);
     auto &right_arg = call.vargs.at(1);
@@ -2032,7 +2118,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     auto *inst = b_.CreateCall(func, arg_values, call.func);
     return ScopedExpr(inst, [this, inst, &call] {
       // We set the debug location on the call instructions only after the
-      // scoped expression is not longer used. Otherwise the instruction emitter
+      // scoped expression is no longer used. Otherwise the instruction emitter
       // seems to use this location for everything, which results in problems.
       inst->setDebugLoc(
           debug_.createDebugLocation(llvm_ctx_, scope_, call.loc));
@@ -4768,6 +4854,40 @@ Value *CodegenLLVM::createFmtString(int print_id)
   res->setAlignment(MaybeAlign(1));
   res->setLinkage(llvm::GlobalValue::InternalLinkage);
   return res;
+}
+
+ScopedExpr CodegenLLVM::createExternFuncCall(
+    const std::string &name,
+    llvm::Type *return_type,
+    llvm::ArrayRef<llvm::Type *> arg_types,
+    llvm::ArrayRef<llvm::Value *> arg_values,
+    const Location &loc)
+{
+  auto *func = extern_funcs_[name];
+  if (!func) {
+    FunctionType *function_type = FunctionType::get(return_type,
+                                                    arg_types,
+                                                    false);
+    func = llvm::Function::Create(
+        function_type, llvm::Function::ExternalLinkage, name, module_.get());
+    func->addFnAttr(Attribute::AlwaysInline);
+    func->addFnAttr(Attribute::NoUnwind);
+    func->setDSOLocal(true);
+
+    // Add noundef attribute to each argument.
+    for (auto &arg : func->args()) {
+      arg.addAttr(Attribute::NoUndef);
+    }
+    extern_funcs_[name] = func;
+  }
+
+  auto *inst = b_.CreateCall(func, arg_values, name);
+  return ScopedExpr(inst, [this, inst, loc] {
+    // We set the debug location on the call instructions only after the
+    // scoped expression is not longer used. Otherwise the instruction emitter
+    // seems to use this location for everything, which results in problems.
+    inst->setDebugLoc(debug_.createDebugLocation(llvm_ctx_, scope_, loc));
+  });
 }
 
 /// This should emit

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -168,7 +168,8 @@ void ResourceAnalyser::visit(Builtin &builtin)
     resources_.global_vars.add_known(bpftrace::globalvars::NUM_CPUS);
   } else if (builtin.ident == "__builtin_cpid") {
     resources_.global_vars.add_known(bpftrace::globalvars::CHILD_PID);
-  } else if (builtin.ident == "ustack" || builtin.ident == "kstack") {
+  } else if (builtin.ident == "ustack" || builtin.ident == "kstack" ||
+             builtin.ident == "__builtin_dw_ustack") {
     const auto &ty = type_map_.type(&builtin);
     if (exceeds_stack_limit(ty.GetSize())) {
       resources_.call_stack_buffers++;
@@ -332,7 +333,8 @@ void ResourceAnalyser::visit(Call &call)
     } else {
       call.addError() << "Different tseries bounds in a single map unsupported";
     }
-  } else if (call.func == "ustack" || call.func == "kstack") {
+  } else if (call.func == "ustack" || call.func == "kstack" ||
+             call.func == "__builtin_dw_ustack") {
     const auto &ty = type_map_.type(&call);
     if (exceeds_stack_limit(ty.GetSize())) {
       resources_.call_stack_buffers++;
@@ -607,7 +609,8 @@ bool ResourceAnalyser::exceeds_stack_limit(size_t size)
 
 bool ResourceAnalyser::uses_usym_table(const std::string &fun)
 {
-  return fun == "usym" || fun == "__builtin_func" || fun == "ustack";
+  return fun == "usym" || fun == "__builtin_func" || fun == "ustack" ||
+         fun == "__builtin_dw_ustack";
 }
 
 void ResourceAnalyser::update_map_info(Map &map)

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -283,6 +283,7 @@ struct nargs_spec {
 
 // clang-format off
 const std::map<std::string, nargs_spec> CALL_NARGS = {
+  { "__builtin_dw_ustack", { .min_args=0, .max_args=2 } },
   { "__builtin_uaddr", { .min_args=1, .max_args=1 } },
   { "avg",            { .min_args=3, .max_args=3 } },
   { "bswap",          { .min_args=1, .max_args=1 } },

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -872,7 +872,8 @@ void TypeRuleCollector::visit(Builtin &builtin)
       builtin_type = CreateStack(
           true, StackType{ .mode = bpftrace_.config_->stack_mode });
     }
-  } else if (builtin.ident == "ustack") {
+  } else if (builtin.ident == "ustack" ||
+             builtin.ident == "__builtin_dw_ustack") {
     builtin_type = CreateStack(
         false, StackType{ .mode = bpftrace_.config_->stack_mode });
   } else if (builtin.ident == "__builtin_comm") {
@@ -1206,7 +1207,7 @@ void TypeRuleCollector::visit(Call &call)
       return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
     } else if (call.func == "kstack") {
       return_type = get_stack_type(call, true);
-    } else if (call.func == "ustack") {
+    } else if (call.func == "ustack" || call.func == "__builtin_dw_ustack") {
       return_type = get_stack_type(call, false);
     } else if (call.func == "path") {
       auto call_type_size = bpftrace_.config_->max_strlen;

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -19,6 +19,7 @@ const auto IMPORT_STATEMENTS = "import statements";
 const auto TSERIES = "tseries";
 const auto ADDR = "address-of operator (&)";
 const auto TYPEINFO = "typeinfo";
+const auto DW_USTACK = "dw_ustack (DWARF stack unwinding)";
 
 std::string get_warning(const std::string &feature, const std::string &config)
 {
@@ -54,6 +55,8 @@ private:
   std::unordered_set<std::string> warned_features;
 
   void check_unstable_addr(Node &node);
+  void check_unstable_tseries(Node &node);
+  void check_unstable_dw_ustack(Node &node);
 };
 
 } // namespace
@@ -96,18 +99,10 @@ void UnstableFeature::visit(RootImport &imp)
 
 void UnstableFeature::visit(Call &call)
 {
-  if (call.func != "tseries") {
-    return;
-  }
-
-  if (bpftrace_.config_->unstable_tseries == ConfigUnstable::error) {
-    call.addError() << get_error(TSERIES, UNSTABLE_TSERIES);
-    return;
-  }
-  if (bpftrace_.config_->unstable_tseries == ConfigUnstable::warn &&
-      !warned_features.contains(UNSTABLE_TSERIES)) {
-    LOG(WARNING) << get_warning(TSERIES, UNSTABLE_TSERIES);
-    warned_features.insert(UNSTABLE_TSERIES);
+  if (call.func == "tseries") {
+    check_unstable_tseries(call);
+  } else if (call.func == "dw_ustack") {
+    check_unstable_dw_ustack(call);
   }
 }
 
@@ -133,6 +128,34 @@ void UnstableFeature::check_unstable_addr(Node &node)
       !warned_features.contains(UNSTABLE_ADDR)) {
     LOG(WARNING) << get_warning(ADDR, UNSTABLE_ADDR);
     warned_features.insert(UNSTABLE_ADDR);
+  }
+}
+
+void UnstableFeature::check_unstable_tseries(Node &node)
+{
+  if (bpftrace_.config_->unstable_tseries == ConfigUnstable::error) {
+    node.addError() << get_error(TSERIES, UNSTABLE_TSERIES);
+    return;
+  }
+
+  if (bpftrace_.config_->unstable_tseries == ConfigUnstable::warn &&
+      !warned_features.contains(UNSTABLE_TSERIES)) {
+    LOG(WARNING) << get_warning(TSERIES, UNSTABLE_TSERIES);
+    warned_features.insert(UNSTABLE_TSERIES);
+  }
+}
+
+void UnstableFeature::check_unstable_dw_ustack(Node &node)
+{
+  if (bpftrace_.config_->unstable_dw_ustack == ConfigUnstable::error) {
+    node.addError() << get_error(DW_USTACK, UNSTABLE_DW_USTACK);
+    return;
+  }
+
+  if (bpftrace_.config_->unstable_dw_ustack == ConfigUnstable::warn &&
+      !warned_features.contains(UNSTABLE_DW_USTACK)) {
+    LOG(WARNING) << get_warning(DW_USTACK, UNSTABLE_DW_USTACK);
+    warned_features.insert(UNSTABLE_DW_USTACK);
   }
 }
 

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -341,6 +341,11 @@ bool BpfBytecode::all_progs_loaded()
   });
 }
 
+bool BpfBytecode::hasMap(const std::string &name) const
+{
+  return maps_.contains(name);
+}
+
 bool BpfBytecode::hasMap(MapType internal_type) const
 {
   return maps_.contains(to_string(internal_type));

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -68,6 +68,7 @@ public:
   const BpfProgram &getProgramForProbe(const Probe &probe) const;
   BpfProgram &getProgramForProbe(const Probe &probe);
 
+  bool hasMap(const std::string &name) const;
   bool hasMap(MapType internal_type) const;
   const BpfMap &getMap(const std::string &name) const;
   const BpfMap &getMap(MapType internal_type) const;

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -121,6 +121,15 @@ Result<> BpfMap::lookup_elem(const void *key, void *value) const
   return OK();
 }
 
+Result<> BpfMap::resize(uint32_t new_size) const
+{
+  auto err = bpf_map__set_max_entries(bpf_map_, new_size);
+  if (err != 0) {
+    return make_error<BpfMapError>(name_, "resize", err);
+  }
+  return OK();
+}
+
 Result<MapElements> BpfMap::collect_elements(int nvalues) const
 {
   auto keys = collect_keys();

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -83,6 +83,7 @@ public:
   Result<> clear() const;
   Result<> update_elem(const void *key, const void *value) const;
   Result<> lookup_elem(const void *key, void *value) const;
+  Result<> resize(uint32_t new_size) const;
 
 private:
   struct bpf_map *bpf_map_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -43,6 +43,7 @@
 #include "bpfprogram.h"
 #include "bpftrace.h"
 #include "btf.h"
+#include "dwunwind.h"
 #include "log.h"
 #include "output/capture.h"
 #include "output/discard.h"
@@ -289,6 +290,116 @@ void skb_output_lost(void *ctx, [[maybe_unused]] int cpu, __u64 cnt)
   perf_ctx->output.lost_events(cnt);
 }
 
+/*
+ * Parse all DWARF unwind information here and buffer in RAM, so we
+ * know how much space we need in the maps. Once dynamically allocated
+ * hash maps are widely available, we can omit this step and directly
+ * push to the maps in the step after loading the progs.
+ */
+int parse_dwarf_unwind(
+    BpfBytecode &bytecode,
+    const std::vector<uint64_t> &pids,
+    std::map<TableType, std::vector<std::vector<uint8_t>>> &unwind_data,
+    std::map<uint32_t, std::vector<uint8_t>> &unwind_mappings)
+{
+  auto unwind = DWARFUnwind(
+      [&unwind_data, &unwind_mappings](TableType t,
+                                       uint32_t k,
+                                       const std::vector<uint8_t> &v) {
+        if (t != TableType::Mappings) {
+          if (!unwind_data.contains(t)) {
+            unwind_data[t] = std::vector<std::vector<uint8_t>>();
+          }
+          auto &table = unwind_data[t];
+          if (k < table.size()) {
+            table[k] = v;
+          } else if (k == table.size()) {
+            table.emplace_back(v);
+          } else {
+            LOG(BUG) << "Unwind mapping key " << k << " out of order, expected "
+                     << table.size();
+            return -1;
+          }
+        } else {
+          unwind_mappings[k] = v;
+        }
+        return 0;
+      });
+  for (const auto &pid : pids) {
+    auto ret = unwind.add_pid(pid);
+    if (ret != DWARFError::Success)
+      return -1;
+  }
+
+  // resize maps
+  for (auto const &t : unwind_data) {
+    Result<> ret = OK();
+    auto size = t.second.size();
+    if (t.first == TableType::UnwindTable) {
+      ret = bytecode.getMap(DWUNWIND_OFFSETMAPS).resize(size);
+    } else if (t.first == TableType::UnwindEntries) {
+      ret = bytecode.getMap(DWUNWIND_CFTS).resize(size);
+    } else if (t.first == TableType::Expressions) {
+      ret = bytecode.getMap(DWUNWIND_EXPRESSIONS).resize(size);
+    } else {
+      LOG(BUG) << "Unknown table type: " << static_cast<int>(t.first);
+      return -1;
+    }
+    if (!ret) {
+      LOG(BUG) << "Failed to resize unwind table: " << ret.takeError();
+      return -1;
+    }
+  }
+  auto ret = bytecode.getMap(DWUNWIND_MAPPINGS).resize(unwind_mappings.size());
+  if (!ret) {
+    LOG(BUG) << "Failed to resize unwind table: " << ret.takeError();
+    return -1;
+  }
+  std::cout << "resized mappings to " << unwind_mappings.size() << std::endl;
+
+  return 0;
+}
+
+int feed_dwarf_unwind(
+    BpfBytecode &bytecode,
+    const std::map<TableType, std::vector<std::vector<uint8_t>>> &unwind_data,
+    const std::map<uint32_t, std::vector<uint8_t>> &unwind_mappings)
+{
+  // update arrays
+  for (auto const &t : unwind_data) {
+    std::string name;
+    const BpfMap *table;
+    if (t.first == TableType::UnwindTable) {
+      table = &bytecode.getMap(DWUNWIND_OFFSETMAPS);
+    } else if (t.first == TableType::UnwindEntries) {
+      table = &bytecode.getMap(DWUNWIND_CFTS);
+    } else if (t.first == TableType::Expressions) {
+      table = &bytecode.getMap(DWUNWIND_EXPRESSIONS);
+    } else {
+      LOG(BUG) << "Unknown table type: " << static_cast<int>(t.first);
+      return -1;
+    }
+    for (size_t i = 0; i < t.second.size(); i++) {
+      auto ret = table->update_elem(&i, t.second[i].data());
+      if (!ret) {
+        LOG(BUG) << "Failed to add unwind entry: " << ret.takeError();
+        return -1;
+      }
+    }
+  }
+  // unwind mappings are indexed by pid, so they are stored in a hash map
+  auto table = bytecode.getMap(DWUNWIND_MAPPINGS);
+  for (auto const &m : unwind_mappings) {
+    auto ret = table.update_elem(&m.first, m.second.data());
+    if (!ret) {
+      LOG(BUG) << "Failed to add unwind mapping: " << ret.takeError();
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
 void BPFtrace::add_param(const std::string &param)
 {
   params_.emplace_back(param);
@@ -431,6 +542,9 @@ int BPFtrace::run(output::Output &out,
                   const ast::CDefinitions &c_definitions,
                   BpfBytecode bytecode)
 {
+  std::map<TableType, std::vector<std::vector<uint8_t>>> unwind_data;
+  std::map<uint32_t, std::vector<uint8_t>> unwind_mappings;
+
   bytecode_ = std::move(bytecode);
   bytecode_.set_map_ids(resources);
 
@@ -467,6 +581,37 @@ int BPFtrace::run(output::Output &out,
 
   set_rlimit_nofile(resources.num_probes(), resources.maps_info.size());
 
+  bool needs_dwarf_unwind = bytecode_.hasMap(DWUNWIND_MAPPINGS);
+  if (needs_dwarf_unwind) {
+    if (procmon_)
+      dwarf_pids_.emplace_back(procmon_->pid());
+    if (child_)
+      dwarf_pids_.emplace_back(child_->pid());
+  }
+
+  if (!(run_tests_ || run_benchmarks_) && child_ &&
+      (has_usdt_ || needs_dwarf_unwind)) {
+    auto result = child_->run(true);
+    if (!result) {
+      LOG(ERROR) << "Failed to setup child: " << result.takeError();
+      return -1;
+    }
+    if (needs_dwarf_unwind) {
+      auto ok = child_->run_until_entry();
+      if (!ok) {
+        LOG(ERROR) << "Failed to run child to entry: " << ok.takeError();
+        return -1;
+      }
+    }
+  }
+
+  if (bytecode_.hasMap(DWUNWIND_MAPPINGS) && !dwarf_pids_.empty()) {
+    int ret = parse_dwarf_unwind(
+        bytecode_, dwarf_pids_, unwind_data, unwind_mappings);
+    if (ret)
+      return ret;
+  }
+
   auto ok = bytecode_.load_progs(resources, *btf_, *feature_, *config_);
   if (!ok) {
     auto errs = handleErrors(std::move(ok), [&](const HelperVerifierError &e) {
@@ -497,6 +642,12 @@ int BPFtrace::run(output::Output &out,
       LOG(ERROR) << errs.takeError();
     }
     return -1;
+  }
+
+  if (bytecode_.hasMap(DWUNWIND_MAPPINGS) && !dwarf_pids_.empty()) {
+    int ret = feed_dwarf_unwind(bytecode_, unwind_data, unwind_mappings);
+    if (ret)
+      return ret;
   }
 
   async_action::AsyncHandlers handlers(*this, c_definitions, out);
@@ -691,14 +842,6 @@ int BPFtrace::run(output::Output &out,
       ++num_signal_attached;
     }
 
-    if (child_ && has_usdt_) {
-      auto result = child_->run(true);
-      if (!result) {
-        LOG(ERROR) << "Failed to setup child: " << result.takeError();
-        return -1;
-      }
-    }
-
     bytecode_.attach_external();
 
     // The kernel appears to fire some probes in the order that they were
@@ -748,7 +891,7 @@ int BPFtrace::run(output::Output &out,
 
     // Kick the child to execute the command.
     if (child_) {
-      if (has_usdt_) {
+      if (has_usdt_ || needs_dwarf_unwind) {
         auto result = child_->resume();
         if (!result) {
           LOG(ERROR) << "Failed to run child: " << result.takeError();

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -213,6 +213,7 @@ public:
   std::unordered_set<std::string> btf_set_;
   std::unique_ptr<util::ChildProc> child_;
   std::unique_ptr<util::Proc> procmon_;
+  std::vector<uint64_t> dwarf_pids_;
   std::optional<pid_t> pid() const
   {
     if (procmon_) {

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 
 #include "build_info.h"
+#include "dwunwind.h"
 
 #include "version.h"
 
@@ -35,6 +36,12 @@ std::string BuildInfo::report()
 #endif
   buf << "  blazesym (advanced symbolization): "
 #ifdef HAVE_BLAZESYM
+      << "yes" << std::endl;
+#else
+      << "no" << std::endl;
+#endif
+  buf << "  dwunwind (DWARF stack unwinding): "
+#ifdef DWUNWIND
       << "yes" << std::endl;
 #else
       << "no" << std::endl;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -331,6 +331,7 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
   { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },
   { UNSTABLE_TYPEINFO, CONFIG_FIELD_PARSER(unstable_typeinfo) },
+  { UNSTABLE_DW_USTACK, CONFIG_FIELD_PARSER(unstable_dw_ustack) },
 };
 
 // These symbols are deprecated, and have been remapped elsewhere.

--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,7 @@ static const auto UNSTABLE_IMPORT_STATEMENT = "unstable_import_statement";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
 static const auto UNSTABLE_ADDR = "unstable_addr";
 static const auto UNSTABLE_TYPEINFO = "unstable_typeinfo";
+static const auto UNSTABLE_DW_USTACK = "unstable_dw_ustack";
 
 static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
   "symbol_source",
@@ -68,6 +69,7 @@ public:
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;
   ConfigUnstable unstable_addr = ConfigUnstable::warn;
   ConfigUnstable unstable_typeinfo = ConfigUnstable::error;
+  ConfigUnstable unstable_dw_ustack = ConfigUnstable::warn;
 #ifdef HAVE_BLAZESYM
   bool use_blazesym = true;
   bool show_debug_info = true;

--- a/src/dwunwind.cpp
+++ b/src/dwunwind.cpp
@@ -1,0 +1,817 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#include <vector>
+#pragma GCC diagnostic pop
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+
+#include "dwunwind.h"
+#include "dwunwind_table.h"
+#include "log.h"
+
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Object/ObjectFile.h"
+#include <llvm/Config/llvm-config.h>
+
+#include "stdlib/stack/expression.h"
+
+const int NUM_REGISTERS = 17;
+const int CFT_ENTRY_SIZE = 228;
+const int MAX_MAPPINGS = 1000;
+const int CHUNK_SIZE = 256 * 1024;
+
+std::ostream &operator<<(std::ostream &os, const DWARFError &err)
+{
+  switch (err) {
+    case DWARFError::Success:
+      os << "Success";
+      break;
+    case DWARFError::FileNotFound:
+      os << "FileNotFound";
+      break;
+    case DWARFError::ParseError:
+      os << "ParseError";
+      break;
+    case DWARFError::UnsupportedFormat:
+      os << "UnsupportedFormat";
+      break;
+    case DWARFError::InternalError:
+      os << "InternalError";
+      break;
+    case DWARFError::TooManyObjects:
+      os << "TooManyObjects";
+      break;
+    default:
+      os << "UnknownError";
+      break;
+  }
+  return os;
+}
+
+static void append_u8(std::vector<uint8_t> &buf, uint8_t val)
+{
+  if (buf.capacity() < buf.size() + 1)
+    throw std::bad_alloc();
+  buf.emplace_back(val);
+}
+
+static void append_u32(std::vector<uint8_t> &buf, uint32_t val)
+{
+  if (buf.capacity() < buf.size() + 4)
+    throw std::bad_alloc();
+  buf.emplace_back(static_cast<uint8_t>(val & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 8) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 16) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 24) & 0xff));
+}
+
+static void append_u64(std::vector<uint8_t> &buf, uint64_t val)
+{
+  if (buf.capacity() < buf.size() + 8)
+    throw std::bad_alloc();
+  buf.emplace_back(static_cast<uint8_t>(val & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 8) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 16) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 24) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 32) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 40) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 48) & 0xff));
+  buf.emplace_back(static_cast<uint8_t>((val >> 56) & 0xff));
+}
+
+static uint64_t expr_get(const std::vector<uint8_t> &expr_u8,
+                         size_t size,
+                         size_t &ix)
+{
+  if (ix + size > expr_u8.size())
+    throw std::out_of_range("expr_get out of range");
+
+  uint64_t v = 0;
+  for (size_t j = 0; j < size; ++j) {
+    v |= static_cast<uint64_t>(expr_u8[ix + j]) << (j * 8);
+  }
+  return v;
+}
+
+static uint64_t expr_get_leb(const std::vector<uint8_t> &expr_u8,
+                             bool is_signed,
+                             size_t &ix)
+{
+  uint64_t result = 0;
+  unsigned shift = 0;
+  uint8_t byte;
+  while (true) {
+    if (ix >= expr_u8.size())
+      throw std::out_of_range("expr_get_sleb out of range");
+
+    byte = expr_u8[ix++];
+    result |= static_cast<uint64_t>(byte & 0x7f) << shift;
+    shift += 7;
+    if ((byte & 0x80) == 0)
+      break;
+  }
+  // sign extend
+  if (is_signed && (shift < 64) && (byte & 0x40))
+    result |= -(1ULL << shift);
+  return result;
+}
+
+static void convert_expression(const std::vector<uint8_t> &expr_u8,
+                               std::vector<uint8_t> &eout)
+{
+  eout.emplace_back(0); // placeholder for number of instructions
+  uint64_t v;
+  uint64_t w;
+  size_t i = 0;
+  uint8_t nexpr = 0;
+  while (i < expr_u8.size()) {
+    if (nexpr == MAX_EXPR_INSTRUCTIONS)
+      throw std::runtime_error("DWARF expression too long");
+    ++nexpr;
+    uint8_t op = expr_u8[i++];
+    switch (op) {
+      case llvm::dwarf::DW_OP_addr:
+        // XXX handle 32 bit case
+        v = expr_get(expr_u8, 8, i);
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_deref:
+        append_u8(eout, EXPR_OP_DEREF);
+        break;
+      case llvm::dwarf::DW_OP_const1u:
+        v = expr_get(expr_u8, 1, i);
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_const1s:
+        v = static_cast<int8_t>(expr_get(expr_u8, 1, i));
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_const2u:
+        v = expr_get(expr_u8, 2, i);
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_const2s:
+        v = static_cast<int16_t>(expr_get(expr_u8, 2, i));
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_const4u:
+        v = expr_get(expr_u8, 4, i);
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_const4s:
+        v = static_cast<int32_t>(expr_get(expr_u8, 4, i));
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_const8u:
+      case llvm::dwarf::DW_OP_const8s:
+        v = expr_get(expr_u8, 8, i);
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_constu:
+        v = expr_get_leb(expr_u8, false, i);
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_consts:
+        v = expr_get_leb(expr_u8, true, i);
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_lit0... llvm::dwarf::DW_OP_lit31:
+        v = op - llvm::dwarf::DW_OP_lit0;
+        append_u8(eout, EXPR_OP_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_reg0... llvm::dwarf::DW_OP_reg31:
+        v = op - llvm::dwarf::DW_OP_reg0;
+        append_u8(eout, EXPR_OP_BREG);
+        append_u8(eout, v);
+        append_u64(eout, 0);
+        break;
+      case llvm::dwarf::DW_OP_breg0... llvm::dwarf::DW_OP_breg31:
+        v = op - llvm::dwarf::DW_OP_breg0;
+        w = expr_get_leb(expr_u8, true, i);
+        append_u8(eout, EXPR_OP_BREG);
+        append_u8(eout, v);
+        append_u64(eout, w);
+        break;
+      case llvm::dwarf::DW_OP_and:
+        append_u8(eout, EXPR_OP_AND);
+        break;
+      case llvm::dwarf::DW_OP_ge:
+        append_u8(eout, EXPR_OP_GE);
+        break;
+      case llvm::dwarf::DW_OP_shl:
+        append_u8(eout, EXPR_OP_SHL);
+        break;
+      case llvm::dwarf::DW_OP_plus:
+        append_u8(eout, EXPR_OP_PLUS);
+        break;
+      case llvm::dwarf::DW_OP_mul:
+        append_u8(eout, EXPR_OP_MUL);
+        break;
+      case llvm::dwarf::DW_OP_plus_uconst:
+        v = expr_get_leb(expr_u8, false, i);
+        append_u8(eout, EXPR_OP_PLUS_CONST);
+        append_u64(eout, v);
+        break;
+      case llvm::dwarf::DW_OP_addrx:
+      case llvm::dwarf::DW_OP_call2:
+      case llvm::dwarf::DW_OP_call4:
+      case llvm::dwarf::DW_OP_call_ref:
+      case llvm::dwarf::DW_OP_const_type:
+      case llvm::dwarf::DW_OP_constx:
+      case llvm::dwarf::DW_OP_convert:
+      case llvm::dwarf::DW_OP_deref_type:
+      case llvm::dwarf::DW_OP_regval_type:
+      case llvm::dwarf::DW_OP_reinterpret:
+      case llvm::dwarf::DW_OP_push_object_address:
+      case llvm::dwarf::DW_OP_call_frame_cfa:
+        LOG(ERROR) << "DWARF expression op 0x" << std::hex
+                   << static_cast<int>(op) << std::dec << " not allowed here.";
+        throw std::runtime_error("invalid DWARF expression");
+        break;
+      default:
+        LOG(ERROR) << "DWARF expression op 0x" << std::hex
+                   << static_cast<int>(op) << std::dec
+                   << " not implemented yet.";
+        throw std::runtime_error("unsupported DWARF expression");
+        break;
+    }
+  }
+  eout[0] = nexpr;
+}
+
+std::optional<uint32_t> DWARFUnwind::add_expression(llvm::DWARFExpression &expr)
+{
+  auto expr_bytes = expr.getData();
+  auto expr_u8 = std::vector<uint8_t>(expr_bytes.begin(), expr_bytes.end());
+  auto it = expressions_.find(expr_u8);
+  if (it != expressions_.end())
+    return it->second;
+
+  uint32_t id = expressions_.size();
+  expressions_[expr_u8] = id;
+
+  //
+  // preprocess expression to simplify bpf code
+  // mainly we expand all arguments to 64 bits (registers to 8 bits)
+  //
+  std::vector<uint8_t> expr_out;
+  expr_out.reserve(256);
+
+  try {
+    convert_expression(expr_u8, expr_out);
+  } catch (const std::exception &e) {
+    LOG(ERROR) << "Failed to convert DWARF expression: " << e.what();
+    return std::nullopt;
+  }
+  expr_out.resize(256, 0);
+
+  if (table_feed_cb_(TableType::Expressions, id, expr_out))
+    return std::nullopt;
+
+  return id;
+}
+
+DWARFError DWARFUnwind::add_object_file(const std::string &filename)
+{
+  uint32_t out_oid;
+
+  auto ret = add_file_nopush(filename, -1, out_oid);
+  if (ret != DWARFError::Success)
+    return ret;
+  return push_current_table();
+}
+
+DWARFError DWARFUnwind::add_file_nopush(const std::string &filename,
+                                        int pid,
+                                        uint32_t &out_oid)
+{
+  auto f = files_seen_.find(filename);
+  if (f != files_seen_.end()) {
+    if (!f->second.has_value())
+      return DWARFError::ParseError;
+    out_oid = *f->second;
+    return DWARFError::Success;
+  }
+
+  DWARFError err = add_new_file(filename, pid, out_oid);
+  if (err != DWARFError::Success) {
+    files_seen_[filename] = std::nullopt;
+  } else {
+    files_seen_[filename] = out_oid;
+  }
+
+  return err;
+}
+
+// Template function to handle specific ELF bit-widths and endianness
+template <typename ELFT>
+void build_map_offsets(const llvm::object::ELFObjectFile<ELFT> *Obj,
+                       std::map<uint64_t, uint64_t> &map_offsets)
+{
+  for (const auto &Section : Obj->sections()) {
+    const typename ELFT::Shdr *header = Obj->getSection(
+        Section.getRawDataRefImpl());
+    if ((header->sh_flags & llvm::ELF::SHF_ALLOC) == 0)
+      continue; // Skip non-allocated sections
+    if (header->sh_addr == header->sh_offset)
+      continue;
+
+    map_offsets[header->sh_addr] = header->sh_addr - header->sh_offset;
+  }
+}
+
+DWARFError DWARFUnwind::add_new_file(const std::string &filename,
+                                     int pid,
+                                     uint32_t &out_oid)
+{
+  auto oid = next_oid_;
+  if (oid == UINT16_MAX) {
+    LOG(ERROR) << "Maximum number of object IDs reached.";
+    return DWARFError::TooManyObjects;
+  }
+  if (oid == 0) {
+    std::vector<uint8_t> empty;
+    empty.resize(CFT_ENTRY_SIZE, 0);
+    if (table_feed_cb_(TableType::UnwindEntries, 0, empty))
+      return DWARFError::InternalError;
+  }
+  ++next_oid_;
+  out_oid = oid;
+
+  std::string fn;
+  if (pid >= 0)
+    fn = "/proc/" + std::to_string(pid) + "/root/" + filename;
+  else
+    fn = filename;
+
+  LOG(V1) << "Adding file " << fn << " with OID " << oid;
+  auto ExpectedBinary = llvm::object::createBinary(fn);
+  if (!ExpectedBinary) {
+    LOG(ERROR) << "Cannot open " << fn << " to extract stack walk information";
+    return DWARFError::FileNotFound;
+  }
+
+  auto *Bin = ExpectedBinary.get().getBinary();
+  auto *Obj = llvm::dyn_cast<llvm::object::ObjectFile>(Bin);
+  if (!Obj)
+    return DWARFError::UnsupportedFormat;
+
+  std::map<uint64_t, uint64_t> map_offsets;
+  if (auto *ELF64LE = llvm::dyn_cast<llvm::object::ELF64LEObjectFile>(Obj)) {
+    build_map_offsets(ELF64LE, map_offsets);
+  } else if (auto *ELF64BE = llvm::dyn_cast<llvm::object::ELF64BEObjectFile>(
+                 Obj)) {
+    build_map_offsets(ELF64BE, map_offsets);
+  } else if (auto *ELF32LE = llvm::dyn_cast<llvm::object::ELF32LEObjectFile>(
+                 Obj)) {
+    build_map_offsets(ELF32LE, map_offsets);
+  } else if (auto *ELF32BE = llvm::dyn_cast<llvm::object::ELF32BEObjectFile>(
+                 Obj)) {
+    build_map_offsets(ELF32BE, map_offsets);
+  } else {
+    LOG(V1) << "Not a recognized ELF object file.";
+    return DWARFError::UnsupportedFormat;
+  }
+
+  return read_eh_frame(fn, oid, map_offsets);
+}
+
+DWARFError DWARFUnwind::push_current_table()
+{
+  if (current_table_.empty())
+    return DWARFError::Success;
+
+  auto ext_table = current_table_;
+  ext_table.resize(CHUNK_SIZE, 0);
+  if (table_feed_cb_(TableType::UnwindTable, current_table_id_, ext_table))
+    return DWARFError::InternalError;
+  return DWARFError::Success;
+}
+
+DWARFError DWARFUnwind::read_eh_frame(
+    const std::string &filename,
+    uint32_t oid,
+    const std::map<uint64_t, uint64_t> &map_offsets)
+{
+#if LLVM_VERSION_MAJOR >= 21
+  auto ExpectedBinary = llvm::object::createBinary(filename);
+  if (!ExpectedBinary)
+    return DWARFError::FileNotFound;
+
+  auto *Bin = ExpectedBinary.get().getBinary();
+  auto *Obj = llvm::dyn_cast<llvm::object::ObjectFile>(Bin);
+  if (!Obj)
+    return DWARFError::UnsupportedFormat;
+
+  auto DICtx = llvm::DWARFContext::create(*Obj);
+  llvm::Expected<const llvm::DWARFDebugFrame *> FrameOrErr = nullptr;
+
+  if (!DICtx->getDWARFObj().getEHFrameSection().Data.empty()) {
+    FrameOrErr = DICtx->getEHFrame();
+  } else {
+    FrameOrErr = DICtx->getDebugFrame();
+  }
+
+  if (!FrameOrErr) {
+    LOG(ERROR) << "object " << filename
+               << " does not contain a .eh_frame "
+                  "or .debug_frame section, can't extract information for "
+                  "stack walking";
+    return DWARFError::ParseError;
+  }
+
+  const llvm::DWARFDebugFrame *Frame = *FrameOrErr;
+  int fdeCount = 0;
+  int rowCount = 0;
+  std::map<uint64_t, uint32_t> rows;
+
+  std::vector<uint8_t> s;
+  s.reserve(CFT_ENTRY_SIZE);
+  std::vector<uint8_t> rs;
+  rs.reserve(12);
+  for (const auto &Entry : Frame->entries()) {
+    if (Entry.getKind() == llvm::dwarf::FrameEntry::FK_FDE) {
+      fdeCount++;
+      const auto *fde = llvm::cast<llvm::dwarf::FDE>(&Entry);
+
+      // find the largest mapping offset <= initial location
+      uint64_t map_offset = 0;
+      auto map_it = map_offsets.lower_bound(fde->getInitialLocation() + 1);
+      if (map_it != map_offsets.begin()) {
+        --map_it;
+        map_offset = map_it->second;
+      }
+
+      auto table = llvm::dwarf::createUnwindTable(fde);
+      for (const auto &row : *table) {
+        ++rowCount;
+        if (!row.hasAddress()) {
+          LOG(V1) << "Row has no address.";
+          return DWARFError::ParseError;
+        }
+
+        auto locations = row.getRegisterLocations();
+        if (!locations.hasLocations()) {
+          LOG(V1) << "Row has no register locations.";
+          return DWARFError::ParseError;
+        }
+
+        s.clear();
+
+#ifdef notyet
+        // Current llvm doesn't give us access to DW_CFA_GNU_args_size
+        // It is also unclear to me atm when exactly we need to account
+        // for it
+        // https://github.com/llvm/llvm-project/issues/176318
+        append_u64(s, row.getGnuArgsSize());
+#else
+        append_u64(s, 0);
+#endif
+
+        /*
+         * convert row into the format used by our eBPF program
+         */
+        auto cfa = row.getCFAValue();
+        if (cfa.getDereference()) {
+          LOG(V1) << "CFA dereference not supported.";
+          return DWARFError::ParseError;
+        }
+        switch (cfa.getLocation()) {
+          case llvm::dwarf::UnwindLocation::RegPlusOffset: {
+            append_u32(s, 1);
+            append_u32(s, cfa.getRegister());
+            append_u64(s, cfa.getOffset());
+            break;
+          }
+          case llvm::dwarf::UnwindLocation::DWARFExpr: {
+            auto expr_opt = cfa.getDWARFExpressionBytes();
+            if (!expr_opt.has_value()) {
+              LOG(V1) << "Missing DWARF expression bytes for CFA.";
+              return DWARFError::ParseError;
+            }
+            auto expr_id = add_expression(expr_opt.value());
+            if (!expr_id.has_value()) {
+              return DWARFError::ParseError;
+            }
+            append_u32(s, 2);
+            append_u32(s, *expr_id);
+            append_u64(s, 0);
+            break;
+          }
+
+          default:
+            LOG(V1) << "Unsupported CFA location type.";
+            return DWARFError::ParseError;
+        }
+
+        std::vector<std::vector<uint8_t>> reg_rules(NUM_REGISTERS);
+
+        for (uint32_t reg : locations.getRegisters()) {
+          auto loc_opt = locations.getRegisterLocation(reg);
+          if (!loc_opt.has_value()) {
+            LOG(V1) << "Missing location for register " << reg;
+            continue;
+          }
+          auto loc = loc_opt.value();
+          if (reg >= NUM_REGISTERS) {
+            LOG(V1) << "Register " << reg << " out of range.";
+            continue;
+          }
+
+          rs.clear();
+
+          switch (loc.getLocation()) {
+            case llvm::dwarf::UnwindLocation::Unspecified:
+              LOG(V1) << "Unspecified location not expected.";
+              continue;
+            case llvm::dwarf::UnwindLocation::Undefined:
+              append_u32(rs, 1);
+              append_u64(rs, 0);
+              break;
+            case llvm::dwarf::UnwindLocation::Same:
+              append_u32(rs, 2);
+              append_u64(rs, 0);
+              break;
+            case llvm::dwarf::UnwindLocation::CFAPlusOffset:
+              if (loc.getDereference())
+                append_u32(rs, 3); // offset(N)
+              else
+                append_u32(rs, 4); // val_offset(N)
+              append_u64(rs, loc.getOffset());
+              break;
+            case llvm::dwarf::UnwindLocation::RegPlusOffset:
+              if (loc.getOffset() != 0) {
+                LOG(V1) << "RegPlusOffset with non-zero offset not supported "
+                           "for reg "
+                        << reg;
+                return DWARFError::ParseError;
+              }
+              append_u32(rs, 5); // register(R)
+              append_u64(rs, loc.getRegister());
+              break;
+            case llvm::dwarf::UnwindLocation::DWARFExpr: {
+              auto expr_opt = loc.getDWARFExpressionBytes();
+              if (!expr_opt.has_value()) {
+                LOG(V1) << "Missing DWARF expression bytes for register.";
+                continue;
+              }
+              auto expr_id = add_expression(expr_opt.value());
+              if (!expr_id.has_value()) {
+                return DWARFError::ParseError;
+              }
+              if (loc.getDereference())
+                append_u32(rs, 6); // expression(E)
+              else
+                append_u32(rs, 7); // val_expression(E)
+              append_u64(rs, *expr_id);
+              break;
+            }
+            case llvm::dwarf::UnwindLocation::Constant:
+              append_u32(rs, 9);
+              append_u64(rs, loc.getOffset());
+              break;
+
+            default:
+              LOG(V1) << "Unsupported location type for reg " << reg;
+              return DWARFError::ParseError;
+          }
+          reg_rules[reg] = rs;
+        }
+
+        for (int reg = 0; reg < NUM_REGISTERS; reg++) {
+          if (reg_rules[reg].empty()) {
+            // default to unspecifed
+            append_u32(s, 0);
+            append_u64(s, 0);
+          } else {
+            s.insert(s.end(), reg_rules[reg].begin(), reg_rules[reg].end());
+          }
+        }
+
+        if (s.size() != CFT_ENTRY_SIZE) {
+          LOG(V1) << "Serialized row size " << s.size()
+                  << " does not match expected " << CFT_ENTRY_SIZE << " bytes.";
+          return DWARFError::InternalError;
+        }
+
+        auto it = entries_.find(s);
+        uint32_t id;
+        if (it != entries_.end()) {
+          id = it->second;
+        } else {
+          id = entries_.size() + 1; // reserve 0 for no entry
+          entries_[s] = id;
+
+          if (table_feed_cb_(TableType::UnwindEntries, id, s))
+            return DWARFError::InternalError;
+        }
+
+        auto start = row.getAddress() - map_offset;
+        // start may override end
+        // start may not override start
+        // end overrides nothing
+        // in case an FDE ends with advance_loc(0), we may have duplicate
+        //   entries
+        auto r = rows.find(start);
+        if (r != rows.end() && r->second != 0 && r->second != id) {
+          LOG(V1) << "Start address " << std::hex << start
+                  << " already exists in rows" << std::dec;
+          // XXX error out?
+        }
+        rows[start] = id;
+      }
+      auto end = fde->getInitialLocation() + fde->getAddressRange() -
+                 map_offset;
+      auto r = rows.find(end);
+      if (r == rows.end())
+        rows[end] = 0;
+    }
+  }
+
+  if (fdeCount == 0) {
+    LOG(WARNING) << "object " << filename
+                 << " does not contain information for stack walking";
+  }
+
+  LOG(V1) << "Summary: Found " << fdeCount << " FDEs and " << rowCount
+          << " rows.";
+  LOG(V1) << "expressions: " << expressions_.size()
+          << ", entries: " << entries_.size() << ", rows: " << rows.size();
+
+  std::vector<std::pair<uint64_t, uint64_t>> table_entries;
+  for (const auto &row : rows) {
+    table_entries.emplace_back(row.first, row.second);
+  }
+  size_t start = 0;
+  while (start < table_entries.size()) {
+    size_t out_entries = 0;
+    auto sz = CHUNK_SIZE - current_table_.size() - 16;
+    auto table_data = dwunwind_build_table(
+        table_entries, start, sz, out_entries);
+    LOG(V1) << "Built table chunk with " << out_entries << " entries, size "
+            << table_data.size() << " bytes.";
+    auto e = table_mappings_.emplace(oid, std::vector<TableMapping>{});
+    e.first->second.push_back(
+        TableMapping{ .file_offset = table_entries[start].first,
+                      .table_id = current_table_id_,
+                      .table_offset = current_table_.size() });
+    if (current_table_.empty()) {
+      swap(current_table_, table_data);
+    } else {
+      current_table_.insert(current_table_.end(),
+                            table_data.begin(),
+                            table_data.end());
+    }
+    if (current_table_.size() >= CHUNK_SIZE - 200) {
+      auto push_ret = push_current_table();
+      if (push_ret != DWARFError::Success)
+        return push_ret;
+      current_table_.clear();
+      ++current_table_id_;
+    }
+    start += out_entries;
+  }
+
+  return DWARFError::Success;
+#else
+  // avoid unused parameter warnings when DWARF_UNWIND is not defined
+  (void)filename;
+  (void)oid;
+  (void)map_offsets;
+  throw std::runtime_error("DWARF unwind not supported");
+#endif
+}
+
+struct ProcessMapEntry {
+  uint64_t vm_start;
+  uint64_t vm_end;
+  uint64_t offset;
+  std::string file_path;
+};
+
+std::vector<ProcessMapEntry> read_process_maps(int pid)
+{
+  std::vector<ProcessMapEntry> maps;
+  std::string filename = "/proc/" + std::to_string(pid) + "/maps";
+  std::ifstream file(filename);
+
+  if (!file.is_open())
+    return maps;
+
+  std::string line;
+  while (std::getline(file, line)) {
+    std::istringstream iss(line);
+
+    std::uintptr_t start = 0;
+    std::uintptr_t end = 0;
+    std::uint64_t offset = 0;
+    unsigned long inode = 0;
+    char dash = 0;
+    std::string perms;
+    std::string dev;
+    std::string path;
+
+    if (iss >> std::hex >> start >> dash >> end >> perms >> offset >> dev >>
+        std::dec >> inode) {
+      iss >> std::ws;
+      // Read the remainder of the line as the path
+      if (std::getline(iss, path) && !path.empty()) {
+        if (!(path[0] == '/'))
+          continue;
+        if (perms.find("x") == std::string::npos)
+          continue;
+        if (path.size() > 10 && path.substr(path.size() - 10) == " (deleted)") {
+          LOG(ERROR) << "object not available: " << path;
+          continue;
+        }
+        maps.emplace_back(ProcessMapEntry{ .vm_start = start,
+                                           .vm_end = end,
+                                           .offset = offset,
+                                           .file_path = std::move(path) });
+      }
+    }
+  }
+
+  return maps;
+}
+
+DWARFError DWARFUnwind::add_pid(pid_t pid)
+{
+  auto maps = read_process_maps(pid);
+  // output mapping vector, reserve room for nentries record at the beginning
+  std::vector<uint8_t> s = { 0, 0, 0, 0, 0, 0, 0, 0 };
+  int num_entries = 0;
+  s.reserve((MAX_MAPPINGS * 24) + 8);
+
+  for (const auto &map : maps) {
+    uint32_t oid;
+    auto err = add_file_nopush(map.file_path, pid, oid);
+    if (err != DWARFError::Success) {
+      LOG(V1) << "File " << map.file_path << " not added: Error " << err;
+      return err;
+    }
+    auto e = table_mappings_.find(oid);
+    if (e == table_mappings_.end()) {
+      LOG(V1) << "No table mapping found for OID " << oid;
+      continue;
+    }
+    auto mapping = e->second;
+    auto map_offset_end = map.offset + (map.vm_end - map.vm_start);
+    for (const auto &me : mapping) {
+      if (me.file_offset >= map_offset_end) {
+        break;
+      }
+      if (me.file_offset < map.offset) {
+        continue;
+      }
+      auto delta = me.file_offset - map.offset;
+
+      auto start = map.vm_start + delta;
+      auto offset = map.offset + delta;
+      auto table_id = me.table_id;
+      auto table_offset = me.table_offset;
+
+      s.reserve(s.size() + 24);
+      append_u64(s, start);
+      append_u64(s, offset);
+      append_u32(s, table_id);
+      append_u32(s, table_offset);
+
+      ++num_entries;
+    }
+  }
+
+  auto push_ret = push_current_table();
+  if (push_ret != DWARFError::Success)
+    return push_ret;
+
+  // set number of entries at the beginning
+  std::vector<uint8_t> nentries;
+  nentries.reserve(8);
+  append_u64(nentries, num_entries);
+  for (int i = 0; i < 8; i++)
+    s[i] = nentries[i];
+
+  // fill up to expected size
+  s.resize((MAX_MAPPINGS * 24) + 8, 0);
+
+  if (table_feed_cb_(TableType::Mappings, pid, s))
+    return DWARFError::InternalError;
+
+  return DWARFError::Success;
+}

--- a/src/dwunwind.h
+++ b/src/dwunwind.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
+#include <llvm/Config/llvm-config.h>
+
+#if (defined(__x86_64__) || defined(__amd64__)) && LLVM_VERSION_MAJOR >= 21
+#define DWUNWIND
+#endif
+
+#define DWUNWIND_MAPPINGS "dwunwind_mappings"
+#define DWUNWIND_OFFSETMAPS "dwunwind_offsetmaps"
+#define DWUNWIND_CFTS "dwunwind_cfts"
+#define DWUNWIND_EXPRESSIONS "dwunwind_expressions"
+
+enum class DWARFError {
+  Success = 0,
+  FileNotFound,
+  ParseError,
+  UnsupportedFormat,
+  InternalError,
+  TooManyObjects,
+};
+std::ostream &operator<<(std::ostream &os, const DWARFError &err);
+
+struct TableMapping {
+  uint64_t file_offset;
+  uint32_t table_id;
+  uint64_t table_offset;
+};
+
+enum class TableType {
+  UnwindTable,
+  UnwindEntries,
+  Expressions,
+  Mappings,
+};
+
+class DWARFUnwind {
+public:
+  using TableFeedCallback = std::function<
+      int(TableType type, uint32_t key, const std::vector<uint8_t> &value)>;
+
+  DWARFUnwind(TableFeedCallback cb)
+  {
+    table_feed_cb_ = std::move(cb);
+  }
+
+  DWARFError add_object_file(const std::string &filename);
+  DWARFError add_pid(pid_t pid);
+
+private:
+  std::optional<uint32_t> add_expression(llvm::DWARFExpression &expr);
+  DWARFError add_new_file(const std::string &filename,
+                          int pid,
+                          uint32_t &out_oid);
+  DWARFError add_file_nopush(const std::string &filename,
+                             int pid,
+                             uint32_t &out_oid);
+  DWARFError push_current_table();
+  DWARFError read_eh_frame(const std::string &filename,
+                           uint32_t oid,
+                           const std::map<uint64_t, uint64_t> &map_offsets);
+
+  TableFeedCallback table_feed_cb_;
+  uint32_t next_oid_{ 0 };
+  uint32_t current_table_id_{ 0 };
+  std::map<std::vector<uint8_t>, uint32_t> expressions_;
+  std::map<std::vector<uint8_t>, uint32_t> entries_;
+  std::unordered_map<uint32_t, std::vector<TableMapping>> table_mappings_;
+  std::unordered_map<std::string, uint32_t> tables_;
+  std::vector<uint8_t> current_table_;
+  std::unordered_map<std::string, std::optional<uint32_t>> files_seen_;
+};

--- a/src/dwunwind_table.cpp
+++ b/src/dwunwind_table.cpp
@@ -1,0 +1,343 @@
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+//
+// Table entry format:
+//     own key
+//     left child ptr or leaf marker
+//     own value
+//     right subtree
+//     left subtree
+//
+//  key is relative to parent key
+//  ptrs are offsets from end of current entry
+//  a pointer marks whether it points to a leaf or not
+//
+//  leaf node format:
+//     own key
+//     left key
+//     left value
+//     own value
+//     right key
+//     right value
+//
+//  The tree can have one leaf in the tree that is not pointed to by a ptr,
+//  thus not explicitly marked as leaf. If present, this is always the rightmost
+//  leaf in the tree. All other leaves are full.
+//
+//  incomplete leaf format;
+//     own key       (0 for empty leaf)
+//     leaf marker   (can be distinguished from ptrs)
+//     left key      (0 if no left entry)
+//     left value
+//     own value
+//     right key     (0 if no right entry)
+//     right value
+//
+// encoding:
+// ptrs: we limit the table size to 2MB, so 21 bits
+//   00-CF: encode as 1 byte
+//   D0-D8: first byte with 3 lower bits of value, followed by 2 bytes
+//          (little-endian)
+// leaf ptrs:
+//   D8-DF: first byte with 3 lower bits of value, followed by 2 bytes
+//          (little-endian)
+//   E0-FF: ptr as 1 byte
+// values:
+//   00-F6: encode as 1 byte
+//   F8-FF: first byte with 3 lower bits of value, followed by 1 byte
+//   F7   : followed by 3 bytes u64
+// RelKey:
+//   00-DE: 1 byte, val + 111
+//   DF   : followed by 8 bytes i64 (little-endian)
+//   E0-FF: lower 5 bits, followed by 1 byte (little-endian)
+//
+// a ptr with value 0 is used to mark a leaf that is pointed to by a
+// non-leaf ptr
+//   This can happen only for the last right child
+//
+// Maximum encodable table size is 256k
+//
+
+struct PtrTooLarge : std::runtime_error {
+  PtrTooLarge() : std::runtime_error("table pointer too large")
+  {
+  }
+};
+
+static std::vector<uint8_t> enc_rel_key(int64_t rel_key)
+{
+  auto ukey = static_cast<uint64_t>(rel_key);
+
+  if (rel_key >= -111 && rel_key <= 111) {
+    return { static_cast<uint8_t>(rel_key + 111) };
+  } else if (rel_key >= -0x1000 && rel_key < 0x1000) {
+    return { static_cast<uint8_t>(0xe0 | ((ukey >> 8) & 0x1f)),
+             static_cast<uint8_t>(ukey & 0xff) };
+  } else {
+    return { 0xdf,
+             static_cast<uint8_t>(ukey & 0xff),
+             static_cast<uint8_t>((ukey >> 8) & 0xff),
+             static_cast<uint8_t>((ukey >> 16) & 0xff),
+             static_cast<uint8_t>((ukey >> 24) & 0xff),
+             static_cast<uint8_t>((ukey >> 32) & 0xff),
+             static_cast<uint8_t>((ukey >> 40) & 0xff),
+             static_cast<uint8_t>((ukey >> 48) & 0xff),
+             static_cast<uint8_t>((ukey >> 56) & 0xff) };
+  }
+}
+
+static std::vector<uint8_t> enc_rel_ptr(uint64_t rel_ptr)
+{
+  if (rel_ptr <= 0xcf) {
+    return { static_cast<uint8_t>(rel_ptr) };
+  } else if (rel_ptr <= 0x3ffff) {
+    return { static_cast<uint8_t>(0xd0 | ((rel_ptr >> 16) & 0x07)),
+             static_cast<uint8_t>(rel_ptr & 0xff),
+             static_cast<uint8_t>(rel_ptr >> 8) };
+  } else {
+    throw PtrTooLarge();
+  }
+}
+
+static std::vector<uint8_t> enc_rel_leaf_ptr(uint64_t rel_ptr)
+{
+  if (rel_ptr <= 0x1f) {
+    return { static_cast<uint8_t>(0xe0 | rel_ptr) };
+  } else if (rel_ptr <= 0x3ffff) {
+    return { static_cast<uint8_t>(0xd8 | ((rel_ptr >> 16) & 0x07)),
+             static_cast<uint8_t>(rel_ptr & 0xff),
+             static_cast<uint8_t>(rel_ptr >> 8) };
+  } else {
+    throw PtrTooLarge();
+  }
+}
+
+static std::vector<uint8_t> enc_leaf_marker()
+{
+  return { 0x00 };
+}
+
+static std::vector<uint8_t> enc_value(uint64_t val)
+{
+  if (val <= 0xf6) {
+    return { static_cast<uint8_t>(val) };
+  } else if (val <= 0x3ff) {
+    return { static_cast<uint8_t>(0xf8 | ((val >> 8) & 0x07)),
+             static_cast<uint8_t>(val & 0xff) };
+  } else if (val <= 0xffffff) {
+    return {
+      0xf7,
+      static_cast<uint8_t>((val >> 16) & 0xff),
+      static_cast<uint8_t>((val >> 8) & 0xff),
+      static_cast<uint8_t>(val & 0xff),
+    };
+  } else {
+    throw std::runtime_error("table value too large");
+  }
+}
+
+static int push(std::vector<uint8_t>& buf, const std::vector<uint8_t>& data)
+{
+  // insert in reverse order
+  buf.insert(buf.end(), data.rbegin(), data.rend());
+
+  return data.size();
+}
+
+struct BuildStats {
+  uint64_t bytes_in_keys = 0;
+  uint64_t bytes_in_values = 0;
+};
+
+static uint64_t build_recurse(
+    BuildStats& stats,
+    std::vector<uint8_t>& buf,
+    const std::vector<std::pair<uint64_t, uint64_t>>& entries,
+    size_t start,
+    size_t end,
+    uint64_t parent_key,
+    bool unmarked_leaf)
+{
+  int n;
+
+  // observations:
+  //  - due to the rules the split point is chosen, the left subtree will
+  //    always be full, so either a node has 2 full leaves or is a leaf itself
+  //  - if the left node is a leaf, the right also is
+  //  - if the left node is not a leaf, the right may be a leaf. As there is
+  //    no right pointer, we can't encode the leafness into the pointer, so
+  //    we encode it into the key
+  //  - the right node always immediately follows its parent, so we don't need
+  //    a right pointer
+  //  - to be able to calculate the forward pointers, we have to build from back
+  //    to front
+  auto len = end - start;
+
+  /*
+   * leaf node
+   */
+  if (len <= 3) {
+    // <key> [<leaf marker>] <left key> <left value> <own value> <right key>
+    //  <right value>
+    // a key of 0 means the entry is not valid
+    // emitted back to front
+
+    uint64_t own_key;
+    if (len == 0)
+      own_key = parent_key; // this entry is a dummy entry, choose it so it is 0
+    else if (len == 1)
+      own_key = entries[start].first;
+    else
+      own_key = entries[start + 1].first;
+
+    // right key/value
+    if (len == 3) {
+      n = push(buf, enc_value(entries[start + 2].second));
+      stats.bytes_in_values += n;
+      n = push(buf, enc_rel_key(entries[start + 2].first - own_key));
+      stats.bytes_in_keys += n;
+    } else {
+      // dummy entry
+      push(buf, enc_value(0));
+      push(buf, enc_rel_key(0));
+    }
+
+    // own value
+    if (len > 0) {
+      auto own_value = entries[start + (len >= 2 ? 1 : 0)].second;
+      n = push(buf, enc_value(own_value));
+      stats.bytes_in_values += n;
+    } else {
+      // dummy entry
+      push(buf, enc_value(0));
+    }
+
+    // left key/value
+    if (len >= 2) {
+      n = push(buf, enc_value(entries[start].second));
+      stats.bytes_in_values += n;
+      n = push(buf, enc_rel_key(entries[start].first - own_key));
+      stats.bytes_in_keys += n;
+    } else {
+      // dummy entry
+      push(buf, enc_value(0));
+      push(buf, enc_rel_key(0));
+    }
+
+    // leaf marker
+    if (unmarked_leaf)
+      push(buf, enc_leaf_marker());
+
+    // own key
+    if (len >= 1) {
+      n = push(buf, enc_rel_key(own_key - parent_key));
+      stats.bytes_in_keys += n;
+    } else {
+      // dummy entry
+      push(buf, enc_rel_key(0));
+    }
+
+    return buf.size();
+  }
+
+  /*
+   * intermediate node
+   */
+
+  // split point: find largest number that creates a tree with no empty pointers
+  size_t split = 3;
+  while ((2 * split) + 1 + 1 <= len) {
+    split = (2 * split) + 1;
+  }
+  split += start;
+
+  auto own_key = entries[split].first;
+  auto own_value = entries[split].second;
+
+  auto left_len = split - start;
+  auto right_len = end - (split + 1);
+  assert(left_len >= 3);
+  auto left_is_leaf = left_len == 3;
+  auto right_is_leaf = right_len <= 3;
+  auto right_unmarked_leaf = right_is_leaf && !left_is_leaf;
+
+  // <own key> <left ptr> <own value> <right subtree> <left subtree>
+  // built from back to front
+  // left subtree
+  auto left_ptr = build_recurse(
+      stats, buf, entries, start, split, own_key, false);
+  // right subtree
+  build_recurse(
+      stats, buf, entries, split + 1, end, own_key, right_unmarked_leaf);
+
+  // own value
+  n = push(buf, enc_value(own_value));
+  stats.bytes_in_values += n;
+
+  // left ptr
+  if (left_is_leaf) {
+    n = push(buf, enc_rel_leaf_ptr(buf.size() - left_ptr));
+  } else {
+    n = push(buf, enc_rel_ptr(buf.size() - left_ptr));
+  }
+
+  // own key
+  n = push(buf, enc_rel_key(own_key - parent_key));
+  stats.bytes_in_keys += n;
+
+  return buf.size();
+}
+
+std::vector<uint8_t> dwunwind_build_table(
+    const std::vector<std::pair<uint64_t, uint64_t>>& entries,
+    size_t start,
+    size_t max_size,
+    size_t& out_entries)
+{
+  size_t left = 0;
+  size_t right = entries.size() - start;
+  size_t n = std::min(static_cast<size_t>(max_size / 2.6),
+                      entries.size() - start);
+
+  std::vector<uint8_t> result_buf;
+  size_t result_entries = 0;
+  // find a number of entries that fills the available space well
+  while (left < right) {
+    BuildStats stats = {};
+    std::vector<uint8_t> buf;
+
+    try {
+      build_recurse(stats, buf, entries, start, start + n, 0, false);
+    } catch (const PtrTooLarge&) {
+      // too large, try fewer entries
+    }
+
+    auto diff = static_cast<signed long>(buf.size()) -
+                static_cast<signed long>(max_size);
+    auto adj = std::max(static_cast<size_t>(labs(diff) / 2.6), 1UL);
+    if (buf.size() > max_size) {
+      right = n - 1;
+      n = std::max(n - adj, left);
+    } else {
+      std::swap(result_buf, buf);
+      result_entries = n;
+      left = n;
+      n = std::min(n + adj, right);
+      if (labs(diff) < 100.0)
+        break;
+    }
+  }
+
+  std::ranges::reverse(result_buf);
+
+  out_entries = result_entries;
+  if (result_entries > 0)
+    return result_buf;
+  else
+    return {};
+}

--- a/src/dwunwind_table.h
+++ b/src/dwunwind_table.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+// Build the main table for dwarf unwinding.
+// This table maps a file offset into a specific elf file to an entry with
+// the actual unwind instructions.
+// Data is encoded as a compact binary tree suitable for lower bound style
+// lookups.
+// See dwundind_table.cpp for details of the encoding.
+std::vector<uint8_t> dwunwind_build_table(
+    const std::vector<std::pair<uint64_t, uint64_t>>& entries,
+    size_t start,
+    size_t max_size,
+    size_t& out_entries);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -46,7 +46,7 @@ hspace   [ \t]
 vspace   \n
 path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
 /* Most of the builtins are prefixed with __builtin_ as they are exposed to users via macros e.g. macro cpu() { __builtin_cpu } */
-builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_usermode|__builtin_username
+builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_dw_ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_usermode|__builtin_username
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|avg|stats)_t|count_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|kstack_t|ustack_t|tseries_t

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "btf.h"
 #include "build_info.h"
 #include "config.h"
+#include "dwunwind.h"
 #include "globalvars.h"
 #include "lockdown.h"
 #include "log.h"
@@ -82,6 +83,7 @@ enum Options {
   CMD,
   DEBUG,
   DRY_RUN,
+  DWARF_PID,
   EMIT_ELF,
   EMIT_LLVM,
   FMT, // Alias for --mode=format.
@@ -130,6 +132,9 @@ void usage(std::ostream& out)
   out << "    -l, --list [search|filename]" << std::endl;
   out << "                   list kernel probes or probes in a program" << std::endl;
   out << "    -p, --pid PID  filter actions and enable USDT probes on PID" << std::endl;
+#ifdef DWUNWIND
+  out << "    --dwarf-pid PID add additional pids to the DWARF-unwinder." << std::endl;
+#endif
   out << "    -c, --cmd CMD  run CMD and enable USDT probes on resulting process" << std::endl;
   out << "    --no-feature FEATURE[,FEATURE]" << std::endl;
   out << "                   disable use of detected features" << std::endl;
@@ -320,6 +325,7 @@ std::vector<std::string> extra_flags(
 
 struct Args {
   std::string pid_str;
+  std::vector<std::string> dwarf_pids_str;
   std::string cmd_str;
   bool listing = false;
   bool safe_mode = true;
@@ -490,6 +496,10 @@ Args parse_args(int argc, char* argv[])
             .has_arg = no_argument,
             .flag = nullptr,
             .val = Options::UNSAFE },
+    option{ .name = "dwarf-pid",
+            .has_arg = required_argument,
+            .flag = nullptr,
+            .val = Options::DWARF_PID },
     option{ .name = "usdt-file-activation",
             .has_arg = no_argument,
             .flag = nullptr,
@@ -640,6 +650,11 @@ Args parse_args(int argc, char* argv[])
       case Options::PROBE_FILTER:
         args.probe_filter = optarg;
         break;
+#ifdef DWUNWIND
+      case Options::DWARF_PID:
+        args.dwarf_pids_str.emplace_back(optarg);
+        break;
+#endif
       case 'I':
         args.include_dirs.emplace_back(optarg);
         break;
@@ -828,6 +843,25 @@ void list_probes(BPFtrace& bpftrace,
   }
 }
 
+uint64_t parse_pid(std::string const& pid_str)
+{
+  auto maybe_pid = util::to_uint(pid_str);
+  if (!maybe_pid) {
+    LOG(ERROR) << "Failed to parse pid: " << maybe_pid.takeError();
+    exit(1);
+  }
+  if (*maybe_pid > 0x400000) {
+    // The actual maximum pid depends on the configuration for the specific
+    // system, i.e. read from `/proc/sys/kernel/pid_max`. We can impose a
+    // basic sanity check here against the nominal maximum for 64-bit
+    // systems.
+    LOG(ERROR) << "Pid out of range: " << *maybe_pid;
+    exit(1);
+  }
+
+  return *maybe_pid;
+}
+
 int main(int argc, char* argv[])
 {
   Log::get().set_colorize(is_colorize());
@@ -872,20 +906,8 @@ int main(int argc, char* argv[])
   bpftrace.probe_filter_ = args.probe_filter;
 
   if (!args.pid_str.empty()) {
-    auto maybe_pid = util::to_uint(args.pid_str);
-    if (!maybe_pid) {
-      LOG(ERROR) << "Failed to parse pid: " << maybe_pid.takeError();
-      exit(1);
-    }
-    if (*maybe_pid > 0x400000) {
-      // The actual maximum pid depends on the configuration for the specific
-      // system, i.e. read from `/proc/sys/kernel/pid_max`. We can impose a
-      // basic sanity check here against the nominal maximum for 64-bit
-      // systems.
-      LOG(ERROR) << "Pid out of range: " << *maybe_pid;
-      exit(1);
-    }
-    auto proc = util::create_proc(*maybe_pid);
+    auto pid = parse_pid(args.pid_str);
+    auto proc = util::create_proc(pid);
     if (!proc) {
       LOG(ERROR) << "Failed to attach to pid: " << proc.takeError();
       exit(1);
@@ -893,6 +915,10 @@ int main(int argc, char* argv[])
     bpftrace.procmon_ = std::move(*proc);
   }
 
+  for (auto const& pid_str : args.dwarf_pids_str) {
+    auto pid = parse_pid(pid_str);
+    bpftrace.dwarf_pids_.emplace_back(pid);
+  }
   if (!args.cmd_str.empty()) {
     bpftrace.cmd_ = args.cmd_str;
     auto child = util::create_child(args.cmd_str);

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1529,6 +1529,21 @@ macro username()
 // ```
 //
 // Note that for these examples to work, bash had to be recompiled with frame pointers.
+macro dw_ustack(mode, limit) {
+  import "stdlib/stack/dwunwind.bpf.c";
+  __builtin_dw_ustack(mode, limit)
+}
+
+macro dw_ustack(mode) {
+  import "stdlib/stack/dwunwind.bpf.c";
+  __builtin_dw_ustack(mode)
+}
+
+macro dw_ustack() {
+  import "stdlib/stack/dwunwind.bpf.c";
+  __builtin_dw_ustack
+}
+
 
 // :function usym
 // :variant usym_t usym(uint64 * addr)

--- a/src/stdlib/stack/dwunwind.bpf.c
+++ b/src/stdlib/stack/dwunwind.bpf.c
@@ -1,0 +1,897 @@
+#define __KERNEL__
+#include <vmlinux.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+#include "expression.h"
+
+#define LOG(...) // bpf_printk(__VA_ARGS__)
+#define DBG(...) // bpf_printk(__VA_ARGS__)
+#define INFO(...) // bpf_printk(__VA_ARGS__)
+#define TABLE(...) // bpf_printk(__VA_ARGS__)
+
+#define MAX_MAPPINGS 1000
+#define MAX_MAPPINGS_BISECT_STEPS 10
+
+#define OFFSETMAP_SIZE 262144  // 256 KB
+#define MAX_OFFSETS_BISECT_STEPS 17
+
+#define MAX_CFT_ENTRIES 1000
+
+#define MAX_EXPRESSION_LEN 255
+#define NUM_REGISTERS 17    // 16 + RIP
+#define EXPR_STACK_SIZE 16
+
+#define RSP 7
+#define RIP 16
+#define MAX_STACK_FRAMES 512
+#define MAX_UPROBES MAX_STACK_FRAMES
+
+#define XOL_PAGE_SIZE 4096
+
+/*
+ * General description of the lookup process:
+ *
+ *  1) With a given pid, see if we have a mapping table for it. If not,
+ *     revert to frame-based stack unwinding.
+ *     The mapping table maps the IP (vma) to the (adjusted) elf-file offset,
+ *     and gives the offsetmap id and start position in the offsetmap.
+ *  2) An offsetmap maps from a file offset to the cft entry, which contains
+ *     the unwind ruleset for that location. Only the cft entry id is stored, as
+ *     a ruleset can occur many times. This makes the representation very
+ *     compact.
+ *     The offsetmap for each file is split into multiple chunks, so that we
+ *     can have a fixed entry size for the bpf map. In case a chunk (or the
+ *     full offsetmap is smaller than the entry size, a bpf map entry can
+ *     contain multiple offsetmap chunks. The offsets are stored in the mapping
+ *     table.
+ *     The chunk is a compact binary tree structure.
+ *  3) The cft entry contains the unwind rules for the location. In case a rule
+ *     involves an expression, only the expression id is registered.
+ *  4) Expressions are stored in a separate map
+ */
+
+#pragma pack(1)
+struct mapping {
+  u64 nentries;
+  struct map_entry {
+    u64 vma_start;
+    u64 offset;
+    u32 offsetmap_id;
+    u32 start_in_map;
+  } entries[MAX_MAPPINGS];
+};
+
+struct offsetmap {
+  u8 map[OFFSETMAP_SIZE];
+};
+
+enum register_rule_type {
+  REGISTER_RULE_UNINITIALIZED = 0,
+  REGISTER_RULE_UNDEFINED = 1,
+  REGISTER_RULE_SAME_VALUE = 2,
+  REGISTER_RULE_OFFSET = 3,
+  REGISTER_RULE_VAL_OFFSET = 4,
+  REGISTER_RULE_REGISTER = 5,
+  REGISTER_RULE_EXPRESSION = 6,
+  REGISTER_RULE_VAL_EXPRESSION = 7,
+};
+
+struct register_rule {
+  enum register_rule_type rtype;
+  union register_rule_data {
+    u64 reg;
+    u64 offset;
+    u32 expression_id;
+  } data;
+};
+
+enum cfa_rule_type {
+  CFA_RULE_UNINITIALIZED = 0,
+  CFA_RULE_REG_OFFSET = 1,
+  CFA_RULE_EXPRESSION = 2,
+};
+
+struct cfa_rule {
+  enum cfa_rule_type rtype;
+  union cfa_rule_data {
+    struct reg_offset {
+      u32 reg;
+      u64 offset;
+    } reg_offset;
+    u32 expression_id;
+  } data;
+};
+
+struct cft {
+  u64 arg_size;
+  struct cfa_rule cfa;
+  struct register_rule rules[NUM_REGISTERS];
+};
+
+struct expression {
+  u8 ninstructions;
+  u8 instructions[MAX_EXPRESSION_LEN];
+ };
+#pragma pack()
+
+struct dwunwind_state {
+  u32 tgid;
+  u64 xol_base;
+  uint current_reg_set;
+  u64 regs_map[2 * NUM_REGISTERS];
+  u64 regs_valid[2];
+  u64 cfa;
+  u64 stack[EXPR_STACK_SIZE];
+  int steps;
+};
+
+//
+// taken from parca-agent bpf code
+// https://github.com/parca-dev/parca-agent/commit/a5ce7e995abf5
+//
+// Hack to thwart the verifier's detection of variable bounds.
+//
+// In recent kernels (6.8 and above) the verifier has gotten smarter
+// in its tracking of variable bounds. For example, after an if statement like
+// `if (v1 < v2)`,
+// if it already had computed bounds for v2, it can infer bounds
+// for v1 in each side of the branch (and vice versa). This means it can verify
+// more programs successfully, which doesn't matter to us because our program
+// was verified successfully before. Unfortunately it has a downside which
+// _does_ matter to us: it increases the number of unique verifier states,
+// which can cause the same instructions to be explored many times, especially
+// in cases where a value is carried through a loop and possibly has
+// multiple sets of different bounds on each iteration of the loop, leading to
+// a combinatorial explosion. This causes us to blow out the kernel's budget of
+// maximum number of instructions verified on program load (currently 1M).
+//
+// `opaquify32` is a no-op; thus `opaquify32(x, anything)` has the same value
+// as `x`.
+// However, the verifier is fortunately not smart enough to realize this,
+// and will not realize the result has the same bounds as `x`, subverting the
+// feature described above.
+//
+// For further discussion, see:
+// https://lore.kernel.org/bpf/874jci5l3f.fsf@taipei.mail-host-address-is-not-set/
+//
+// if the verifier knows `val` is constant, you must set `seed`
+// to something the verifier has no information about
+// (if you don't have something handy, you can use `bpf_get_prandom_u32`).
+// Otherwise, if the verifier knows bounds on `val` but not its exact value,
+// it's fine to just use -1.
+static __always_inline u32 opaquify32(u32 val, u32 seed) {
+  // We use inline asm to make sure clang doesn't optimize it out
+  asm volatile(
+    "%0 ^= %1\n"
+    "%0 ^= %1\n"
+    : "+&r"(val)
+    : "r"(seed)
+  );
+  return val;
+}
+
+// like opaquify32, but for u64.
+static __always_inline u64 opaquify64(u64 val, u64 seed) {
+  asm volatile(
+    "%0 ^= %1\n"
+    "%0 ^= %1\n"
+    : "+&r"(val)
+    : "r"(seed)
+  );
+  return val;
+}
+
+static __always_inline ulong opaquify_ul(ulong val, ulong seed) {
+  asm volatile(
+    "%0 ^= %1\n"
+    "%0 ^= %1\n"
+    : "+&r"(val)
+    : "r"(seed)
+  );
+  return val;
+}
+
+/*
+ * maps
+ * once dynamic hashmaps are widely available, we can use those
+ * instead of arrays to avoid having to pre-calculate the number
+ * of entries in user space
+ */
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __uint(max_entries, 1);   // updated from user space
+  __type(key, u32);
+  __type(value, struct mapping);
+} dwunwind_mappings SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 1);  // updated from user space
+  __type(key, u32);
+  __type(value, struct offsetmap);
+} dwunwind_offsetmaps SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 1);  // updated from user space
+  __type(key, u32);
+  __type(value, struct cft);
+} dwunwind_cfts SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 1);  // updated from user space
+  __type(key, u32);
+  __type(value, struct expression);
+} dwunwind_expressions SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __uint(max_entries, 1);
+  __type(key, u32);
+  __type(value, struct dwunwind_state);
+} dwunwind_state_scrach SEC(".maps");
+
+
+static struct map_entry *
+find_mapping(struct mapping *m, u64 ip)
+{
+  int i;
+  u32 n = m->nentries;
+  if (n > MAX_MAPPINGS)
+    n = MAX_MAPPINGS;
+
+  ulong left = 0;
+  ulong right = n;
+  ulong mid = 0;
+  for (i = 0; i < MAX_MAPPINGS_BISECT_STEPS && left < right; ++i) {
+    mid = (left + right) / 2;
+    mid = opaquify_ul(mid, (ulong)ip);
+    if (mid >= MAX_MAPPINGS)
+      break;
+    struct map_entry *me = &m->entries[mid];
+
+    DBG("bisection step %d: left %d right %d mid %d vma_start %lx",
+      i, left, right, mid, me->vma_start);
+    if (me->vma_start <= ip)
+      left = mid + 1;
+    else
+      right = mid;
+  }
+  if (left == 0) {
+    LOG("ip %lx below first vma_start", ip);
+    return NULL;
+  }
+  --left;
+  left = opaquify_ul(left, (ulong)ip);
+  if (left >= MAX_MAPPINGS)
+    return NULL;
+  struct map_entry *me = &m->entries[left];
+  INFO("ip %lx found in mapping %d: %lx", ip, left, me->vma_start);
+  INFO("    obj %d off %lx map %d",
+    me->offset >> 48, me->offset & 0xffffffffffff, me->offsetmap_id);
+  return me;
+}
+
+// see src/dwunwind.cpp for encoding details
+static u64
+uw_read_key(u8 *ptr, ulong *pos)
+{
+  u64 key = 0;
+  u8 b = ptr[(*pos)++];
+
+  if (b <= 0xde) {
+    key = (u64)b - 111;
+  } else if (b == 0xdf) {
+    /* 8 byte */
+    key = *(u64 *)&ptr[*pos];
+    *pos += 8;
+  } else {
+    /* 5 bit + 1 byte */
+    key = ((b & 0x1f) << 8) | ptr[(*pos)++];
+    /* sign extend */
+    if (key & 0x1000) {
+      key |= ~0x1ffful;
+    }
+  }
+
+  return key;
+}
+
+static u32
+uw_read_rel_ptr(u8 *ptr, ulong *pos, int *is_leaf)
+{
+  u32 rel_ptr = 0;
+  u8 b = ptr[(*pos)++];
+
+  if (b <= 0xcf) {
+    rel_ptr = b;
+    *is_leaf = 0;
+  } else if (b <= 0xd7) {
+    /* 3 bit + 2 byte */
+    rel_ptr = ((b & 0x07) << 16) | *(u16 *)&ptr[*pos];
+    *pos += 2;
+    *is_leaf = 0;
+  } else if (b <= 0xdf) {
+    /* leaf ptr: 3 bit + 2 byte */
+    rel_ptr = ((b & 0x07) << 16) | *(u16 *)&ptr[*pos];
+    *pos += 2;
+    *is_leaf = 1;
+  } else {
+    /* leaf ptr: 1 byte */
+    rel_ptr = b & 0x1f;
+    *is_leaf = 1;
+  }
+  return rel_ptr;
+}
+
+static u64
+uw_read_value(u8 *ptr, ulong *pos)
+{
+  u64 val = 0;
+  u8 b = ptr[(*pos)++];
+
+  if (b <= 0xf6) {
+    val = b;
+  } else if (b == 0xf7) {
+    /* 3 byte */
+    val = (ptr[*pos] << 16) | (ptr[*pos + 1] << 8) | ptr[*pos + 2];
+    *pos += 3;
+  } else {
+    /* 3 bit + 1 byte */
+    val = ((b & 0x07) << 8) | ptr[(*pos)++];
+  }
+  return val;
+}
+
+// returns entry_id
+int __noinline
+find_cft(u32 offsetmap_id, u64 start_in_map, u64 search_key)
+{
+  struct offsetmap *om = bpf_map_lookup_elem(&dwunwind_offsetmaps, &offsetmap_id);
+  if (om == NULL) {
+    LOG("offsetmap lookup failed for id %d", offsetmap_id);
+    return -1;
+  }
+  DBG("offsetmap found, id %d, start %d offset %x", offsetmap_id,
+      start_in_map, search_key);
+  u8 *ptr = om->map;
+  int is_leaf = 0;
+  u64 parent_key = 0;
+  ulong pos = start_in_map;
+  ulong best = -1;
+  ulong depth = 0;
+
+  while (depth++ < MAX_OFFSETS_BISECT_STEPS) {
+    /* bounds check for loop */
+    pos = opaquify_ul(pos, (ulong)search_key);
+    best = opaquify_ul(best, (ulong)search_key);
+    if (pos >= OFFSETMAP_SIZE - 15) {
+      LOG("uw_read_key: pos %d out of bounds", pos);
+      return -1;
+    }
+    u64 current_key = uw_read_key(ptr, &pos);
+    TABLE(" read key %ld abs %lx at pos %d", current_key,
+      current_key + parent_key, pos);
+    if (current_key == 0) { /* final empty node */
+      return best;
+    }
+    current_key += parent_key;
+    current_key = opaquify_ul(current_key, (ulong)search_key);
+    parent_key = current_key;
+
+    if (is_leaf) {
+      /* leaf node reached */
+      break;
+    }
+
+    if (!is_leaf && ptr[pos] == 0) {
+      /* unmarked leaf node */
+      ++pos;
+      break;
+    }
+
+    TABLE("left ptr at pos %d", pos);
+    u32 rel_ptr = uw_read_rel_ptr(ptr, &pos, &is_leaf);
+    if (search_key < current_key) {
+      TABLE(" go left at key %lx", current_key);
+      /* go to left child */
+      pos += rel_ptr;
+    } else {
+      best = uw_read_value(ptr, &pos);
+      TABLE(" go right: best %d at key %lx", best, current_key);
+      /* continue with right child */
+    }
+  }
+
+  if (pos >= OFFSETMAP_SIZE - 15) {
+    LOG("uw_read_key: pos %d out of bounds", pos);
+    return -1;
+  }
+  /* leaf node case */
+
+  /* left key/value */
+  u64 left_key = uw_read_key(ptr, &pos);
+  u64 left_value = uw_read_value(ptr, &pos);
+  TABLE(" leaf left key %lx value %d", left_key + parent_key, left_value);
+
+  if (pos >= OFFSETMAP_SIZE - 15) {
+    LOG("uw_read_key: pos %d out of bounds", pos);
+    return -1;
+  }
+  /* own value */
+  u64 own_value = uw_read_value(ptr, &pos);
+  TABLE(" leaf own value %d", own_value);
+
+  if (search_key < parent_key) {
+    if (left_key != 0 && search_key >= (left_key + parent_key)) {
+      TABLE(" leaf left match: key %lx value %d",
+        left_key + parent_key, left_value);
+      return left_value;
+    }
+    return best;
+  }
+
+  if (pos >= OFFSETMAP_SIZE - 15) {
+    LOG("uw_read_key: pos %d out of bounds", pos);
+    return -1;
+  }
+  /* right key/value */
+  u64 right_key = uw_read_key(ptr, &pos);
+  u64 right_value = uw_read_value(ptr, &pos);
+
+  if (right_key != 0 && search_key >= (right_key + parent_key)) {
+    TABLE(" leaf right match: key %lx value %d",
+      right_key + parent_key, right_value);
+    return right_value;
+  }
+
+  return own_value;
+}
+
+u64 __noinline
+eval_expr(int expression_id, int *error)
+{
+  u32 zero = 0;
+  struct dwunwind_state *s = bpf_map_lookup_elem(&dwunwind_state_scrach, &zero);
+  if (s == NULL) {
+    LOG("no scratch state");
+    goto err;
+  }
+  u64 *o_regs = &s->regs_map[s->current_reg_set ? NUM_REGISTERS : 0];
+  u64 o_regs_v = s->regs_valid[s->current_reg_set ? 1 : 0];
+  struct expression *expr = bpf_map_lookup_elem(&dwunwind_expressions,
+      &expression_id);
+  if (expr == NULL) {
+    LOG("expression id %d not found", expression_id);
+    goto err;
+  }
+  u64 *stack = s->stack;
+  unsigned long sp = 0;
+  int ninstr = expr->ninstructions;
+  unsigned long i = 0;
+  unsigned long n = 0;
+  if (ninstr > MAX_EXPR_INSTRUCTIONS) {
+    LOG("expression id %d too many instructions %d",
+        expression_id, ninstr);
+    goto err;
+  }
+  for (int n = 0; n < ninstr; ++n) {
+    /*
+     * all bounds checks upfront to reduce the number of branches
+     */
+    i = opaquify_ul(i, (ulong)expression_id);
+    if (i >= MAX_EXPRESSION_LEN - 10) {
+      LOG(" eval expr: instruction pointer out of bounds");
+      goto err;
+    }
+    u8 instr = expr->instructions[i];
+    u64 a1 = 0;
+    u64 a2 = 0;
+    ++i;
+    if ((instr & 0xc0) == 0x40) {
+      // one 8 bit argument, register
+      a1 = expr->instructions[i++];
+    } else if ((instr & 0xc0) == 0x80) {
+      // one 64 bit argument
+      a1 = *(u64 *)&expr->instructions[i];
+      i += 8;
+    } else if ((instr & 0xc0) == 0xc0) {
+      // one 8 bit and one 64 bit argument
+      a1 = expr->instructions[i++];
+      a2 = *(u64 *)&expr->instructions[i];
+      i += 8;
+    }
+
+    sp = opaquify_ul(sp, (ulong)expression_id);
+    if (sp >= EXPR_STACK_SIZE) {
+      LOG(" eval expr: stack overflow");
+      goto err;
+    }
+
+    switch (instr) {
+      case EXPR_OP_AND:
+      case EXPR_OP_SHL:
+      case EXPR_OP_GE:
+      case EXPR_OP_PLUS:
+      case EXPR_OP_MUL:
+        if (sp < 2) {
+          LOG(" eval expr: stack underflow in %d", instr);
+          goto err;
+        }
+        break;
+      case EXPR_OP_DEREF:
+      case EXPR_OP_PLUS_CONST:
+        if (sp < 1) {
+          LOG(" eval expr: stack underflow in %d", instr);
+          goto err;
+        }
+        break;
+    }
+
+    DBG(" eval expr id %d instr %d op %x sp %d a1 %lx a2 %lx",
+        expression_id, i, instr, sp, a1, a2);
+    switch (instr) {
+      case EXPR_OP_CONST:
+        stack[sp++] = a1;
+        break;
+      case EXPR_OP_BREG:
+        if (a1 >= NUM_REGISTERS) {
+          LOG(" eval expr: invalid register number %d", (int)a1);
+          goto err;
+        }
+        if ((o_regs_v & (1 << a1)) == 0) {
+          LOG(" eval expr: register %d not valid", (int)a1);
+          goto err;
+        }
+        stack[sp++] = o_regs[a1] + a2;
+        break;
+      case EXPR_OP_AND:
+        stack[sp - 2] = stack[sp - 2] & stack[sp - 1];
+        --sp;
+        break;
+      case EXPR_OP_SHL:
+        stack[sp - 2] = stack[sp - 2] << stack[sp - 1];
+        --sp;
+        break;
+      case EXPR_OP_GE:
+        stack[sp - 2] = (stack[sp - 2] >= stack[sp - 1]) ? 1 : 0;
+        --sp;
+        break;
+      case EXPR_OP_PLUS:
+        stack[sp - 2] = stack[sp - 2] + stack[sp - 1];
+        --sp;
+        break;
+      case EXPR_OP_MUL:
+        stack[sp - 2] = stack[sp - 2] * stack[sp - 1];
+        --sp;
+        break;
+      case EXPR_OP_PLUS_CONST:
+        stack[sp - 1] = stack[sp - 1] + a1;
+        break;
+      case EXPR_OP_DEREF: {
+          u64 addr = stack[--sp];
+          u64 val = 0;
+          int ret = bpf_probe_read_user(&val, sizeof(val), (void *)addr);
+          if (ret < 0) {
+            LOG(" eval expr: failed to deref addr %lx", addr);
+            goto err;
+          }
+          stack[sp++] = val;
+        break;
+      }
+      default:
+        LOG(" eval expr: unsupported op %x", instr);
+        goto err;
+    }
+  }
+
+  if (sp == 0) {
+    LOG(" eval expr: empty stack at end");
+    goto err;
+  }
+
+  if (sp > 16) {
+    LOG(" eval expr: stack overflow at end, sp %d", sp);
+    goto err;
+  }
+  LOG(" returning %lx", stack[sp - 1]);
+  return stack[sp - 1];
+
+err:
+  if (error != NULL)
+    *error = 1;
+  return 0;
+}
+
+u64 recover_uretprobe_addr(u64 rsp)
+{
+  struct task_struct *task = bpf_get_current_task_btf();
+  struct uprobe_task *up = BPF_CORE_READ(task, utask);
+  struct return_instance *ri = BPF_CORE_READ(up, return_instances);
+
+  for (int i = 0; i < MAX_UPROBES; ++i) {
+    if (ri == NULL) {
+      LOG("no match upretprobe found");
+      return 0;
+    }
+    u64 stack = BPF_CORE_READ(ri, stack);
+    u64 retaddr = BPF_CORE_READ(ri, orig_ret_vaddr);
+    LOG("uretprobe: rsp %lx stack %lx retaddr %lx", rsp, stack, retaddr);
+    if (stack + 8 == rsp) {
+      return retaddr;
+    }
+    ri = BPF_CORE_READ(ri, next);
+  }
+
+  return 0;
+}
+
+int
+unwind_step(void)
+{
+  // fetch state from scratch memory
+  u32 zero = 0;
+  struct dwunwind_state *s = bpf_map_lookup_elem(&dwunwind_state_scrach, &zero);
+  if (s == NULL) {
+    LOG("no scratch state");
+    return 1;
+  }
+
+  /*
+   * load mapping for pid
+   * eventually we might want to use bpf_find_vma if it is widely available
+   */
+  struct mapping *m = bpf_map_lookup_elem(&dwunwind_mappings, &s->tgid);
+  if (m == NULL) {
+    INFO("no mapping found");
+    return 1;
+  }
+
+  u64 *regs_o;    /* regs, old set */
+  u64 *regs_n;    /* regs, new set */
+  u64 regs_v_o;  /* regs valid, old set */
+  u64 regs_v_n;  /* regs valid, new set */
+
+  if (s->current_reg_set == 0) {
+    regs_v_o = s->regs_valid[0];
+    regs_n = &s->regs_map[NUM_REGISTERS];
+    regs_o = &s->regs_map[0];
+  } else {
+    regs_v_o = s->regs_valid[1];
+    regs_n = &s->regs_map[0];
+    regs_o = &s->regs_map[NUM_REGISTERS];
+  }
+  regs_v_n = regs_v_o;
+
+  if ((regs_v_o & (1 << RIP)) == 0) {
+    INFO("Stack walk: PC is None, stopping");
+    return 1;
+  }
+
+  struct map_entry *me = find_mapping(m, regs_o[RIP]);
+  if (me == NULL) {
+    LOG("no map entry found");
+    return 1;
+  }
+
+  u64 offset = regs_o[RIP] - me->vma_start + me->offset;
+  DBG("rip %lx vma_start %lx offset %lx", regs_o[RIP], me->vma_start, offset);
+  int cft_id;
+  [[clang::noinline]] cft_id = find_cft(me->offsetmap_id, me->start_in_map, offset);
+  INFO(" found cft entry id %d", cft_id);
+
+  if (cft_id < 0) {
+    LOG("error in offsetmap processing");
+    return 1;
+  }
+  if (cft_id == 0) {
+    LOG("no offsetmap entry found for ip %lx offset %lx", regs_o[RIP], offset);
+    return 1;
+  }
+
+  struct cft *cf = bpf_map_lookup_elem(&dwunwind_cfts, &cft_id);
+  if (cf == NULL) {
+    LOG("cft not found");
+    return 1;
+  }
+  INFO("cft %d found", cft_id);
+
+  /* compute CFA */
+  u64 cfa;
+  if (cf->cfa.rtype == CFA_RULE_UNINITIALIZED) {
+    LOG("Stack walk: CFA uninitialized, stopping");
+    return 1;
+  } else if (cf->cfa.rtype == CFA_RULE_EXPRESSION) {
+    int error = 0;
+    [[clang::noinline]] cfa = eval_expr(cf->cfa.data.expression_id, &error);
+    INFO("eval_expr cft_id %d ip %lx", cft_id, regs_o[RIP]);
+    INFO("step %d CFA = %lx error %d", s->steps, cfa, error);
+    if (error != 0)
+      return 1;
+  } else if (cf->cfa.rtype == CFA_RULE_REG_OFFSET) {
+    u32 r = cf->cfa.data.reg_offset.reg;
+    s64 o = cf->cfa.data.reg_offset.offset;
+    if ((regs_v_o & (1 << r)) == 0) {
+      LOG("Stack walk: CFA register r%d not valid, stopping", r);
+      return 1;
+    }
+    if (r >= NUM_REGISTERS) {
+      LOG("Stack walk: CFA register r%d out of range, stopping", r);
+      return 1;
+    }
+    cfa = regs_o[r] + o;
+    INFO("  CFA = r%d (%lx) + %lld = %lx", r, regs_o[r], o);
+    INFO("  new CFA = %lx", cfa);
+  } else {
+    LOG("Stack walk: unknown CFA rule type %d, stopping", cf->cfa.rtype);
+    return 1;
+  }
+
+  // unwind stack pointer
+  regs_o[RSP] = cfa;
+  regs_n[RSP] = cfa;
+  s->cfa = cfa;
+
+  for (int reg = 0; reg < NUM_REGISTERS; ++reg) {
+    regs_v_n = opaquify_ul(regs_v_n, (ulong)cft_id);
+    if (cf->rules[reg].rtype == REGISTER_RULE_UNINITIALIZED ||
+        cf->rules[reg].rtype == REGISTER_RULE_SAME_VALUE) {
+      // register is unchanged
+      regs_n[reg] = regs_o[reg];
+      DBG("  r%d: same value %lx", reg, regs_n[reg]);
+    } else if (cf->rules[reg].rtype == REGISTER_RULE_UNDEFINED) {
+      // register is undefined
+      DBG("  r%d: undefined", reg);
+      regs_v_n &= ~(1 << reg);
+    } else if (cf->rules[reg].rtype == REGISTER_RULE_OFFSET) {
+      // register is at CFA + offset
+      s64 off = cf->rules[reg].data.offset;
+      u64 addr = cfa + off;
+      // read value from user stack
+      u64 val = 0;
+      int ret = bpf_probe_read_user(&val, sizeof(val), (void *)addr);
+      if (ret < 0) {
+        LOG("Stack walk: failed to read r%d at addr %lx",
+          reg, addr);
+        return 1;
+      }
+      DBG("  r%d: at addr %lx value %lx", reg, addr, val);
+      regs_n[reg] = val;
+      regs_v_n |= (1 << reg);
+    } else {
+      LOG("Stack walk: unsupported register rule type %d for r%d",
+        cf->rules[reg].rtype, reg);
+      return 1;
+    }
+  }
+
+  if (regs_n[RIP] >= s->xol_base && regs_n[RIP] < s->xol_base + XOL_PAGE_SIZE) {
+    // in xol page, adjust to return address
+    u64 rec;
+    [[clang::noinline]] rec = recover_uretprobe_addr(regs_n[RSP]);
+    if (rec != 0)
+      regs_n[RIP] = rec;
+  }
+
+  // adjust recovered IP to fall into previous instruction
+  // this is not valid for signal frames, but we don't have this
+  // information yet.
+  regs_n[RIP] -= 1;
+
+  // switch reg set
+  s->current_reg_set = !s->current_reg_set;
+  s->regs_valid[s->current_reg_set ? 1 : 0] = regs_v_n;
+
+  INFO("After unwind step: next PC %lx", regs_n[RIP]);
+
+  s->steps += 1;
+  return 0;
+}
+
+long __ustack_dwunwind(void *ctx, u64 *buf, u32 buf_size, u32 tgid)
+{
+  struct task_struct *task;
+
+  u64 *buf_start = buf;
+
+  /* test if we have a mapping for this pid, otherwise fall back to ustack() */
+  void *m = bpf_map_lookup_elem(&dwunwind_mappings, &tgid);
+  if (m == NULL)
+    return bpf_get_stack(ctx, buf, buf_size, BPF_F_USER_STACK);
+
+  task = bpf_get_current_task_btf();
+  if (task == NULL) {
+    LOG("no task struct");
+    return 0;
+  }
+
+  struct mm_struct *mm = BPF_CORE_READ(task, mm);
+  if (mm == NULL) {
+    LOG("no mm struct");
+    return 0;
+  }
+  u64 stack_top = BPF_CORE_READ(mm, start_stack);
+  INFO("start stack: %lx", stack_top);
+
+  /* find uprobes xol page to be able to walk through uretprobes */
+  struct xol_area *xol_area = BPF_CORE_READ(mm, uprobes_state.xol_area);
+  u64 xol_base = BPF_CORE_READ(xol_area, vaddr);
+  INFO("xol base: %lx", xol_base);
+
+  /*
+   * user mode regs are passed in as ctx. We fetch
+   * them anyway, so that it also works when called from
+   * kernel probes
+   */
+  struct pt_regs *pregs = (struct pt_regs *)bpf_task_pt_regs(task);
+  if (pregs == NULL) {
+    LOG("no pt_regs");
+    return 0;
+  }
+  // XXX differentiate between 32 and 64 bit?
+
+  u32 zero = 0;
+  struct dwunwind_state *s = bpf_map_lookup_elem(&dwunwind_state_scrach, &zero);
+  if (s == NULL) {
+    LOG("no scratch state");
+    return 1;
+  }
+  s->tgid = tgid;
+  s->xol_base = xol_base;
+
+  // XXX just read all as a block and sort later?
+  // XXX not all needed for stack walk without params
+  s->regs_map[0] = BPF_CORE_READ(pregs, ax);
+  s->regs_map[1] = BPF_CORE_READ(pregs, dx);
+  s->regs_map[2] = BPF_CORE_READ(pregs, cx);
+  s->regs_map[3] = BPF_CORE_READ(pregs, bx);
+  s->regs_map[4] = BPF_CORE_READ(pregs, si);
+  s->regs_map[5] = BPF_CORE_READ(pregs, di);
+  s->regs_map[6] = BPF_CORE_READ(pregs, bp);
+  s->regs_map[7] = BPF_CORE_READ(pregs, sp);
+  s->regs_map[8] = BPF_CORE_READ(pregs, r8);
+  s->regs_map[9] = BPF_CORE_READ(pregs, r9);
+  s->regs_map[10] = BPF_CORE_READ(pregs, r10);
+  s->regs_map[11] = BPF_CORE_READ(pregs, r11);
+  s->regs_map[12] = BPF_CORE_READ(pregs, r12);
+  s->regs_map[13] = BPF_CORE_READ(pregs, r13);
+  s->regs_map[14] = BPF_CORE_READ(pregs, r14);
+  s->regs_map[15] = BPF_CORE_READ(pregs, r15);
+  s->regs_map[16] = BPF_CORE_READ(pregs, ip);
+  INFO("rsp %lx ip %lx r8 %lx",
+    s->regs_map[7], s->regs_map[16], s->regs_map[8]);
+
+  INFO("tgid %d", tgid);
+
+  s->current_reg_set = 0;
+  s->regs_valid[0] = 0x1ffff;
+  s->steps = 0;
+
+  if (buf_size < 8) {
+    LOG("buffer too small");
+    return 0;
+  }
+
+  *buf++ = s->regs_map[RIP];
+  int nframes = buf_size / sizeof(u64);
+  for (int i = 1; i < MAX_STACK_FRAMES && i < nframes; ++i) {
+    [[clang::noinline]] if (unwind_step() != 0)
+      goto done;
+    ulong off = s->current_reg_set == 1 ? NUM_REGISTERS : 0;
+    INFO("frame %d: RIP %lx RSP %lx", i,
+      s->regs_map[RIP + off], s->regs_map[RSP + off]);
+    if (s->regs_map[RSP + off] >= stack_top - 8) {
+      INFO("top of stack reached");
+      goto done;
+    }
+    *buf++ = s->regs_map[RIP + off];
+  }
+
+done:
+  INFO("walked %d steps", s->steps);
+  INFO("\n");
+  return (u64)buf - (u64)buf_start;
+}

--- a/src/stdlib/stack/expression.h
+++ b/src/stdlib/stack/expression.h
@@ -1,0 +1,22 @@
+#ifndef EXPRESSION_H__
+#define EXPRESSION_H__
+
+// NOLINTBEGIN(modernize-macro-to-enum) - shared with BPF C code
+#define MAX_EXPR_INSTRUCTIONS 32
+
+// OPs without arguments
+#define EXPR_OP_DEREF   0x01
+#define EXPR_OP_AND     0x02
+#define EXPR_OP_GE      0x03
+#define EXPR_OP_SHL     0x04
+#define EXPR_OP_PLUS    0x05
+#define EXPR_OP_MUL     0x06
+// OPs with one 8 bit argument
+// OPs with one 64 bit argument
+#define EXPR_OP_CONST   0x81
+#define EXPR_OP_PLUS_CONST 0x82
+// OPs with one 8 bit and one 64 bit argument
+#define EXPR_OP_BREG    0xc1
+// NOLINTEND(modernize-macro-to-enum)
+
+#endif // EXPRESSION_H__

--- a/src/util/proc.h
+++ b/src/util/proc.h
@@ -38,6 +38,12 @@ public:
   // Only valid when run() has been called with pause=true.
   virtual Result<> resume() = 0;
 
+  // Continue a paused child until it reaches its entry point (after dynamic
+  // linking completes). This ensures all shared libraries are loaded and
+  // /proc/pid/maps is fully populated. Only valid when run() has been called
+  // with pause=true. The child remains paused after this call.
+  virtual Result<> run_until_entry() = 0;
+
   // Terminate the child process.
   //
   // \param force Forcefully kill the child (SIGKILL).

--- a/tests/runtime/dwunwind
+++ b/tests/runtime/dwunwind
@@ -1,0 +1,5 @@
+NAME dwunwind full stack trace without frame pointers
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=0 } u:./testprogs/uprobe_nofp:funcD { printf("%s\n", dw_ustack()); exit(); }' -c ./testprogs/uprobe_nofp
+EXPECT_REGEX funcD\+[0-9]+\s+funcC\+[0-9]+\s+funcB\+[0-9]+\s+funcA\+[0-9]+\s+main\+[0-9]+
+REQUIRES_FEATURE dwunwind
+TIMEOUT 5

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -165,6 +165,7 @@ class Runner(object):
         bpffeature["get_func_ip"] = output.find("get_func_ip: yes") != -1
         bpffeature["jiffies64"] = output.find("jiffies64: yes") != -1
         bpffeature["lookup_percpu_elem"] = output.find("lookup_percpu_elem: yes") != -1
+        bpffeature["dwunwind"] = output.find("dwunwind (DWARF stack unwinding): yes") != -1
         return bpffeature
 
 

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -44,6 +44,12 @@ endfunction()
 testprog_compile(FALSE)
 testprog_compile(TRUE)
 
+# uprobe_nofp must be compiled without frame pointers to validate that
+# DWARF-based stack unwinding can produce a full stack trace.
+foreach(prog uprobe_nofp uprobe_nofp-pie)
+  set_target_properties(${prog} PROPERTIES COMPILE_FLAGS "-g -O1 -fomit-frame-pointer -fno-optimize-sibling-calls")
+endforeach()
+
 find_program(GO_EXECUTABLE go)
 if(GO_EXECUTABLE)
   file(GLOB testprog_go_sources CONFIGURE_DEPENDS *.go)

--- a/tests/testprogs/uprobe_nofp.c
+++ b/tests/testprogs/uprobe_nofp.c
@@ -1,0 +1,38 @@
+#include <unistd.h>
+
+// This test program is compiled without frame pointers (-fomit-frame-pointer).
+// Only DWARF-based stack unwinding can produce a full stack trace.
+
+volatile int sink;
+
+__attribute__((noinline)) void funcD(void)
+{
+  sink = 42;
+}
+
+__attribute__((noinline)) void funcC(void)
+{
+  funcD();
+  sink;
+}
+
+__attribute__((noinline)) void funcB(void)
+{
+  funcC();
+  sink;
+}
+
+__attribute__((noinline)) void funcA(void)
+{
+  funcB();
+  sink;
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  while (1) {
+    funcA();
+    usleep(500);
+  }
+  return 0;
+}

--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -60,6 +60,15 @@ TEST(unstable_feature, check_error)
              "address-of operator (&) feature is not enabled by default. To "
              "enable this unstable "
              "feature, set the config flag to enable. unstable_addr=enable");
+
+  test("config = { unstable_dw_ustack=warn } uprobe:./a:main "
+       "{ @ = dw_ustack(); }");
+  test_error(
+      "config = { unstable_dw_ustack=error } uprobe:./a:main "
+      "{ @ = dw_ustack(); }",
+      "dw_ustack (DWARF stack unwinding) feature is not enabled by default. "
+      "To enable this unstable feature, set the config flag to enable. "
+      "unstable_dw_ustack=enable");
 }
 
 } // namespace bpftrace::test::unstable_feature


### PR DESCRIPTION
This adds dwarf unwinding for ustack(). The feature is only available for x64 and llvm >= 21.
Two command line parameters are added: --dwarf-pid (-P) and --dwarf-unwind (-u). -u enables it in combination with -p and -c, while -P can be used freely to trace any running process.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
