### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -31,7 +31,7 @@ jobs:
           echo "month_name=$month_name" >> "$GITHUB_ENV"
 
       - name: Run issue-metrics tool for issues
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:bpftrace/bpftrace is:issue created:${{ env.last_month }} -reason:"not planned"'
@@ -41,7 +41,7 @@ jobs:
           OUTPUT_FILE: issue_metrics.md
 
       - name: Run issue-metrics tool for PRs
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:bpftrace/bpftrace is:pr created:${{ env.last_month }} -reason:"not planned"'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
