### PR TITLE
Only run clang-tidy on OUR src directory

### DIFF
--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -69,4 +69,4 @@ run make -C "$BUILD_DIR" -j $(nproc)
 # and unset, then it's an empty arg and run-clang-tidy will treat it as
 # an empty regex which causes all sorts of trouble.
 run run-clang-tidy -q -format -config-file .clang-tidy -p "$BUILD_DIR" $FIX \
-  '^.*(src|tests)/.*\.(h|cpp)$'
+  '(?!.*/(libbpf)/).*(src|tests)/.*\.(h|cpp)$'


### PR DESCRIPTION
libbpf (submodule) also has a src directory so clang-tidy was running against this too.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
