### PR TITLE
Fix segfault in str function

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1333,7 +1333,11 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     Value *strlen = b_.getInt64(max_strlen);
     if (call.vargs.size() > 1) {
       auto scoped_arg = visit(call.vargs.at(1));
-      Value *proposed_strlen = scoped_arg.value();
+      // Widen to i64 to match strlen (max_strlen) above, since the
+      // ICmp and Select below require matching operand types.
+      Value *proposed_strlen = b_.CreateIntCast(scoped_arg.value(),
+                                                b_.getInt64Ty(),
+                                                false);
 
       // integer comparison: unsigned less-than-or-equal-to
       CmpInst::Predicate P = CmpInst::ICMP_ULE;

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -141,6 +141,11 @@ PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/tr
 AFTER ./testprogs/true zztest
 EXPECT zzte
 
+NAME string truncation variable length
+PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { $a = (uint16)5; print(str(args.argv[1], $a)); exit(); }
+AFTER ./testprogs/true zztest
+EXPECT zzte
+
 NAME explicit string truncation with expression
 PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { $a = 1; print(str(args.argv[1], $a + 4)); exit(); }
 AFTER ./testprogs/true zztest


### PR DESCRIPTION
Stacked PRs:
 * __->__#5107


--- --- ---

### Fix segfault in str function


When a variable is passed as the second argument to `str` it needs to be 8
bytes in size or there is a type mismatch when we do a comparison with the
max strlen and a segfault occurs. To fix this just cast the second argument
to a uint64.

Signed-off-by: Jordan Rome <linux@jordanrome.com>