### PR TITLE
tools/naptime.bt: Fix map key leak

### DIFF
--- a/tools/naptime.bt
+++ b/tools/naptime.bt
@@ -31,6 +31,8 @@
 #include <linux/sched.h>
 #endif
 
+let @rqtp = lruhash(4096);
+
 BEGIN
 {
   printf("Tracing sleeps. Hit Ctrl-C to end.\n");
@@ -46,12 +48,14 @@ tracepoint:syscalls:sys_enter_nanosleep
 
 tracepoint:syscalls:sys_exit_clock_nanosleep,
 tracepoint:syscalls:sys_exit_nanosleep
-/ args.ret == 0 /
+/ has_key(@rqtp, tid) /
 {
-  time("%H:%M:%S ");
-  $t = @rqtp[tid];
-  printf("%-6d %-16s %-6d %-16s %d.%03d\n",
-         ppid, pcomm, pid, comm, $t.tv_sec, ((uint64)$t.tv_nsec) / 1e6);
+  if (args.ret == 0) {
+    time("%H:%M:%S ");
+    $t = @rqtp[tid];
+    printf("%-6d %-16s %-6d %-16s %d.%03d\n",
+           ppid, pcomm, pid, comm, $t.tv_sec, ((uint64)$t.tv_nsec) / 1e6);
+  }
   delete(@rqtp, tid);
 }
 


### PR DESCRIPTION
When naptime runs for a long time and a large number of failed nanosleep/clock_nanosleep calls occur during this period, a large number of invalid keys will remain in @rqtp. These keys are the TIDs of the processes that failed to call nanosleep.

Warning:

    naptime.bt:44:3-25: WARNING: Map full; can't update element.
    Try increasing max_map_keys config or manually setting the max entries in a map declaration e.g. `let @a = hash(5000)`
    Additional Info - helper: map_update_elem, retcode: -7
      @rqtp[tid] = args.rqtp;
      ~~~~~~~~~~~~~~~~~~~~~~

Test, too much failed calls:

    $ more sleep.c
    #include <stdio.h>
    #include <time.h>
    int main(void)
    {
        struct timespec ts = {-1, -1};
        nanosleep(&ts, NULL);
        return 0;
    }
    $ gcc sleep.c -o sleep
    $ while :; do ./sleep ; done

Fixes: 3f2dfae17f7e ("tools/naptime: Filter out failed calls and add clock_nanosleep support (#5117)")
