### PR TITLE
dwarf: add source location listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Add source location listing
+  - [#5116](https://github.com/bpftrace/bpftrace/pull/5116)
 - Extend support for DWARF formats
   - [#5095](https://github.com/bpftrace/bpftrace/pull/5095)
 - Ternary operator supports an empty second operand.

--- a/docs/language.md
+++ b/docs/language.md
@@ -1510,6 +1510,21 @@ uprobe:/bin/bash@readline.c:362 { ... }
 
 `file` path may be absolute or relative, and `line:col` must refer to a valid statement in that file. Only statements originating from the specified file are considered; statements from included files are ignored.
 
+To get a full list of attachable source locations, use the extra verbose listing option `-lvv`, see [Listing Probes](../man/adoc/bpftrace.adoc#listing-probes).
+
+```
+# bpftrace -lvv 'uprobe:./foo:main'
+uprobe:./foo:main
+    args:
+      int argc
+      char** argv
+    source lines:
+      @src/main.c:30:1
+      @src/main.c:31:12
+      @src/main.c:32:3
+      ...
+```
+
 When tracing C++ programs, it’s possible to turn on automatic symbol demangling by using the `:cpp` prefix:
 
 ```

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -355,6 +355,7 @@ combined with `-e` or filename args to see all the probes that a program would a
 # bpftrace -l -e 'tracepoint:xdp:mem_* { exit(); }'
 # bpftrace -l my_script.bt
 # bpftrace -lv 'enum cpu_usage_stat'
+# bpftrace -lvv 'u:/bin/bash:readline'
 ----
 
 The verbose flag (`-v`) can be specified to inspect arguments (`args`) for providers that support it:
@@ -391,6 +392,27 @@ struct css_task_iter {
         struct list_head iters_node;
 };
 ----
+
+Providers that support DWARF can also use the extra verbose flag (`-lvv`) to list attachable source locations:
+
+----
+# bpftrace -l 'uprobe:/bin/bash:readline' -vv    # works only if /bin/bash has DWARF
+uprobe:/bin/bash:readline
+    args:
+      const char* prompt
+    source lines:
+      @lib/readline/readline.c:355:1
+      @lib/readline/readline.c:356:3
+      @lib/readline/readline.c:362:3
+      ...
+----
+
+Each listed source location can be used directly as a probe target (see link:https://github.com/bpftrace/bpftrace/blob/master/docs/language.md#uprobe-uretprobe[uprobes]),
+allowing probes to be attached at a specific file, line, and column rather than at a function entry point. Inlined functions are not listed, as attaching to them via source
+location is not supported yet.
+
+Note: Source location listing is currently only available for providers with DWARF support (e.g. uprobe). Output can be
+large for functions with many statements.
 
 === Preprocessor Options
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -63,6 +63,7 @@ namespace bpftrace {
 std::set<DebugStage> bt_debug = {};
 bool bt_quiet = false;
 bool bt_verbose = false;
+bool bt_verbose_extra = false;
 bool dry_run = false;
 volatile sig_atomic_t BPFtrace::exitsig_recv = false;
 volatile sig_atomic_t BPFtrace::sigusr1_recv = false;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -50,6 +50,7 @@ enum class DebugStage;
 extern std::set<DebugStage> bt_debug;
 extern bool bt_quiet;
 extern bool bt_verbose;
+extern bool bt_verbose_extra;
 extern bool dry_run;
 
 enum class DebugStage {

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -26,6 +26,7 @@ namespace bpftrace {
 struct FuncInfo {
   std::string name;
   Dwarf_Die die;
+  bool prefer_abstract_die;
 };
 
 Dwarf::Dwarf(BPFtrace *bpftrace,
@@ -141,17 +142,46 @@ static std::string get_die_name(Dwarf_Die *die)
 static int get_func_die_cb(Dwarf_Die *func_die, void *arg)
 {
   auto *func_info = static_cast<struct FuncInfo *>(arg);
-  if (dwarf_hasattr_integrate(func_die, DW_AT_name) &&
-      get_die_name(func_die) == func_info->name) {
-    func_info->die = *func_die;
+  if (!dwarf_hasattr_integrate(func_die, DW_AT_name) ||
+      get_die_name(func_die) != func_info->name)
+    return DWARF_CB_OK;
+
+  // Only concrete function definition DIEs have PC range, abstract definitions
+  // and stubs do not.
+  bool has_addr = dwarf_hasattr(func_die, DW_AT_low_pc) ||
+                  dwarf_hasattr(func_die, DW_AT_ranges);
+
+  // Skip callsite stub DIEs; these don't have the attributes of a function die
+  // and lead to wrong results.
+  if (!has_addr && dwarf_hasattr(func_die, DW_AT_abstract_origin))
+    return DWARF_CB_OK;
+
+  // Lookup referenced abstract-origin die; preferred for param type info.
+  if (func_info->prefer_abstract_die &&
+      dwarf_hasattr(func_die, DW_AT_abstract_origin)) {
+    Dwarf_Attribute attr;
+    Dwarf_Die origin_die;
+    dwarf_formref_die(dwarf_attr(func_die, DW_AT_abstract_origin, &attr),
+                      &origin_die);
+    func_info->die = origin_die;
     return DWARF_CB_ABORT;
   }
-  return DWARF_CB_OK;
+
+  // Keep looking for a concrete function DIE with present PC range; preferred
+  // for address/line info.
+  if (!func_info->prefer_abstract_die && !has_addr)
+    return DWARF_CB_OK;
+
+  func_info->die = *func_die;
+  return DWARF_CB_ABORT;
 }
 
-std::optional<Dwarf_Die> Dwarf::get_func_die(const std::string &function) const
+std::optional<Dwarf_Die> Dwarf::get_func_die(const std::string &function,
+                                             bool prefer_abstract_die) const
 {
-  struct FuncInfo func_info = { .name = function, .die = {} };
+  struct FuncInfo func_info = { .name = function,
+                                .die = {},
+                                .prefer_abstract_die = prefer_abstract_die };
 
   CuInfo cu_info = {};
   while (next_cu_info(&cu_info)) {
@@ -173,7 +203,7 @@ static Dwarf_Die type_of(Dwarf_Die &die)
 std::vector<Dwarf_Die> Dwarf::function_param_dies(
     const std::string &function) const
 {
-  auto func_die = get_func_die(function);
+  auto func_die = get_func_die(function, true);
   if (!func_die)
     return {};
 
@@ -374,7 +404,7 @@ std::vector<std::string> Dwarf::get_function_params(
   for (auto &param_die : function_param_dies(function)) {
     Dwarf_Die type_die = type_of(param_die);
     const std::string type_name = get_type_name(type_die);
-    if (dwarf_hasattr(&param_die, DW_AT_name))
+    if (dwarf_hasattr_integrate(&param_die, DW_AT_name))
       result.push_back(type_name + " " + get_die_name(&param_die));
     else
       result.push_back(type_name);
@@ -446,6 +476,62 @@ std::vector<Dwarf_Die> Dwarf::get_all_children_with_tag(Dwarf_Die *die, int tag)
   return children;
 }
 
+template <typename VisitCallback>
+void Dwarf::visit_die_subtree(Dwarf_Die *die, VisitCallback &&callback)
+{
+  callback(die);
+
+  Dwarf_Die child_die;
+  Dwarf_Die *child_iter = &child_die;
+  if (dwarf_child(die, &child_die) != 0)
+    return;
+
+  do {
+    visit_die_subtree(&child_die, callback);
+  } while (dwarf_siblingof(child_iter, &child_die) == 0);
+}
+
+std::vector<std::pair<Dwarf_Addr, Dwarf_Addr>> Dwarf::get_inlined_func_ranges(
+    Dwarf_Die *func_die)
+{
+  std::vector<std::pair<Dwarf_Addr, Dwarf_Addr>> ranges;
+  if (dwarf_tag(func_die) != DW_TAG_subprogram) {
+    return {};
+  }
+
+  auto get_inlined_ranges_cb = [&ranges](Dwarf_Die *die) {
+    if (dwarf_tag(die) != DW_TAG_inlined_subroutine)
+      return;
+    Dwarf_Addr base = 0, begin = 0, end = 0;
+    ptrdiff_t offset = 0;
+    while ((offset = dwarf_ranges(die, offset, &base, &begin, &end)) > 0)
+      ranges.emplace_back(begin, end);
+  };
+
+  visit_die_subtree(func_die, get_inlined_ranges_cb);
+
+  return ranges;
+}
+
+static bool is_inlined_addr(Dwarf_Die *cudie, Dwarf_Addr addr)
+{
+  Dwarf_Die *scopes = nullptr;
+  int num_scopes = dwarf_getscopes(cudie, addr, &scopes);
+  if (num_scopes <= 0)
+    return false;
+
+  bool inlined = false;
+  for (int i = 0; i < num_scopes; i++) {
+    if (dwarf_tag(&scopes[i]) == DW_TAG_inlined_subroutine) {
+      inlined = true;
+      break;
+    }
+  }
+
+  free(scopes);
+  return inlined;
+}
+
 ssize_t Dwarf::get_array_size(Dwarf_Die &subrange_die)
 {
   Dwarf_Attribute size_attr;
@@ -509,110 +595,177 @@ ssize_t Dwarf::get_bitfield_size(Dwarf_Die &field_die)
   return 0;
 }
 
-std::optional<std::filesystem::path> Dwarf::get_cu_src_path(Dwarf_Die *cudie)
+std::vector<std::pair<Dwarf::CuInfo, std::string>> Dwarf::get_cus_with_srcfile(
+    const std::string &source_file) const
 {
-  Dwarf_Files *files;
-  size_t nfiles;
-  if (dwarf_getsrcfiles(cudie, &files, &nfiles) == 0 && nfiles > 0) {
-    // The returned source file path may either be absolute or relative.
-    // According to the DWARF standard, source file paths should be locatable by
-    // combining DW_AT_comp_dir with the CU's file name. However, DW_AT_comp_dir
-    // may be missing or empty, therefore callers should not assume the path is
-    // always absolute. https://wiki.dwarfstd.org/Best_Practices.md
-    const char *src = dwarf_filesrc(files, 0, nullptr, nullptr);
-    if (src) {
-      return std::filesystem::path(src);
-    }
-  }
-
-  return std::nullopt;
-}
-
-Result<Dwarf::CuInfo> Dwarf::get_cu_by_src(const std::string &source_file) const
-{
-  std::optional<CuInfo> matched_cu;
-  std::filesystem::path matched_src_path;
+  std::vector<std::pair<Dwarf::CuInfo, std::string>> cu_list;
 
   CuInfo cu_info = {};
   while (next_cu_info(&cu_info)) {
-    auto src_path = get_cu_src_path(cu_info.cu_die());
-    if (!src_path)
-      continue;
-
-    if (util::path_ends_with(*src_path, source_file)) {
-      if (!matched_cu) {
-        matched_cu = cu_info;
-        matched_src_path = *src_path;
-      } else {
-        return make_error<DwarfParseError>(
-            "Ambiguous source path, matches multiple files: " +
-            matched_src_path.string() + ", " + src_path->string());
+    Dwarf_Files *files = nullptr;
+    size_t nfiles = 0;
+    if (dwarf_getsrcfiles(cu_info.cu_die(), &files, &nfiles) == 0) {
+      for (size_t i = 0; i < nfiles; ++i) {
+        const char *src = dwarf_filesrc(files, i, nullptr, nullptr);
+        if (src && util::path_ends_with(src, source_file)) {
+          cu_list.emplace_back(cu_info, src);
+          break;
+        }
       }
     }
   }
 
-  if (!matched_cu)
-    return make_error<DwarfParseError>("No compilation unit matches " +
-                                       source_file);
+  return cu_list;
+}
 
-  return std::move(*matched_cu);
+Result<> Dwarf::foreach_src_line(Dwarf_Die *cudie, LineCallback auto &&callback)
+{
+  Dwarf_Lines *lines = nullptr;
+  size_t num_lines = 0;
+  if (dwarf_getsrclines(cudie, &lines, &num_lines) != 0)
+    return make_error<DwarfParseError>(
+        "Failed to get compilation unit source lines");
+
+  for (size_t i = 0; i < num_lines; i++) {
+    Dwarf_Line *line = dwarf_onesrcline(lines, i);
+    if (!line)
+      continue;
+
+    int lineno, linecol;
+    if (dwarf_lineno(line, &lineno) != 0 || dwarf_linecol(line, &linecol) != 0)
+      continue;
+
+    const char *linesrc = dwarf_linesrc(line, nullptr, nullptr);
+    if (!linesrc)
+      continue;
+
+    if (!callback(line, linesrc, lineno, linecol))
+      break;
+  }
+
+  return OK();
 }
 
 Result<uint64_t> Dwarf::line_to_addr(const std::string &source_file,
                                      size_t line_num,
                                      size_t col_num) const
 {
-  auto cu = get_cu_by_src(source_file);
-  if (!cu) {
-    return cu.takeError();
+  // Get all compilation units that reference the given source file in their
+  // source file table, as (CU, resolved source file) pairs. Direct 1:1 matching
+  // via DW_AT_name is unreliable due to LTO, DWZ, and other compiler settings.
+  auto matched_cus = get_cus_with_srcfile(source_file);
+  if (matched_cus.empty()) {
+    return make_error<DwarfParseError>("No compilation unit matches " +
+                                       source_file);
   }
 
-  auto src_path = get_cu_src_path(cu->cu_die());
-  if (!src_path) {
-    return make_error<DwarfParseError>(
-        "Failed to get compilation unit source path");
-  }
-
-  Dwarf_Lines *lines = nullptr;
-  size_t num_lines = 0;
-
-  if (dwarf_getsrclines(cu->cu_die(), &lines, &num_lines) != 0) {
-    return make_error<DwarfParseError>(
-        "Failed to get compilation unit source lines");
-  }
-
-  for (size_t i = 0; i < num_lines; i++) {
-    Dwarf_Line *line = dwarf_onesrcline(lines, i);
-    if (!line) {
-      continue;
-    }
-
-    int lineno, linecol;
-    if (dwarf_lineno(line, &lineno) != 0 ||
-        dwarf_linecol(line, &linecol) != 0) {
-      continue;
-    }
-
-    const char *linesrc = dwarf_linesrc(line, nullptr, nullptr);
-    if (!linesrc) {
-      continue;
-    }
-
-    // Check if the line source matches the CU's source path, to avoid
-    // unintentionally accessing statements from included files.
-    if (util::path_ends_with(linesrc, *src_path) &&
-        line_num == static_cast<size_t>(lineno) &&
-        (col_num == 0 || col_num == static_cast<size_t>(linecol))) {
-      Dwarf_Addr addr;
-      if (dwarf_lineaddr(line, &addr) == 0) {
-        return addr;
+  std::optional<uint64_t> address;
+  std::string matched_src;
+  bool ambiguity = false;
+  for (auto &pair : matched_cus) {
+    auto &cu = pair.first;
+    auto &source = pair.second;
+    auto find_address =
+        [&cu, &source, &line_num, &col_num, &address, &matched_src, &ambiguity](
+            Dwarf_Line *line,
+            const char *linesrc,
+            int lineno,
+            int linecol) -> bool {
+      // Check if the line source matches the CU's source
+      // file, to avoid unintentionally accessing
+      // statements from included files (e.g. inlined or template code) with
+      // matching line number (and column).
+      if (util::path_ends_with(linesrc, source) &&
+          line_num == static_cast<size_t>(lineno) &&
+          (col_num == 0 || col_num == static_cast<size_t>(linecol))) {
+        Dwarf_Addr addr;
+        if (dwarf_lineaddr(line, &addr) == 0) {
+          // Skip inlined entries
+          if (is_inlined_addr(cu.cu_die(), addr))
+            return true;
+          // Since partial source path matching is used for better UX, multiple
+          // matches with different resolved source paths can occur, leading to
+          // ambiguity. For example, @file.c:1 may match both src/file.c and
+          // lib/file.c.
+          if (address && matched_src != source) {
+            ambiguity = true;
+          } else {
+            address = addr;
+            matched_src = source;
+          }
+          // Stop iterating this CU once a match is found.
+          return false;
+        }
       }
-    }
+      return true;
+    };
+
+    auto err = foreach_src_line(cu.cu_die(), find_address);
+    if (!err)
+      return err.takeError();
+
+    if (ambiguity)
+      return make_error<DwarfParseError>(
+          "Ambiguous source path, matches multiple files: " + matched_src +
+          ", " + source);
   }
+
+  if (address)
+    return address.value();
 
   return make_error<DwarfParseError>(
       "Unable to map '" + source_file + ":" + std::to_string(line_num) +
       (col_num > 0 ? ":" + std::to_string(col_num) : "") + "' to address");
+}
+
+Result<std::vector<std::string>> Dwarf::get_function_src_lines(
+    const std::string &function) const
+{
+  std::vector<std::string> src_lines;
+  std::unordered_set<std::string> seen;
+
+  // Non-abstract func die with present PC range.
+  auto func_die = get_func_die(function, false);
+  if (!func_die)
+    return src_lines;
+
+  Dwarf_Die cudie;
+  dwarf_diecu(&func_die.value(), &cudie, nullptr, nullptr);
+
+  // Precompute PC ranges of inlined functions in the given function DIE's
+  // subtree. This serves as an optimised alternative to dwarf_getscopes.
+  auto inlined_ranges = get_inlined_func_ranges(&func_die.value());
+  auto is_inlined = [&inlined_ranges](Dwarf_Addr addr) -> bool {
+    return std::ranges::any_of(inlined_ranges, [addr](const auto &range) {
+      return addr >= range.first && addr < range.second;
+    });
+  };
+
+  // Get the source-line info for each line whose address falls within
+  // the given function's PC range. Inlined functions are filtered out
+  // on a best-effort basis due to possible overlapping PC ranges.
+  auto get_src_line =
+      [&src_lines, &seen, &func_die, &is_inlined](Dwarf_Line *line,
+                                                  const char *linesrc,
+                                                  int lineno,
+                                                  int linecol) -> bool {
+    Dwarf_Addr addr = 0;
+    if (dwarf_lineaddr(line, &addr) == 0 &&
+        dwarf_haspc(&func_die.value(), addr) == 1) {
+      auto entry = std::string(linesrc) + ":" + std::to_string(lineno);
+      if (linecol > 0)
+        entry += ":" + std::to_string(linecol);
+      if (seen.insert(entry).second && !is_inlined(addr))
+        src_lines.push_back(std::move(entry));
+    }
+    return true;
+  };
+
+  auto err = foreach_src_line(&cudie, get_src_line);
+  if (!err)
+    return err.takeError();
+
+  return src_lines;
 }
 
 } // namespace bpftrace

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -39,6 +39,10 @@ namespace bpftrace {
 
 class BPFtrace;
 
+template <typename T>
+concept LineCallback =
+    std::is_invocable_r_v<bool, T, Dwarf_Line *, const char *, int, int>;
+
 class Dwarf {
 public:
   virtual ~Dwarf();
@@ -61,11 +65,16 @@ public:
   SizedType get_stype(const std::string &type_name) const;
   void resolve_fields(const SizedType &type) const;
 
+  // Maps a source file, line, and optional column to the *first* corresponding
+  // instruction address. Mapping to inlined code is not supported.
   Result<uint64_t> line_to_addr(const std::string &source_file,
                                 size_t line_num,
                                 size_t col_num = 0) const;
+  // Returns source lines associated with a function as 'file:line:col' strings.
+  // Inlined line entries are omitted.
+  Result<std::vector<std::string>> get_function_src_lines(
+      const std::string &function) const;
 
-private:
   // Compilation unit wrapper, abstracting over regular and split (DWO/DWP)
   // CU DIEs.
   class CuInfo {
@@ -89,13 +98,15 @@ private:
     }
   };
 
+private:
   Dwarf(BPFtrace *bpftrace,
         const std::string &file_path,
         std::string debuginfo_path);
 
   bool next_cu_info(CuInfo *cu_info) const;
   std::vector<Dwarf_Die> function_param_dies(const std::string &function) const;
-  std::optional<Dwarf_Die> get_func_die(const std::string &function) const;
+  std::optional<Dwarf_Die> get_func_die(const std::string &function,
+                                        bool prefer_abstract_die) const;
   std::string get_type_name(Dwarf_Die &type_die) const;
   Dwarf_Word get_type_encoding(Dwarf_Die &type_die) const;
   std::optional<Dwarf_Die> find_type(const std::string &name) const;
@@ -106,8 +117,10 @@ private:
   std::optional<Bitfield> resolve_bitfield(Dwarf_Die &field_die) const;
 
   SizedType get_stype(Dwarf_Die &type_die, bool resolve_structs = true) const;
-
-  Result<CuInfo> get_cu_by_src(const std::string &source_file) const;
+  // Returns all CUs that reference the given source file in their srcfile table
+  // as (CU, resolved source file) pairs.
+  std::vector<std::pair<Dwarf::CuInfo, std::string>> get_cus_with_srcfile(
+      const std::string &source_file) const;
 
   static std::optional<Dwarf_Die> get_child_with_tagname(
       Dwarf_Die *die,
@@ -115,8 +128,17 @@ private:
       const std::string &name);
   static std::vector<Dwarf_Die> get_all_children_with_tag(Dwarf_Die *die,
                                                           int tag);
-
-  static std::optional<std::filesystem::path> get_cu_src_path(Dwarf_Die *cudie);
+  // Preorder DFS traversal of a DIE subtree.
+  template <typename VisitCallback>
+  static void visit_die_subtree(Dwarf_Die *die, VisitCallback &&callback);
+  // Iterates line table in a CUDIE and calls the given callback for
+  // each entry. If the callback returns false value the iteration stops,
+  // otherwise keeps iterating.
+  static Result<> foreach_src_line(Dwarf_Die *cudie,
+                                   LineCallback auto &&callback);
+  // Returns PC ranges of all inlined subroutines within the given function DIE.
+  static std::vector<std::pair<Dwarf_Addr, Dwarf_Addr>> get_inlined_func_ranges(
+      Dwarf_Die *func_die);
 
   Dwfl *dwfl = nullptr;
   Dwfl_Callbacks callbacks;
@@ -183,6 +205,12 @@ public:
                                 __attribute__((unused)),
                                 size_t line_num __attribute__((unused)),
                                 size_t col_num __attribute__((unused))) const
+  {
+    return make_error<DwarfParseError>();
+  }
+
+  Result<std::vector<std::string>> get_function_src_lines(
+      const std::string &function __attribute__((unused))) const
   {
     return make_error<DwarfParseError>();
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -620,8 +620,12 @@ Args parse_args(int argc, char* argv[])
         break;
       case 'v':
       case Options::VERBOSE:
-        ENABLE_LOG(V1);
-        bt_verbose = true;
+        if (bt_verbose) {
+          bt_verbose_extra = true;
+        } else {
+          ENABLE_LOG(V1);
+          bt_verbose = true;
+        }
         break;
       case 'B':
         if (std::strcmp(optarg, "line") == 0) {

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -476,10 +476,45 @@ FuncParamLists ProbeMatcher::get_params_for_matches(
   }
 }
 
+SourceLineLists ProbeMatcher::get_source_lines_for_matches(
+    ProbeType probe_type,
+    const std::set<std::string>& matches)
+{
+  if (!bt_verbose_extra ||
+      (probe_type != ProbeType::uprobe && probe_type != ProbeType::kprobe))
+    return {};
+
+  SourceLineLists result;
+  static std::set<std::string> warned_paths;
+
+  for (const auto& match : matches) {
+    std::string fun = match;
+    std::string path = util::erase_prefix(fun);
+    auto dwarf = Dwarf::GetFromBinary(nullptr,
+                                      path,
+                                      bpftrace_->debuginfo_path_);
+    if (dwarf) {
+      auto lines = dwarf->get_function_src_lines(fun);
+      if (lines) {
+        result.emplace(match, *lines);
+      } else {
+        LOG(WARNING) << lines.takeError();
+      }
+    } else {
+      if (warned_paths.insert(path).second)
+        LOG(WARNING) << "No DWARF found for \"" << path << "\""
+                     << ", cannot show source line info";
+    }
+  }
+
+  return result;
+}
+
 void ProbeMatcher::format_matches_for_listing(
     ProbeType probe_type,
     const std::set<std::string>& matches,
     const FuncParamLists& param_lists,
+    const SourceLineLists& src_lists,
     std::vector<std::string>& results,
     const std::string& lang)
 {
@@ -504,11 +539,25 @@ void ProbeMatcher::format_matches_for_listing(
     std::ostringstream ss;
     ss << probe_type << ":" << match_print;
     results.push_back(ss.str());
+
     if (bt_verbose) {
-      auto it = param_lists.find(match);
-      if (it != param_lists.end()) {
-        for (const auto& param : it->second)
-          results.push_back("    " + param);
+      const std::string indent = bt_verbose_extra ? "      " : "    ";
+
+      auto param_it = param_lists.find(match);
+      if (param_it != param_lists.end() && !param_it->second.empty()) {
+        if (bt_verbose_extra)
+          results.emplace_back("    args:");
+        for (const auto& param : param_it->second)
+          results.push_back(indent + param);
+      }
+
+      if (bt_verbose_extra) {
+        auto src_it = src_lists.find(match);
+        if (src_it != src_lists.end() && !src_it->second.empty()) {
+          results.emplace_back("    source lines:");
+          for (const auto& line : src_it->second)
+            results.push_back(indent + "@" + line);
+        }
       }
     }
   }
@@ -527,8 +576,9 @@ std::vector<std::string> ProbeMatcher::get_probes_for_listing(
 
       auto matches = get_matches_for_ap(*ap);
       auto param_lists = get_params_for_matches(probe_type, matches);
+      auto source_lines = get_source_lines_for_matches(probe_type, matches);
       format_matches_for_listing(
-          probe_type, matches, param_lists, results, ap->lang);
+          probe_type, matches, param_lists, source_lines, results, ap->lang);
     }
   }
   return results;
@@ -632,7 +682,9 @@ std::vector<std::string> ProbeMatcher::get_probes_for_listing(
         probe_type, target, search_input, false /* demangle_symbols */);
 
     auto param_lists = get_params_for_matches(probe_type, matches);
-    format_matches_for_listing(probe_type, matches, param_lists, results);
+    auto source_lines = get_source_lines_for_matches(probe_type, matches);
+    format_matches_for_listing(
+        probe_type, matches, param_lists, source_lines, results);
   }
   return results;
 }

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -50,6 +50,8 @@ const std::unordered_set<std::string> TIME_UNITS = { "s", "ms", "us", "hz" };
 
 const std::unordered_set<std::string> SIGNALS = { "SIGUSR1" };
 
+using SourceLineLists = std::map<std::string, std::vector<std::string>>;
+
 class BPFtrace;
 
 class ProbeMatcher {
@@ -101,7 +103,8 @@ private:
                                            const std::set<std::string> &set);
 
   virtual std::unique_ptr<std::istream> get_symbols_from_traceable_funcs(
-      bool with_modules = false, std::optional<std::string> module = std::nullopt) const;
+      bool with_modules = false,
+      std::optional<std::string> module = std::nullopt) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_list(
       const std::vector<ProbeListItem> &probes_list) const;
   virtual std::unique_ptr<std::istream> get_fentry_symbols(
@@ -121,9 +124,15 @@ private:
   FuncParamLists get_uprobe_params(const std::set<std::string> &uprobes);
   FuncParamLists get_params_for_matches(ProbeType probe_type,
                                         const std::set<std::string> &matches);
+
+  SourceLineLists get_source_lines_for_matches(
+      ProbeType probe_type,
+      const std::set<std::string> &matches);
+
   void format_matches_for_listing(ProbeType probe_type,
                                   const std::set<std::string> &matches,
                                   const FuncParamLists &param_lists,
+                                  const SourceLineLists &src_lists,
                                   std::vector<std::string> &results,
                                   const std::string &lang = "");
 };

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -157,3 +157,19 @@ EXPECT ok
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/debug/dwp/uprobe_test-split
+
+NAME list uprobe source lines - basic
+RUN {{BPFTRACE}} -lvv 'uprobe:./testprogs/uprobe_test:uprobeFunction1'
+EXPECT_REGEX ^\s+@[^\s]+uprobe_test\.c:16(:[0-9]+)?$
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
+NAME list uprobe source lines - wildcard
+RUN {{BPFTRACE}} -lvv 'uprobe:./testprogs/uprobe_test:*'
+EXPECT_REGEX ^\s+@[^\s]+uprobe_test\.c:16(:[0-9]+)?$
+EXPECT_REGEX ^\s+@[^\s]+uprobe_test\.c:22(:[0-9]+)?$
+EXPECT_REGEX ^\s+@[^\s]+uprobe_test\.c:27(:[0-9]+)?$
+EXPECT_REGEX ^\s+@[^\s]+uprobe_test\.c:70(:[0-9]+)?$
+EXPECT_REGEX ^\s+@[^\s]+uprobe_test\.c:75(:[0-9]+)?$
+REQUIRES_FEATURE dwarf
+TIMEOUT 5


### PR DESCRIPTION
When tracing at the source level, it is not always obvious which source locations are valid probe targets, as this depends on how the compiler maps source to instructions. Functions may be fully inlined, or their source lines reordered or omitted.

This extends the source location probe feature introduced in [#4867](https://github.com/bpftrace/bpftrace/pull/4867) by adding an extra verbose listing option (`-lvv`) for providers with DWARF support. The output lists attachable source locations ordered by their corresponding instruction address, similiar to tools like readelf and dwarfdump.

```
    $ bpftrace -lvv 'uprobe:./app:func'
    uprobe:./app:func
        args:
          int n
        source lines:
          @src/foo.c:42:1
          @src/foo.c:43:3
          @lib/bar.c:17:1
          ...
```

Since attaching to inlined functions via source location is not supported yet, inlined line entries are omitted (filtered) from the listing output. Also disabled in `line_to_addr`.

Note: Output can be large for functions with many statements.

Additionally few bugs were fixed:
  - `get_func_die_cb` could previously return function DIE stubs leading to parsing failures, as they have no attributes. These are now skipped and abstract-origin/concrete func dies are returned. The problem was that the function returned the first match by name, even though it was not usable function DIE.
  - `get_cu_by_src` was replaced with `get_cus_with_srcfile`, since it is not guranteed that comp units name corresponds to a source file, especially with LTO/DWZ builds. The function now returns a list of CUs, that contain the given source file string in their DIE source file table.
  -  Use `hasattr_integrate` instead of `hasattr` in `get_function_params` , as its able to resolve attributes from referenced DIEs. Otherwise, data would be lost unnecessarily.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
