### PR TITLE
Support args builtin for fentry/fexit:bpf probes

### DIFF
--- a/src/ast/passes/args_resolver.cpp
+++ b/src/ast/passes/args_resolver.cpp
@@ -1,4 +1,5 @@
 #include <bpf/bpf.h>
+#include <bpf/btf.h>
 #include <cassert>
 
 #include "arch/arch.h"
@@ -10,6 +11,7 @@
 #include "dwarf_parser.h"
 #include "probe_matcher.h"
 #include "probe_types.h"
+#include "scopeguard.h"
 #include "util/result.h"
 
 namespace bpftrace::ast {
@@ -60,6 +62,32 @@ Result<std::shared_ptr<Struct>> ArgsResolver::resolve_args(
   switch (probe_type) {
     case ProbeType::fentry:
     case ProbeType::fexit:
+      if (ap.target == "bpf" && ap.bpf_prog_id != 0) {
+        int fd = bpf_prog_get_fd_by_id(ap.bpf_prog_id);
+        if (fd < 0) {
+          return make_error<ast::ArgParseError>(
+              ap.name(), "failed to get BPF program fd");
+        }
+        SCOPE_EXIT { close(fd); };
+
+        struct bpf_prog_info info = {};
+        __u32 info_len = sizeof(info);
+        if (bpf_prog_get_info_by_fd(fd, &info, &info_len) != 0 ||
+            info.btf_id == 0) {
+          return make_error<ast::ArgParseError>(
+              ap.name(), "BPF program has no BTF");
+        }
+
+        struct btf *prog_btf = btf__load_from_kernel_by_id(info.btf_id);
+        if (!prog_btf) {
+          return make_error<ast::ArgParseError>(
+              ap.name(), "failed to load BPF program BTF");
+        }
+        SCOPE_EXIT { btf__free(prog_btf); };
+
+        return bpftrace_.btf_->resolve_args(
+            ap.func, probe_type == ProbeType::fexit, false, prog_btf);
+      }
       return bpftrace_.btf_->resolve_args(ap.func,
                                           probe_type == ProbeType::fexit,
                                           false);

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -256,11 +256,6 @@ std::optional<Expression> Builtins::visit(Builtin &builtin)
     if (type == ProbeType::fentry || type == ProbeType::fexit ||
         type == ProbeType::uprobe || type == ProbeType::rawtracepoint ||
         type == ProbeType::tracepoint) {
-      if ((type == ProbeType::fentry || type == ProbeType::fexit) &&
-          probe->attach_points[0]->target == "bpf") {
-        builtin.addError() << "The args builtin cannot be used for "
-                              "'fentry/fexit:bpf' probes";
-      }
     } else {
       builtin.addError()
           << "The args builtin can only be used with "

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -562,16 +562,27 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
 
 Result<std::shared_ptr<Struct>> BTF::resolve_args(std::string_view func,
                                                   bool ret,
-                                                  bool skip_first_arg)
+                                                  bool skip_first_arg,
+                                                  struct btf *prog_btf)
 {
-  if (!has_data()) {
-    return make_error<ast::ArgParseError>(func, "BTF data not available");
-  }
+  BTFId func_id;
 
-  auto func_id = find_id(func, BTF_KIND_FUNC);
-  if (!func_id.btf) {
-    return make_error<ast::ArgParseError>(
-        func, "BTF data for the function not found");
+  if (prog_btf) {
+    __s32 id = btf__find_by_name_kind(prog_btf, func.data(), BTF_KIND_FUNC);
+    if (id < 0) {
+      return make_error<ast::ArgParseError>(
+          func, "BTF data for the function not found in BPF program");
+    }
+    func_id = { .btf = prog_btf, .id = static_cast<__u32>(id) };
+  } else {
+    if (!has_data()) {
+      return make_error<ast::ArgParseError>(func, "BTF data not available");
+    }
+    func_id = find_id(func, BTF_KIND_FUNC);
+    if (!func_id.btf) {
+      return make_error<ast::ArgParseError>(
+          func, "BTF data for the function not found");
+    }
   }
 
   const struct btf_type *t = btf__type_by_id(func_id.btf, func_id.id);

--- a/src/btf.h
+++ b/src/btf.h
@@ -115,7 +115,8 @@ public:
   Result<std::shared_ptr<Struct>> resolve_args(
       std::string_view func,
       bool ret,
-      bool skip_first_arg);
+      bool skip_first_arg,
+      struct btf *prog_btf = nullptr);
   Result<std::shared_ptr<Struct>> resolve_raw_tracepoint_args(
       std::string_view func);
   void resolve_fields(const SizedType& type);

--- a/tests/builtins.cpp
+++ b/tests/builtins.cpp
@@ -110,10 +110,6 @@ stdin:1:18-22: ERROR: The args builtin can only be used with tracepoint, rawtrac
 iter:task { $x = args.foo; }
                  ~~~~
 )");
-  test_error(
-      "fentry:bpf:fake_prog { $x = args.foo; }",
-      "ERROR: The args builtin cannot be used for 'fentry/fexit:bpf' probes");
-
   std::vector<std::string> invalid = { "begin",
                                        "end",
                                        "test:k",

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -653,6 +653,18 @@ EXPECT_REGEX fentry:bpf:[0-9]+:interval_us_100000_1
 EXPECT_REGEX fentry:bpf:[0-9]+:interval_us_100000_2
 TIMEOUT 10
 
+NAME fentry_bpf_args
+RUN {{BPFTRACE}} runtime/scripts/bpf_attach.bt & sleep 3 && {{BPFTRACE}} -e 'fentry:bpf:interval_us_* { printf("ctx=%p\n", args.ctx); exit(); }'
+EXPECT_REGEX ctx=0x[0-9a-f]+
+TIMEOUT 10
+REQUIRES_FEATURE btf
+
+NAME fexit_bpf_args
+RUN {{BPFTRACE}} runtime/scripts/bpf_attach.bt & sleep 3 && {{BPFTRACE}} -e 'fexit:bpf:interval_us_* { printf("ctx=%p ret=%d\n", args.ctx, retval); exit(); }'
+EXPECT_REGEX ctx=0x[0-9a-f]+ ret=-?[0-9]+
+TIMEOUT 15
+REQUIRES_FEATURE btf
+
 NAME probe_filter matches specific probe
 RUN {{BPFTRACE}} --probe-filter ':200' -e 'interval:ms:100 { printf("bad\n"); exit(); } interval:ms:200 { printf("hit\n"); exit(); }'
 EXPECT hit


### PR DESCRIPTION
Hi,

This PR enables using bpftrace to get args via fentry and fexit on bpf programs.

I used it to get visibility into what scx schedulers are doing in bpf code.

The following is processed to make things easy to read, but all the data is sourced via bpftrace.

```
    update_task_cell                                                                    mitosis.bpf.c:490
      task_struct *p
        pid                    468
        cpus_ptr               0xffff(0-15)
        dsq_id                 SCX_DSQ_INVALID
        enq_flags              NONE
        slice                  19924357
        vtime                  8028805812
        weight                 100
        sticky_cpu             -1
        scx_flags              RESET_RUNNABLE_AT|DEQD_FOR_SLEEP|ENABLED
      task_ctx *tctx
        cpumask                0xffff(0-15)
        started_running_at     53709451287
        basis_vtime            0
        cell                   0
        configuration_seq      1
        all_cell_cpus_allowed  1
        borrowed               0
      cgroup *cg
        flags                  NONE
        level                  0
        max_depth              2147483647
        nr_descendants         3
        nr_dying_descendants   0
        max_descendants        2147483647
        nr_populated_csets     1
```

bpftrace is amazing, thank you!

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc` (not apply)
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
