### PR TITLE
Fix parse_modules() to handle kernels without modules

### DIFF
--- a/src/symbols/kernel.cpp
+++ b/src/symbols/kernel.cpp
@@ -246,17 +246,23 @@ static bool is_bad_func(const std::string &func)
 
 static Result<ModuleSet> parse_modules()
 {
-  std::ifstream modules_file("/proc/modules");
-  if (modules_file.fail()) {
-    return make_error<SystemError>("Error reading modules from /proc/modules");
-  }
-
   // We have a single pseudo-module for the main kernel binary, which
   // is vmlinux. This is used throughout the codebase to refer to the
   // kernel. For simplicity, we just add it here and everything else
   // just works out, since we also use it during populate_lazy.
   ModuleSet modules;
   modules.emplace("vmlinux");
+
+  std::ifstream modules_file("/proc/modules");
+  if (modules_file.fail()) {
+    // If the kernel is built without modules, then /proc/modules will not exist
+    if (errno == ENOENT) {
+      return modules;
+    }
+
+    return make_error<SystemError>("Error reading modules from /proc/modules");
+  }
+
   for (std::string line; std::getline(modules_file, line);) {
     // /proc/modules format: name size refcount deps state addr
     // We only need the name (first space-separated field)


### PR DESCRIPTION
On kernels built with CONFIG_MODULE=n, bpftrace fails like this:

    # bpftrace -e 'kprobe:acpi_os_read_port { @[kstack] = count(); }'
    ERROR: Failed to open kernel function info: Error reading modules
    from /proc/modules (No such file or directory)

Simply returning {"vmlinux"} as the set of modules when /proc/modules does not exist fixes the problem.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
