### PR TITLE
Add info about preserving env for runtime tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,8 @@ These are `test:` probes written to test core functionality, and standard librar
 
 Runtime tests will call the bpftrace executable. These are located in `tests/runtime` and are managed by a custom framework.
 
-* Run: `sudo <builddir>/tests/runtime-tests.sh`
+* Run (non-Nix): `sudo <builddir>/tests/runtime-tests.sh`
+* Run (Nix): `sudo --preserve-env=PATH --preserve-env=PYTHONPATH ./build/tests/runtime-tests.sh`
 * Use the `TEST_FILTER` environment variable (or the `--filter` arg when running `runtime-tests.sh`) to only run a subset of the tests. The passed value should be a colon-separated list of positive and negative (starting with `-`) regex patterns. Only tests which match any of the positive patterns (by default `.*`) and none of the negative patterns will be executed. For example, `sudo <builddir>/tests/runtime-tests.sh --filter="^uprobe.*:-list"` will run all tests from the `uprobe` suite, except for tests for probe listing.
 * There are environment variables to override paths for the bpftrace executables, if necessary. See runtime-tests.sh for details.
 


### PR DESCRIPTION
When you are using `sudo` to run the runtime tests you need to preserve the env, which is what we're already doing in CI, or else you might get a version of python that doesn't have LooseVersion.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
