### PR TITLE
tools/naptime: Filter out failed calls and add clock_nanosleep support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
 #### Security
 #### Docs
 #### Tools
+- naptime.bt: Filter out failed calls and add clock_nanosleep support
+  - [#5117](https://github.com/bpftrace/bpftrace/pull/5117)
 
 ## [0.25.1] 2026-03-25
 

--- a/tools/naptime.bt
+++ b/tools/naptime.bt
@@ -38,10 +38,24 @@ BEGIN
          "TIME", "PPID", "PCOMM", "PID", "COMM", "SECONDS");
 }
 
+tracepoint:syscalls:sys_enter_clock_nanosleep,
 tracepoint:syscalls:sys_enter_nanosleep
-/args.rqtp.tv_sec + args.rqtp.tv_nsec/
+{
+  @rqtp[tid] = args.rqtp;
+}
+
+tracepoint:syscalls:sys_exit_clock_nanosleep,
+tracepoint:syscalls:sys_exit_nanosleep
+/ args.ret == 0 /
 {
   time("%H:%M:%S ");
+  $t = @rqtp[tid];
   printf("%-6d %-16s %-6d %-16s %d.%03d\n",
-         ppid, pcomm, pid, comm, args.rqtp.tv_sec, ((uint64)args.rqtp.tv_nsec) / 1e6);
+         ppid, pcomm, pid, comm, $t.tv_sec, ((uint64)$t.tv_nsec) / 1e6);
+  delete(@rqtp, tid);
+}
+
+END
+{
+  clear(@rqtp);
 }


### PR DESCRIPTION
naptime.bt should filter out failed sleeps, because there is no nap. At the same time, add clock_nanosleep support, glibc uses clock_nanosleep(2) instead of nanosleep(2) some times.

Test source code nanosleep.c:

    #include <stdio.h>
    #include <sys/syscall.h>
    #include <time.h>
    #include <unistd.h>

    int main(void)
    {
        struct timespec ts1 = {1, 1}, ts2 = {-1, -1};
        nanosleep(&ts1, NULL);                  // (1) glibc, success
        syscall(__NR_nanosleep, &ts1, NULL);    // (2) syscall, success
        nanosleep(&ts2, NULL);                  // (3) glibc, failed
        syscall(__NR_nanosleep, &ts2, NULL);    // (4) syscall, failed
        return 0;
    }

# Before: missed (1) and incorrect statistics (4)

    TIME     PPID   PCOMM            PID    COMM             SECONDS
    20:53:18 5575   nanosleep        35143  nanosleep        1.000          (2)
    20:53:19 5575   nanosleep        35143  nanosleep        -1.-140462611  (4)

# After: successfully counted (1) and (2), filtered out the failed (3) and (4)

    TIME     PPID   PCOMM            PID    COMM             SECONDS
    20:54:13 5575   nanosleep        35285  nanosleep        1.000          (1)
    20:54:14 5575   nanosleep        35285  nanosleep        1.000          (2)
