### PR TITLE
Fix segfault in str function (#5107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.2] TBD
+
+#### Fixed
+- Fix crash when passing a variable as the second arg to `str`
+  - [#5107](https://github.com/bpftrace/bpftrace/pull/5107)
+
 ## [0.25.1] 2026-03-25
 
 #### Fixed

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1305,7 +1305,11 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     Value *strlen = b_.getInt64(max_strlen);
     if (call.vargs.size() > 1) {
       auto scoped_arg = visit(call.vargs.at(1));
-      Value *proposed_strlen = scoped_arg.value();
+      // Widen to i64 to match strlen (max_strlen) above, since the
+      // ICmp and Select below require matching operand types.
+      Value *proposed_strlen = b_.CreateIntCast(scoped_arg.value(),
+                                                b_.getInt64Ty(),
+                                                false);
 
       // integer comparison: unsigned less-than-or-equal-to
       CmpInst::Predicate P = CmpInst::ICMP_ULE;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -31,10 +31,10 @@
 #include "probe_matcher.h"
 #include "required_resources.h"
 #include "struct.h"
+#include "symbols/kernel.h"
 #include "types.h"
 #include "usyms.h"
 #include "util/cpus.h"
-#include "symbols/kernel.h"
 #include "util/proc.h"
 #include "util/result.h"
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -137,6 +137,11 @@ PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/tr
 AFTER ./testprogs/true zztest
 EXPECT zzte
 
+NAME string truncation variable length
+PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { $a = (uint16)5; print(str(args.argv[1], $a)); exit(); }
+AFTER ./testprogs/true zztest
+EXPECT zzte
+
 NAME explicit string truncation with expression
 PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { $a = 1; print(str(args.argv[1], $a + 4)); exit(); }
 AFTER ./testprogs/true zztest


### PR DESCRIPTION
When a variable is passed as the second argument to `str` it needs to be 8 bytes in size or there is a type mismatch when we do a comparison with the max strlen and a segfault occurs. To fix this just cast the second argument to a uint64.

stack-info: PR: https://github.com/bpftrace/bpftrace/pull/5107, branch: user/jordalgo/fix_str_length/1



(cherry picked from commit ffb4699f5312eccfab86a9a9833ec46ecb8eccd3)


##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
