### PR TITLE
Remove SizedType from AST

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -13,7 +13,6 @@
 #include "ast/context.h"
 #include "diagnostic.h"
 #include "probe_types.h"
-#include "types.h"
 #include "symbols/elf_parser.h"
 
 namespace bpftrace::ast {
@@ -161,6 +160,7 @@ class String;
 class None;
 class Identifier;
 class Builtin;
+class ParsedType;
 class Call;
 class Sizeof;
 class Offsetof;
@@ -525,9 +525,129 @@ public:
   size_t injected_args = 0;
 };
 
+class ParsedType : public Node {
+public:
+  enum class Kind {
+    Identifier,
+    Struct,
+    Union,
+    Enum,
+    Pointer,
+    Array,
+  };
+
+  ParsedType(ASTContext &ctx, Location &&loc, Kind kind, std::string name)
+      : Node(ctx, std::move(loc)), kind(kind), name(std::move(name)) {};
+
+  ParsedType(ASTContext &ctx, Location &&loc, ParsedType *pointee)
+      : Node(ctx, std::move(loc)), kind(Kind::Pointer), inner(pointee) {};
+
+  ParsedType(ASTContext &ctx,
+             Location &&loc,
+             uint64_t size,
+             ParsedType *element)
+      : Node(ctx, std::move(loc)),
+        kind(Kind::Array),
+        array_size(size),
+        inner(element) {};
+
+  ParsedType(ASTContext &ctx, const Location &loc, const ParsedType &other)
+      : Node(ctx, loc + other.loc),
+        kind(other.kind),
+        name(other.name),
+        array_size(other.array_size),
+        inner(other.inner ? ctx.clone_node<ParsedType>(loc, other.inner)
+                          : nullptr) {};
+
+  std::string type_name() const
+  {
+    switch (kind) {
+      case Kind::Identifier:
+        return name;
+      case Kind::Struct:
+        return "struct " + name;
+      case Kind::Union:
+        return "union " + name;
+      case Kind::Enum:
+        return "enum " + name;
+      case Kind::Pointer:
+      case Kind::Array:
+        return inner ? inner->type_name() + "*" : "";
+    }
+
+    return "";
+  }
+
+  const ParsedType &base_type() const
+  {
+    if ((kind == Kind::Pointer || kind == Kind::Array) && inner) {
+      return inner->base_type();
+    }
+    return *this;
+  }
+
+  bool operator==(const ParsedType &other) const
+  {
+    return kind == other.kind && name == other.name &&
+           array_size == other.array_size &&
+           (inner == other.inner ||
+            (inner && other.inner && *inner == *other.inner));
+  }
+
+  std::strong_ordering operator<=>(const ParsedType &other) const
+  {
+    if (auto cmp = kind <=> other.kind; cmp != 0) {
+      return cmp;
+    }
+    if (auto cmp = name <=> other.name; cmp != 0) {
+      return cmp;
+    }
+    if (auto cmp = array_size <=> other.array_size; cmp != 0) {
+      return cmp;
+    }
+    if (inner && other.inner)
+      return *inner <=> *other.inner;
+    if (!inner && !other.inner)
+      return std::strong_ordering::equal;
+    return inner ? std::strong_ordering::greater : std::strong_ordering::less;
+  }
+
+  Kind kind;
+  std::string name;
+  uint64_t array_size = 0;
+  ParsedType *inner = nullptr;
+};
+
+using ExprOrType = std::variant<Expression, ParsedType *>;
+
+inline bool expr_or_type_equal(const ExprOrType &lhs, const ExprOrType &rhs)
+{
+  if (auto *const *p = std::get_if<ParsedType *>(&lhs)) {
+    auto *const *q = std::get_if<ParsedType *>(&rhs);
+    return q && *p && *q && **p == **q;
+  }
+  return lhs == rhs;
+}
+
+inline std::strong_ordering expr_or_type_compare(const ExprOrType &lhs,
+                                                 const ExprOrType &rhs)
+{
+  if (auto cmp = lhs.index() <=> rhs.index(); cmp != 0)
+    return cmp;
+  if (auto *const *p = std::get_if<ParsedType *>(&lhs)) {
+    auto *q = std::get<ParsedType *>(rhs);
+    if (*p && q)
+      return **p <=> *q;
+    if (!*p && !q)
+      return std::strong_ordering::equal;
+    return *p ? std::strong_ordering::greater : std::strong_ordering::less;
+  }
+  return std::get<Expression>(lhs) <=> std::get<Expression>(rhs);
+}
+
 class Sizeof : public Node {
 public:
-  explicit Sizeof(ASTContext &ctx, Location &&loc, SizedType type)
+  explicit Sizeof(ASTContext &ctx, Location &&loc, ParsedType *type)
       : Node(ctx, std::move(loc)), record(std::move(type)) {};
   explicit Sizeof(ASTContext &ctx, Location &&loc, Expression expr)
       : Node(ctx, std::move(loc)), record(expr) {};
@@ -536,35 +656,21 @@ public:
 
   bool operator==(const Sizeof &other) const
   {
-    if (record.index() != other.record.index())
-      return false;
-    return std::visit(
-        [&other](const auto &v) {
-          using T = std::decay_t<decltype(v)>;
-          return v == std::get<T>(other.record);
-        },
-        record);
+    return expr_or_type_equal(record, other.record);
   }
   std::strong_ordering operator<=>(const Sizeof &other) const
   {
-    if (auto cmp = record.index() <=> other.record.index(); cmp != 0)
-      return cmp;
-    return std::visit(
-        [&other](const auto &v) -> std::strong_ordering {
-          using T = std::decay_t<decltype(v)>;
-          return v <=> std::get<T>(other.record);
-        },
-        record);
+    return expr_or_type_compare(record, other.record);
   }
 
-  std::variant<Expression, SizedType> record;
+  ExprOrType record;
 };
 
 class Offsetof : public Node {
 public:
   explicit Offsetof(ASTContext &ctx,
                     Location &&loc,
-                    SizedType record,
+                    ParsedType *record,
                     std::vector<std::string> field)
       : Node(ctx, std::move(loc)),
         record(std::move(record)),
@@ -581,32 +687,16 @@ public:
 
   bool operator==(const Offsetof &other) const
   {
-    if (record.index() != other.record.index())
-      return false;
-    bool record_equal = std::visit(
-        [&other](const auto &v) {
-          using T = std::decay_t<decltype(v)>;
-          return v == std::get<T>(other.record);
-        },
-        record);
-    return record_equal && field == other.field;
+    return expr_or_type_equal(record, other.record) && field == other.field;
   }
   std::strong_ordering operator<=>(const Offsetof &other) const
   {
-    if (auto cmp = record.index() <=> other.record.index(); cmp != 0)
+    if (auto cmp = expr_or_type_compare(record, other.record); cmp != 0)
       return cmp;
-    auto record_cmp = std::visit(
-        [&other](const auto &v) -> std::strong_ordering {
-          using T = std::decay_t<decltype(v)>;
-          return v <=> std::get<T>(other.record);
-        },
-        record);
-    if (record_cmp != 0)
-      return record_cmp;
     return field <=> other.field;
   }
 
-  std::variant<Expression, SizedType> record;
+  ExprOrType record;
   std::vector<std::string> field;
 };
 
@@ -632,7 +722,7 @@ public:
 
 class Typeof : public Node {
 public:
-  explicit Typeof(ASTContext &ctx, Location &&loc, SizedType record)
+  explicit Typeof(ASTContext &ctx, Location &&loc, ParsedType *record)
       : Node(ctx, std::move(loc)), record(std::move(record)) {};
   explicit Typeof(ASTContext &ctx, Location &&loc, Expression expr)
       : Node(ctx, std::move(loc)), record(expr) {};
@@ -642,14 +732,14 @@ public:
 
   bool operator==(const Typeof &other) const
   {
-    return record == other.record;
+    return expr_or_type_equal(record, other.record);
   }
   std::strong_ordering operator<=>(const Typeof &other) const
   {
-    return record <=> other.record;
+    return expr_or_type_compare(record, other.record);
   }
 
-  std::variant<Expression, SizedType> record;
+  ExprOrType record;
 };
 
 class Typeinfo : public Node {

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ast/ast.h"
+#include "types.h"
 
 namespace bpftrace::ast {
 

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -108,22 +108,25 @@ public:
   template <NodeType T, typename... Args>
   T *make_node(const SourceLocation &loc, Args &&...args)
   {
-    // Occasionally, the parse default-constructs SourceLocation objects,
-    // which therefore do not reference the original source. We fix up this
-    // case and bound a location to the current from this context.
-    auto bound_loc = loc;
-    if (bound_loc.source_ == nullptr) {
-      bound_loc.source_ = source_;
-    }
-    auto loc_chain = std::make_shared<LocationChain>(std::move(bound_loc));
-    return make_node<T, Args...>(std::move(loc_chain),
-                                 std::forward<Args>(args)...);
+    return make_node<T, Args...>(location(loc), std::forward<Args>(args)...);
   }
 
   template <NodeType T, typename... Args>
   T *make_node(const Location &loc, Args... args)
   {
     return make_node<T, Args...>(Location(loc), std::forward<Args>(args)...);
+  }
+
+  Location location(const SourceLocation &loc)
+  {
+    // Occasionally, the parse default-constructs SourceLocation objects,
+    // which therefore do not reference the original source. We fix up this
+    // case and bind a location to the current source from this context.
+    auto bound_loc = loc;
+    if (bound_loc.source_ == nullptr) {
+      bound_loc.source_ = source_;
+    }
+    return std::make_shared<LocationChain>(std::move(bound_loc));
   }
 
   template <NodeType T>

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -40,7 +40,7 @@ public:
 
 private:
   void resolve_fields(SizedType &type);
-  void resolve_type(SizedType &type);
+  void resolve_type(const ParsedType &type);
 
   ProbeType probe_type_;
   std::string attach_func_;
@@ -173,8 +173,8 @@ void FieldAnalyser::visit(MapAccess &acc)
 
 void FieldAnalyser::visit(Sizeof &szof)
 {
-  if (std::holds_alternative<SizedType>(szof.record)) {
-    resolve_type(std::get<SizedType>(szof.record));
+  if (auto *const *type = std::get_if<ParsedType *>(&szof.record)) {
+    resolve_type(**type);
   } else {
     visit(szof.record);
   }
@@ -182,8 +182,8 @@ void FieldAnalyser::visit(Sizeof &szof)
 
 void FieldAnalyser::visit(Offsetof &offof)
 {
-  if (std::holds_alternative<SizedType>(offof.record)) {
-    resolve_type(std::get<SizedType>(offof.record));
+  if (auto *const *type = std::get_if<ParsedType *>(&offof.record)) {
+    resolve_type(**type);
   } else {
     visit(offof.record);
   }
@@ -191,8 +191,8 @@ void FieldAnalyser::visit(Offsetof &offof)
 
 void FieldAnalyser::visit(Typeof &typeof)
 {
-  if (std::holds_alternative<SizedType>(typeof.record)) {
-    resolve_type(std::get<SizedType>(typeof.record));
+  if (auto *const *type = std::get_if<ParsedType *>(&typeof.record)) {
+    resolve_type(**type);
   } else {
     visit(typeof.record);
   }
@@ -235,16 +235,19 @@ void FieldAnalyser::resolve_fields(SizedType &type)
     bpftrace_.btf_->resolve_fields(type);
 }
 
-void FieldAnalyser::resolve_type(SizedType &type)
+void FieldAnalyser::resolve_type(const ParsedType &type)
 {
   sized_type_ = CreateNone();
 
-  SizedType inner_type = type;
-  while (inner_type.IsPtrTy())
-    inner_type = inner_type.GetPointeeTy();
-  if (!inner_type.IsCStructTy())
+  const auto &base = type.base_type();
+  if (base.kind == ParsedType::Kind::Identifier &&
+      ident_to_builtin_type(base.name))
     return;
-  const auto &name = inner_type.GetName();
+  if (base.kind != ParsedType::Kind::Struct &&
+      base.kind != ParsedType::Kind::Union &&
+      base.kind != ParsedType::Kind::Identifier)
+    return;
+  const auto name = base.type_name();
 
   if (probe_) {
     for (auto &ap : probe_->attach_points)

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -144,7 +144,7 @@ public:
   void visit(Offsetof &offsetof_node);
   void visit(Typeof &typeof_node);
 
-  void visit_type_record(std::variant<Expression, SizedType> &record);
+  void visit_expr_or_type(ExprOrType &record);
 
   std::optional<BlockExpr *> expand(const Macro &macro, Call &call);
   std::optional<BlockExpr *> expand(const Macro &macro, Identifier &ident);
@@ -235,8 +235,7 @@ void MacroExpander::visit(Map &map)
 // offsetof). A bare identifier here is intended as a type name, not a macro
 // invocation. Use the call syntax (e.g. sizeof(mymacro())) or typeof wrapper
 // (e.g. (typeof(mymacro()))x) to force macro expansion in type contexts.
-void MacroExpander::visit_type_record(
-    std::variant<Expression, SizedType> &record)
+void MacroExpander::visit_expr_or_type(ExprOrType &record)
 {
   if (auto *expr = std::get_if<Expression>(&record)) {
     auto *ident = expr->as<Identifier>();
@@ -251,17 +250,17 @@ void MacroExpander::visit_type_record(
 
 void MacroExpander::visit(Sizeof &sizeof_node)
 {
-  visit_type_record(sizeof_node.record);
+  visit_expr_or_type(sizeof_node.record);
 }
 
 void MacroExpander::visit(Offsetof &offsetof_node)
 {
-  visit_type_record(offsetof_node.record);
+  visit_expr_or_type(offsetof_node.record);
 }
 
 void MacroExpander::visit(Typeof &typeof_node)
 {
-  visit_type_record(typeof_node.record);
+  visit_expr_or_type(typeof_node.record);
 }
 
 void MacroExpander::visit(Expression &expr)

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -495,8 +495,13 @@ Buffer Formatter::visit(Typeof& typeof)
   } else {
     // Prefer the simpler form for direct types.
     return format(
-        std::get<SizedType>(typeof.record), metadata, max_width, bare);
+        *std::get<ParsedType*>(typeof.record), metadata, max_width, bare);
   }
+}
+
+Buffer Formatter::visit(ParsedType& type)
+{
+  return visit(static_cast<const ParsedType&>(type));
 }
 
 Buffer Formatter::visit(Typeinfo& typeinfo)
@@ -1376,9 +1381,32 @@ Buffer Formatter::visit(NamedArgument& named_arg)
   return elem;
 }
 
-Buffer Formatter::visit(const SizedType& type)
+Buffer Formatter::visit(const ParsedType& type)
 {
-  return Buffer().text(typestr(type));
+  switch (type.kind) {
+    case ParsedType::Kind::Identifier:
+    case ParsedType::Kind::Struct:
+    case ParsedType::Kind::Union:
+    case ParsedType::Kind::Enum:
+      return Buffer().text(type.type_name());
+    case ParsedType::Kind::Pointer:
+      if (!type.inner) {
+        return {};
+      }
+      return format(*type.inner, metadata, max_width, bare).text("*");
+    case ParsedType::Kind::Array: {
+      if (!type.inner) {
+        return {};
+      }
+      auto buffer = format(*type.inner, metadata, max_width, bare).text("[");
+      if (type.array_size != 0) {
+        buffer = std::move(buffer).text(std::to_string(type.array_size));
+      }
+      return std::move(buffer).text("]");
+    }
+  }
+
+  return {};
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -72,6 +72,7 @@ public:
   Buffer visit(None &none);
   Buffer visit(Builtin &builtin);
   Buffer visit(Identifier &identifier);
+  Buffer visit(ParsedType &type);
   Buffer visit(Variable &var);
   Buffer visit(VariableAddr &var_addr);
   Buffer visit(SubprogArg &subprog_arg);
@@ -120,7 +121,7 @@ public:
   Buffer visit(RootStatement &root);
   Buffer visit(CStatement &cstmt);
   Buffer visit(NamedArgument& named_arg);
-  Buffer visit(const SizedType &type);
+  Buffer visit(const ParsedType &type);
 
 private:
   template <typename U>

--- a/src/ast/passes/types/ast_transformer.cpp
+++ b/src/ast/passes/types/ast_transformer.cpp
@@ -138,7 +138,10 @@ std::optional<Expression> AstTransformer::visit(Binop &binop)
       binop.loc,
       updated_rht == updated_lht ? "memcmp" : "memcmp_record",
       ExpressionList{ binop.left, binop.right, size });
-  auto *typeof_node = ast_.make_node<Typeof>(binop.loc, CreateBool());
+  auto *parsed_type = ast_.make_node<ParsedType>(binop.loc,
+                                                 ParsedType::Kind::Identifier,
+                                                 "bool");
+  auto *typeof_node = ast_.make_node<Typeof>(binop.loc, parsed_type);
   auto *cast = ast_.make_node<Cast>(binop.loc, typeof_node, call);
   if (binop.op == Operator::NE) {
     return cast;
@@ -192,8 +195,8 @@ std::optional<Expression> AstTransformer::visit(FieldAccess &acc)
 std::optional<Expression> AstTransformer::visit(Offsetof &offof)
 {
   SizedType cstruct;
-  if (std::holds_alternative<SizedType>(offof.record)) {
-    cstruct = std::get<SizedType>(offof.record);
+  if (std::holds_alternative<ParsedType *>(offof.record)) {
+    cstruct = get_type(std::get<ParsedType *>(offof.record));
   } else {
     cstruct = get_type(&std::get<Expression>(offof.record).node());
   }
@@ -218,8 +221,8 @@ std::optional<Expression> AstTransformer::visit(Offsetof &offof)
 std::optional<Expression> AstTransformer::visit(Sizeof &szof)
 {
   size_t size = 0;
-  if (std::holds_alternative<SizedType>(szof.record)) {
-    auto &ty = std::get<SizedType>(szof.record);
+  if (std::holds_alternative<ParsedType *>(szof.record)) {
+    const auto &ty = get_type(std::get<ParsedType *>(szof.record));
     if (ty.IsNoneTy()) {
       return std::nullopt;
     }

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -162,7 +162,9 @@ static std::optional<SizedType> try_int_cast(ASTContext &ctx,
     return std::nullopt;
   }
 
-  auto *typeof_r = ctx.make_node<Typeof>(Location(exp.loc()), target_type);
+  auto *typeof_r = ctx.make_node<Typeof>(
+      Location(exp.loc()),
+      sized_type_to_parsed_type(ctx, Location(exp.loc()), target_type));
   exp = ctx.make_node<Cast>(Location(exp.loc()),
                             typeof_r,
                             clone(ctx, exp.loc(), exp));
@@ -183,7 +185,9 @@ static std::optional<SizedType> try_string_cast(ASTContext &ctx,
     return std::nullopt;
   }
 
-  auto *typeof_r = ctx.make_node<Typeof>(Location(exp.loc()), target_type);
+  auto *typeof_r = ctx.make_node<Typeof>(
+      Location(exp.loc()),
+      sized_type_to_parsed_type(ctx, Location(exp.loc()), target_type));
   exp = ctx.make_node<Cast>(Location(exp.loc()),
                             typeof_r,
                             clone(ctx, exp.loc(), exp));
@@ -221,7 +225,9 @@ static std::optional<SizedType> try_expression_cast(
   } else if (target_type.IsRecordTy()) {
     return try_record_cast(ctx, expr, expr_type, target_type);
   } else if (target_type.IsPtrTy()) {
-    auto *typeof_r = ctx.make_node<Typeof>(Location(expr.loc()), target_type);
+    auto *typeof_r = ctx.make_node<Typeof>(
+        Location(expr.loc()),
+        sized_type_to_parsed_type(ctx, Location(expr.loc()), target_type));
     expr = ctx.make_node<Cast>(Location(expr.loc()),
                                typeof_r,
                                clone(ctx, expr.loc(), expr));
@@ -376,7 +382,10 @@ void CastCreator::visit(Call &call)
       auto arg_type = type_map_.type(call.vargs.at(1));
       if (arg_type != CreateUInt32() && arg_type.IsIntegerTy()) {
         auto *typeof_c = ctx_.make_node<Typeof>(
-            Location(call.vargs.at(1).loc()), CreateUInt32());
+            Location(call.vargs.at(1).loc()),
+            sized_type_to_parsed_type(ctx_,
+                                      Location(call.vargs.at(1).loc()),
+                                      CreateUInt32()));
         call.vargs.at(1) = ctx_.make_node<Cast>(
             Location(call.vargs.at(1).loc()),
             typeof_c,

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -932,8 +932,8 @@ void TypeChecker::visit(Cast &cast)
   visit(cast.expr);
   visit(cast.typeof);
 
-  const auto &resolved_ty = type_map_.type(&cast);
-  if (resolved_ty.IsNoneTy()) {
+  const auto &ty = type_map_.type(&cast);
+  if (ty.IsNoneTy()) {
     cast.addError() << "Incomplete cast, unknown type";
     return;
   }
@@ -946,10 +946,6 @@ void TypeChecker::visit(Cast &cast)
     cast.addError() << "Cannot cast from \"" << rhs << "\" type";
     return;
   }
-
-  // Resolved the type because we may mutate it below, for various reasons.
-  cast.typeof->record = resolved_ty;
-  auto &ty = std::get<SizedType>(cast.typeof->record);
 
   auto logError = [&]() {
     cast.addError() << "Cannot cast from \"" << rhs << "\" to \"" << ty << "\"";

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -381,7 +381,8 @@ private:
     return it->second;
   }
 
-  bool resolve_struct_type(SizedType &type, Node &node);
+  std::optional<SizedType> resolve_parsed_type(ParsedType *type, Node &node);
+  bool resolve_external_type(SizedType &type, Node &node);
   bool check_offsetof_type(Offsetof &offof, SizedType cstruct);
 
   SizedType get_var_type(const ScopedVariable &scoped_var,
@@ -1414,16 +1415,17 @@ void TypeRuleCollector::visit(Cast &cast)
       },
   });
 
-  if (std::holds_alternative<SizedType>(cast.typeof->record)) {
-    auto &ty = std::get<SizedType>(cast.typeof->record);
-    if (!resolve_struct_type(ty, *cast.typeof)) {
+  if (std::holds_alternative<ParsedType *>(cast.typeof->record)) {
+    auto ty = resolve_parsed_type(std::get<ParsedType *>(cast.typeof->record),
+                                  *cast.typeof);
+    if (!ty) {
       return;
     }
     const auto &expr_ty = resolver_.get_type(&cast.expr.node());
     if (!expr_ty.IsNoneTy()) {
-      ty = update_cast_expr(ty, expr_ty, probe);
+      *ty = update_cast_expr(*ty, expr_ty, probe);
     }
-    resolver_.set_type(&cast, ty);
+    resolver_.set_type(&cast, *ty);
   } else {
     visit(cast.typeof);
     resolver_.add_type_rule({
@@ -1888,10 +1890,9 @@ void TypeRuleCollector::visit(Offsetof &offof)
 {
   // This type will change later depending on what integer literal it resolves
   // to in AstTransformer but for now set it to the smallest uint
-  if (std::holds_alternative<SizedType>(offof.record)) {
-    auto &ty = std::get<SizedType>(offof.record);
-    resolve_struct_type(ty, offof);
-    if (!check_offsetof_type(offof, ty)) {
+  if (std::holds_alternative<ParsedType *>(offof.record)) {
+    auto ty = resolve_parsed_type(std::get<ParsedType *>(offof.record), offof);
+    if (!ty || !check_offsetof_type(offof, *ty)) {
       return;
     }
     resolver_.set_type(&offof, CreateUInt8());
@@ -1906,7 +1907,7 @@ void TypeRuleCollector::visit(Offsetof &offof)
         .resolve = [this,
                     &offof](const std::vector<SizedType> &inputs) -> SizedType {
           auto local_type = inputs[0];
-          resolve_struct_type(local_type, offof);
+          resolve_external_type(local_type, offof);
           if (!check_offsetof_type(offof, local_type)) {
             return CreateNone();
           }
@@ -1950,9 +1951,11 @@ void TypeRuleCollector::visit(Sizeof &szof)
 {
   // This type will change later depending on what integer literal it resolves
   // to for now set it to the smallest uint
-  if (std::holds_alternative<SizedType>(szof.record)) {
-    auto &ty = std::get<SizedType>(szof.record);
-    resolve_struct_type(ty, szof);
+  if (std::holds_alternative<ParsedType *>(szof.record)) {
+    auto ty = resolve_parsed_type(std::get<ParsedType *>(szof.record), szof);
+    if (!ty) {
+      return;
+    }
     resolver_.set_type(&szof, CreateUInt8());
   } else {
     auto &expr = std::get<Expression>(szof.record);
@@ -1988,12 +1991,13 @@ void TypeRuleCollector::visit(Subprog &subprog)
   for (SubprogArg *arg : subprog.args) {
     ScopedVariable scoped_var = std::make_pair(&subprog, arg->var->ident);
 
-    if (std::holds_alternative<SizedType>(arg->typeof->record)) {
-      auto &ty = std::get<SizedType>(arg->typeof->record);
-      if (resolve_struct_type(ty, *arg->typeof)) {
-        resolver_.set_type(scoped_var, ty);
-        resolver_.set_type(arg->typeof, ty);
-        if (ty.GetSize() != 0) {
+    if (std::holds_alternative<ParsedType *>(arg->typeof->record)) {
+      auto ty = resolve_parsed_type(std::get<ParsedType *>(arg->typeof->record),
+                                    *arg->typeof);
+      if (ty) {
+        resolver_.set_type(scoped_var, *ty);
+        resolver_.set_type(arg->typeof, *ty);
+        if (ty->GetSize() != 0) {
           sized_decl_vars_.insert(scoped_var);
         }
       }
@@ -2014,10 +2018,12 @@ void TypeRuleCollector::visit(Subprog &subprog)
 
 void TypeRuleCollector::visit(Typeof &typeof)
 {
-  if (std::holds_alternative<SizedType>(typeof.record)) {
-    auto &ty = std::get<SizedType>(typeof.record);
-    resolve_struct_type(ty, typeof);
-    resolver_.set_type(&typeof, ty);
+  if (std::holds_alternative<ParsedType *>(typeof.record)) {
+    auto ty = resolve_parsed_type(std::get<ParsedType *>(typeof.record),
+                                  typeof);
+    if (ty) {
+      resolver_.set_type(&typeof, *ty);
+    }
   } else {
     auto &expr = std::get<Expression>(typeof.record);
     ++introspection_level_;
@@ -2275,16 +2281,17 @@ void TypeRuleCollector::visit(VarDeclStatement &decl)
   auto *scope = scope_stack_.back();
   ScopedVariable scoped_var = std::make_pair(scope, decl.var->ident);
 
-  if (std::holds_alternative<SizedType>(decl.typeof->record)) {
-    auto &ty = std::get<SizedType>(decl.typeof->record);
-    if (!resolve_struct_type(ty, *decl.typeof)) {
+  if (std::holds_alternative<ParsedType *>(decl.typeof->record)) {
+    auto ty = resolve_parsed_type(std::get<ParsedType *>(decl.typeof->record),
+                                  *decl.typeof);
+    if (!ty) {
       return;
     }
-    resolver_.set_type(scoped_var, ty);
-    resolver_.set_type(decl.typeof, ty);
+    resolver_.set_type(scoped_var, *ty);
+    resolver_.set_type(decl.typeof, *ty);
     // Some declared types like 'string' have no size so we can factor in the
     // size of the assignment
-    if (ty.GetSize() != 0) {
+    if (ty->GetSize() != 0) {
       sized_decl_vars_.insert(scoped_var);
     }
   } else {
@@ -2326,46 +2333,62 @@ void TypeRuleCollector::visit(VariableAddr &var_addr)
   });
 }
 
-bool TypeRuleCollector::resolve_struct_type(SizedType &type, Node &node)
+std::optional<SizedType> TypeRuleCollector::resolve_parsed_type(
+    ParsedType *type,
+    Node &node)
 {
-  SizedType inner_type = type;
-  int pointer_level = 0;
-  while (inner_type.IsPtrTy()) {
-    inner_type = inner_type.GetPointeeTy();
-    pointer_level++;
+  if (!type) {
+    return std::nullopt;
   }
 
-  bool is_array = false;
-  size_t num_elements = 0;
-  if (inner_type.IsArrayTy()) {
-    num_elements = inner_type.GetNumElements();
-    inner_type = inner_type.GetElementTy();
-    is_array = true;
+  auto sized_type = parsed_type_to_sized_type(*type);
+  // N.B. Only certain SizedTypes might need additional external resolution,
+  // e.g. structs, typedefs, etc.
+  if (!resolve_external_type(sized_type, node)) {
+    return std::nullopt;
+  }
+  resolver_.set_type(type, sized_type);
+  return sized_type;
+}
+
+bool TypeRuleCollector::resolve_external_type(SizedType &type, Node &node)
+{
+  if (type.IsPtrTy()) {
+    auto inner = type.GetPointeeTy();
+    if (!resolve_external_type(inner, node)) {
+      return false;
+    }
+    type = CreatePointer(inner);
+    return true;
   }
 
-  if (inner_type.IsCStructTy() && !inner_type.GetStruct()) {
-    auto struct_type = bpftrace_.structs.Lookup(inner_type.GetName()).lock();
-    if (!struct_type) {
-      // Try to find the type as something other than a struct, e.g. 'char' or
-      // 'uint64_t'
-      auto stype = bpftrace_.btf_->get_stype(inner_type.GetName());
-      if (stype.IsNoneTy()) {
-        node.addError() << "Cannot resolve unknown type \""
-                        << inner_type.GetName() << "\"\n";
-        return false;
-      } else {
-        type = stype;
-      }
-    } else {
-      type = CreateCStruct(inner_type.GetName(), struct_type);
+  if (type.IsArrayTy()) {
+    auto num_elements = type.GetNumElements();
+    auto inner = type.GetElementTy();
+    if (!resolve_external_type(inner, node)) {
+      return false;
     }
-    if (is_array) {
-      type = CreateArray(num_elements, type);
+    type = CreateArray(num_elements, inner);
+    return true;
+  }
+
+  if (type.IsCStructTy() && !type.GetStruct()) {
+    auto struct_type = bpftrace_.structs.Lookup(type.GetName()).lock();
+    if (struct_type) {
+      type = CreateCStruct(type.GetName(), struct_type);
+      return true;
     }
-    while (pointer_level > 0) {
-      type = CreatePointer(type);
-      pointer_level--;
+
+    // Try to find the type as something other than a struct, e.g. 'char' or
+    // 'uint64_t'
+    auto stype = bpftrace_.btf_->get_stype(type.GetName());
+    if (stype.IsNoneTy()) {
+      node.addError() << "Cannot resolve unknown type \"" << type.GetName()
+                      << "\"\n";
+      return false;
     }
+
+    type = stype;
   }
   return true;
 }

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -57,6 +57,10 @@ public:
   {
     return default_value();
   }
+  R visit([[maybe_unused]] ParsedType &type)
+  {
+    return default_value();
+  }
   R visit([[maybe_unused]] Variable &var)
   {
     return default_value();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -8,6 +8,7 @@
 #include <unordered_set>
 
 #include "log.h"
+#include "types.h"
 #include "util/int_parser.h"
 
 // clang-format off
@@ -573,7 +574,7 @@ Subprog *Parser::parse_subprog()
       if (!expect(':')) {
         break;
       }
-      auto *type = parse_type_annotation();
+      auto *type = parse_type_annotation(true);
       if (!type) {
         break;
       }
@@ -592,7 +593,7 @@ Subprog *Parser::parse_subprog()
     return nullptr;
   }
 
-  auto *return_type = parse_type_annotation();
+  auto *return_type = parse_type_annotation(true);
   if (!return_type) {
     return nullptr;
   }
@@ -1419,7 +1420,7 @@ Statement Parser::parse_statement()
     consume_layout();
     if (peek() == ':') {
       advance();
-      type_annotation = parse_type_annotation();
+      type_annotation = parse_type_annotation(true);
     }
 
     consume_layout();
@@ -1485,31 +1486,48 @@ Statement Parser::parse_statement()
 
 // Type parsing
 
-SizedType Parser::parse_sized_type()
+ParsedType *Parser::parse_type(bool emit_error)
 {
-  auto name = consume_identifier("expected type name");
+  auto [begin_line, begin_col] = get_current_line_col();
+  auto name = emit_error ? consume_identifier("expected type name")
+                         : consume_identifier();
   if (!name) {
-    return CreateNone();
+    return nullptr;
   }
 
-  std::string type_ident = *name;
+  ParsedType *type = nullptr;
   if (*name == "struct" || *name == "union" || *name == "enum") {
-    auto type_name = consume_identifier("expected identifier");
+    auto type_name = emit_error ? consume_identifier("expected identifier")
+                                : consume_identifier();
     if (!type_name) {
-      return CreateNone();
+      return nullptr;
     }
-    type_ident += " " + *type_name;
+    auto kind = ParsedType::Kind::Struct;
+    if (*name == "union") {
+      kind = ParsedType::Kind::Union;
+    } else if (*name == "enum") {
+      kind = ParsedType::Kind::Enum;
+    }
+    type = ctx_.make_node<ParsedType>(
+        make_loc(begin_line, begin_col, line_, col_), kind, *type_name);
+  } else {
+    type = ctx_.make_node<ParsedType>(
+        make_loc(begin_line, begin_col, line_, col_),
+        ParsedType::Kind::Identifier,
+        *name);
   }
-  SizedType stype = compound_ident_to_type(type_ident);
 
   // Pointer and array suffixes in any order.
   consume_layout();
   while (peek() == '*' || peek() == '[') {
     if (peek() == '*') {
+      auto [pointer_line, pointer_col] = get_current_line_col();
       advance();
-      stype = CreatePointer(stype);
+      type = ctx_.make_node<ParsedType>(
+          make_loc(pointer_line, pointer_col, line_, col_), type);
       consume_layout();
     } else {
+      auto [array_line, array_col] = get_current_line_col();
       advance();
       consume_layout();
       uint64_t size = 0;
@@ -1519,12 +1537,13 @@ SizedType Parser::parse_sized_type()
         size = res ? *res : 0;
       }
       expect(']');
-      stype = CreateArray(size, stype);
+      type = ctx_.make_node<ParsedType>(
+          make_loc(array_line, array_col, line_, col_), size, type);
       consume_layout();
     }
   }
 
-  return stype;
+  return type;
 }
 
 std::optional<size_t> Parser::scan_type_suffixes(size_t pos,
@@ -1555,7 +1574,7 @@ std::optional<size_t> Parser::scan_type_suffixes(size_t pos,
   return pos;
 }
 
-std::optional<std::variant<Expression, SizedType>> Parser::
+std::optional<std::variant<Expression, ParsedType *>> Parser::
     try_parse_type_reference(std::string_view end_chars)
 {
   auto sp = save_point();
@@ -1580,7 +1599,7 @@ std::optional<std::variant<Expression, SizedType>> Parser::
     return next != '\0' && end_chars.find(next) != std::string_view::npos;
   };
 
-  bool is_known_type = false;
+  bool is_unknown_typedef = true;
   if (ident == "struct" || ident == "union" || ident == "enum") {
     lookahead = scan_layout(lookahead);
     if (!is_identifier_start(char_at(lookahead))) {
@@ -1588,9 +1607,9 @@ std::optional<std::variant<Expression, SizedType>> Parser::
       return std::nullopt;
     }
     lookahead = scan_identifier_end(lookahead);
-    is_known_type = true;
-  } else if (ident_to_type(std::string(ident)).has_value()) {
-    is_known_type = true;
+    is_unknown_typedef = false;
+  } else if (ident_to_builtin_type(std::string(ident)).has_value()) {
+    is_unknown_typedef = false;
   }
 
   bool saw_suffix = false;
@@ -1599,10 +1618,10 @@ std::optional<std::variant<Expression, SizedType>> Parser::
     sp.restore();
     return std::nullopt;
   }
-  bool parse_as_sized_type = is_known_type || saw_suffix;
+  bool parse_as_type = !is_unknown_typedef || saw_suffix;
 
-  if (parse_as_sized_type) {
-    return parse_sized_type();
+  if (parse_as_type) {
+    return parse_type();
   }
 
   auto [begin_line, begin_col] = get_current_line_col();
@@ -1616,7 +1635,7 @@ std::optional<std::variant<Expression, SizedType>> Parser::
   return Expression(id);
 }
 
-Typeof *Parser::parse_type_annotation()
+Typeof *Parser::parse_type_annotation(bool type_only)
 {
   consume_layout();
   auto [begin_line, begin_col] = get_current_line_col();
@@ -1630,9 +1649,8 @@ Typeof *Parser::parse_type_annotation()
     if (auto type_ref = try_parse_type_reference(")")) {
       expect(')');
       auto loc = make_loc(begin_line, begin_col, line_, col_);
-      if (auto *stype = std::get_if<SizedType>(&*type_ref)) {
-        return ctx_.make_node<Typeof>(loc,
-                                      normalize_array_to_sized_type(*stype));
+      if (auto *type = std::get_if<ParsedType *>(&*type_ref)) {
+        return ctx_.make_node<Typeof>(loc, *type);
       }
       return ctx_.make_node<Typeof>(loc,
                                     std::move(std::get<Expression>(*type_ref)));
@@ -1643,10 +1661,19 @@ Typeof *Parser::parse_type_annotation()
     return ctx_.make_node<Typeof>(loc, std::move(expr));
   }
 
+  if (type_only) {
+    auto *type = parse_type();
+    if (!type) {
+      return nullptr;
+    }
+    auto loc = make_loc(begin_line, begin_col, line_, col_);
+    return ctx_.make_node<Typeof>(loc, type);
+  }
+
   if (auto type_ref = try_parse_type_reference(";,=){}")) {
     auto loc = make_loc(begin_line, begin_col, line_, col_);
-    if (auto *stype = std::get_if<SizedType>(&*type_ref)) {
-      return ctx_.make_node<Typeof>(loc, normalize_array_to_sized_type(*stype));
+    if (auto *type = std::get_if<ParsedType *>(&*type_ref)) {
+      return ctx_.make_node<Typeof>(loc, *type);
     }
     return ctx_.make_node<Typeof>(loc,
                                   std::move(std::get<Expression>(*type_ref)));
@@ -2133,9 +2160,8 @@ Expression Parser::parse_primary()
     if (auto type_ref = try_parse_type_reference(")")) {
       expect(')');
       auto loc = make_loc(begin_line, begin_col, line_, col_);
-      if (auto *stype = std::get_if<SizedType>(&*type_ref)) {
-        auto *s = ctx_.make_node<Sizeof>(loc,
-                                         normalize_array_to_sized_type(*stype));
+      if (auto *type = std::get_if<ParsedType *>(&*type_ref)) {
+        auto *s = ctx_.make_node<Sizeof>(loc, *type);
         return { s };
       }
       auto *s = ctx_.make_node<Sizeof>(
@@ -2162,14 +2188,12 @@ Expression Parser::parse_primary()
     sp.restore();
 
     if (is_struct_type) {
-      auto stype = parse_sized_type();
+      auto *type = parse_type();
       expect(',');
       auto fields = parse_field_access();
       expect(')');
       auto loc = make_loc(begin_line, begin_col, line_, col_);
-      auto *o = ctx_.make_node<Offsetof>(loc,
-                                         normalize_array_to_sized_type(stype),
-                                         std::move(fields));
+      auto *o = ctx_.make_node<Offsetof>(loc, type, std::move(fields));
       return { o };
     }
     // Expression form: offsetof(expr, field)
@@ -2428,23 +2452,35 @@ std::optional<Expression> Parser::try_parse_cast_expr(int begin_line,
     typeof_node = parse_type_annotation();
   } else {
     consume_layout();
+    if (!is_identifier_start(peek())) {
+      sp.restore();
+      return std::nullopt;
+    }
+    size_t lookahead = pos_;
+    const size_t ident_start = lookahead;
+    lookahead = scan_identifier_end(lookahead);
+    if (is_builtin(view(ident_start, lookahead))) {
+      sp.restore();
+      return std::nullopt;
+    }
     auto [type_begin_line, type_begin_col] = get_current_line_col();
-    if (auto type_ref = try_parse_type_reference(")")) {
+    if (auto *type = parse_type(false)) {
       auto loc = make_loc(type_begin_line, type_begin_col, line_, col_);
-      if (auto *stype = std::get_if<SizedType>(&*type_ref)) {
-        typeof_node = ctx_.make_node<Typeof>(
-            loc, normalize_array_to_sized_type(*stype));
-      } else {
-        typeof_node = ctx_.make_node<Typeof>(
-            loc, std::move(std::get<Expression>(*type_ref)));
-      }
+      typeof_node = ctx_.make_node<Typeof>(loc, type);
     } else {
       sp.restore();
       return std::nullopt;
     }
   }
 
-  if (!expect(')') || !can_start_expression()) {
+  consume_layout();
+  if (peek() != ')') {
+    sp.restore();
+    return std::nullopt;
+  }
+  advance();
+  consume_layout();
+  if (!can_start_expression()) {
     sp.restore();
     return std::nullopt;
   }

--- a/src/parser.h
+++ b/src/parser.h
@@ -60,10 +60,10 @@ private:
   ast::Statement parse_statement();
 
   // Type parsing
-  SizedType parse_sized_type();
-  ast::Typeof *parse_type_annotation();
+  ast::ParsedType *parse_type(bool emit_error = true);
+  ast::Typeof *parse_type_annotation(bool type_only = false);
   std::optional<size_t> scan_type_suffixes(size_t pos, bool &saw_suffix) const;
-  std::optional<std::variant<ast::Expression, SizedType>> try_parse_type_reference(
+  std::optional<std::variant<ast::Expression, ast::ParsedType *>> try_parse_type_reference(
       std::string_view end_chars);
 
   // Expression grammar

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2,12 +2,16 @@
 #include <iostream>
 #include <sstream>
 
+#include "ast/ast.h"
 #include "ast/async_event_types.h"
 #include "struct.h"
 #include "types.h"
 #include "util/exceptions.h"
 
 namespace bpftrace {
+
+static constexpr std::string_view STRUCT_PREFIX = "struct ";
+static constexpr std::string_view UNION_PREFIX = "union ";
 
 std::ostream &operator<<(std::ostream &os, Type type)
 {
@@ -601,10 +605,9 @@ SizedType CreateTimestampMode()
   return { Type::timestamp_mode, 0 };
 }
 
-std::optional<SizedType> ident_to_type(const std::string &name)
+std::optional<SizedType> ident_to_builtin_type(const std::string &name)
 {
   static const std::unordered_map<std::string, SizedType> types = {
-    // Integer types
     { "bool", CreateBool() },
     { "int8", CreateInt(8) },
     { "int16", CreateInt(16) },
@@ -614,7 +617,6 @@ std::optional<SizedType> ident_to_type(const std::string &name)
     { "uint16", CreateUInt(16) },
     { "uint32", CreateUInt(32) },
     { "uint64", CreateUInt(64) },
-    // Builtin types
     { "void", CreateVoid() },
     { "min_t", CreateMin(true) },
     { "max_t", CreateMax(true) },
@@ -639,26 +641,6 @@ std::optional<SizedType> ident_to_type(const std::string &name)
   if (it != types.end())
     return it->second;
   return std::nullopt;
-}
-
-SizedType compound_ident_to_type(const std::string &ident)
-{
-  auto known = ident_to_type(ident);
-  if (known) {
-    return *known;
-  }
-  static constexpr std::string_view ENUM = "enum ";
-  if (ident.starts_with(ENUM)) {
-    auto enum_name = ident.substr(ENUM.size());
-    // This is an automatic promotion to a uint64
-    // even though it's possible that highest variant value of that enum
-    // fits into a smaller int. This will also affect casts from a smaller
-    // int and cause an ERROR: Integer size mismatch.
-    // This could potentially be revisited or the cast relaxed
-    // if we check the variant values during type resolution.
-    return CreateEnum(64, enum_name);
-  }
-  return CreateCStruct(ident);
 }
 
 SizedType normalize_array_to_sized_type(SizedType type)
@@ -980,6 +962,84 @@ std::ostream &operator<<(std::ostream &os, TSeriesAggFunc agg)
   }
 
   return os;
+}
+
+SizedType parsed_type_to_sized_type(const ast::ParsedType &type)
+{
+  switch (type.kind) {
+    case ast::ParsedType::Kind::Identifier:
+      if (auto bt = ident_to_builtin_type(type.name)) {
+        return *bt;
+      }
+      return CreateCStruct(type.name);
+    case ast::ParsedType::Kind::Struct:
+    case ast::ParsedType::Kind::Union:
+      return CreateCStruct(type.type_name());
+    case ast::ParsedType::Kind::Enum:
+      return CreateEnum(64, type.name);
+    case ast::ParsedType::Kind::Pointer: {
+      assert(type.inner);
+      return CreatePointer(parsed_type_to_sized_type(*type.inner));
+    }
+    case ast::ParsedType::Kind::Array: {
+      assert(type.inner);
+      return normalize_array_to_sized_type(
+          CreateArray(type.array_size, parsed_type_to_sized_type(*type.inner)));
+    }
+  }
+
+  return CreateNone();
+}
+
+ast::ParsedType *sized_type_to_parsed_type(ast::ASTContext &ctx,
+                                           const ast::Location &loc,
+                                           const SizedType &type)
+{
+  if (type.IsPtrTy()) {
+    auto *pointee = sized_type_to_parsed_type(ctx, loc, type.GetPointeeTy());
+    return ctx.make_node<ast::ParsedType>(loc, pointee);
+  }
+
+  if (type.IsArrayTy()) {
+    auto *element = sized_type_to_parsed_type(ctx, loc, type.GetElementTy());
+    return ctx.make_node<ast::ParsedType>(loc, type.GetNumElements(), element);
+  }
+
+  if (type.IsStringTy() || type.IsBufferTy() || type.IsInetTy()) {
+    auto *base = ctx.make_node<ast::ParsedType>(
+        loc, ast::ParsedType::Kind::Identifier, typestr(type.GetTy()));
+    if (type.GetSize() == 0) {
+      return base;
+    }
+    return ctx.make_node<ast::ParsedType>(loc, type.GetSize(), base);
+  }
+
+  if (type.IsEnumTy()) {
+    return ctx.make_node<ast::ParsedType>(loc,
+                                          ast::ParsedType::Kind::Enum,
+                                          type.GetName());
+  }
+
+  if (type.IsCStructTy()) {
+    const auto &name = type.GetName();
+    if (name.starts_with(STRUCT_PREFIX)) {
+      return ctx.make_node<ast::ParsedType>(loc,
+                                            ast::ParsedType::Kind::Struct,
+                                            name.substr(STRUCT_PREFIX.size()));
+    }
+    if (name.starts_with(UNION_PREFIX)) {
+      return ctx.make_node<ast::ParsedType>(loc,
+                                            ast::ParsedType::Kind::Union,
+                                            name.substr(UNION_PREFIX.size()));
+    }
+    return ctx.make_node<ast::ParsedType>(loc,
+                                          ast::ParsedType::Kind::Identifier,
+                                          name);
+  }
+
+  return ctx.make_node<ast::ParsedType>(loc,
+                                        ast::ParsedType::Kind::Identifier,
+                                        typestr(type));
 }
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -610,14 +610,25 @@ SizedType CreateTimestampMode();
 
 // Converts a type name string (e.g. "uint32", "string") to the corresponding
 // SizedType, or std::nullopt if the name is not a known type.
-std::optional<SizedType> ident_to_type(const std::string &name);
-SizedType compound_ident_to_type(const std::string &ident);
+std::optional<SizedType> ident_to_builtin_type(const std::string &name);
 
 // Normalize Array(N, SizedBaseType) into the appropriate sized type.
 // For example, Array(64, String(0)) becomes String(64). This allows the
 // parser to treat all [N] suffixes uniformly as arrays, deferring the
 // sized-type interpretation to a later stage.
 SizedType normalize_array_to_sized_type(SizedType type);
+
+namespace ast {
+class ASTContext;
+class LocationChain;
+using Location = std::shared_ptr<LocationChain>;
+class ParsedType;
+} // namespace ast
+
+SizedType parsed_type_to_sized_type(const ast::ParsedType &type);
+ast::ParsedType *sized_type_to_parsed_type(ast::ASTContext &ctx,
+                                           const ast::Location &loc,
+                                           const SizedType &type);
 
 std::optional<SizedType> get_promoted_int(const SizedType &currentType,
                                           const SizedType &newType);

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -6,7 +6,6 @@
 #include "ast/clone.h"
 #include "ast/context.h"
 #include "ast/location.h"
-#include "types.h"
 
 namespace bpftrace::test::ast {
 
@@ -137,13 +136,38 @@ std::vector<Call *> variants<Call>(ASTContext &c, SourceLocation l)
 }
 
 template <>
+std::vector<ParsedType *> variants<ParsedType>(ASTContext &c, SourceLocation l)
+{
+  auto *inner_id = c.make_node<ParsedType>(l,
+                                           ParsedType::Kind::Identifier,
+                                           "int32");
+  auto *inner_struct = c.make_node<ParsedType>(l,
+                                               ParsedType::Kind::Struct,
+                                               "task_struct");
+  return {
+    c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint64"),
+    c.make_node<ParsedType>(l, ParsedType::Kind::Struct, "task_struct"),
+    c.make_node<ParsedType>(l, ParsedType::Kind::Union, "my_union"),
+    c.make_node<ParsedType>(l, ParsedType::Kind::Enum, "my_enum"),
+    c.make_node<ParsedType>(l, inner_id),
+    c.make_node<ParsedType>(l, inner_struct),
+    c.make_node<ParsedType>(l, static_cast<uint64_t>(10), inner_id),
+  };
+}
+
+template <>
 std::vector<Sizeof *> variants<Sizeof>(ASTContext &c, SourceLocation l)
 {
   Expression expr = c.make_node<Integer>(l, 42UL);
-  return { c.make_node<Sizeof>(l, CreateInt32()),
-           c.make_node<Sizeof>(l, CreateInt64()),
-           c.make_node<Sizeof>(l, CreateUInt32()),
-           c.make_node<Sizeof>(l, std::move(expr)) };
+  return {
+    c.make_node<Sizeof>(
+        l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32")),
+    c.make_node<Sizeof>(
+        l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int64")),
+    c.make_node<Sizeof>(
+        l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32")),
+    c.make_node<Sizeof>(l, std::move(expr))
+  };
 }
 
 template <>
@@ -155,10 +179,21 @@ std::vector<Offsetof *> variants<Offsetof>(ASTContext &c, SourceLocation l)
   Expression expr = c.make_node<Variable>(l, std::string("$var"));
   std::vector<std::string> field4 = { "member" };
 
-  return { c.make_node<Offsetof>(l, CreateInteger(32, false), field1),
-           c.make_node<Offsetof>(l, CreateInteger(64, false), field2),
-           c.make_node<Offsetof>(l, CreateString(64), field3),
-           c.make_node<Offsetof>(l, std::move(expr), field4) };
+  auto *string = c.make_node<ParsedType>(l,
+                                         ParsedType::Kind::Identifier,
+                                         "string");
+  return {
+    c.make_node<Offsetof>(
+        l,
+        c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32"),
+        field1),
+    c.make_node<Offsetof>(
+        l,
+        c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint64"),
+        field2),
+    c.make_node<Offsetof>(l, c.make_node<ParsedType>(l, 64, string), field3),
+    c.make_node<Offsetof>(l, std::move(expr), field4)
+  };
 }
 
 template <>
@@ -299,16 +334,20 @@ std::vector<MapAccess *> variants<MapAccess>(ASTContext &c, SourceLocation l)
 template <>
 std::vector<Cast *> variants<Cast>(ASTContext &c, SourceLocation l)
 {
-  auto *typeof1 = c.make_node<Typeof>(l, CreateInt32());
+  auto *typeof1 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32"));
   Expression expr1 = c.make_node<Integer>(l, 42UL);
 
-  auto *typeof2 = c.make_node<Typeof>(l, CreateInt64());
+  auto *typeof2 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int64"));
   Expression expr2 = c.make_node<Integer>(l, 24UL);
 
-  auto *typeof3 = c.make_node<Typeof>(l, CreateInt32());
+  auto *typeof3 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32"));
   Expression expr3 = c.make_node<Variable>(l, std::string("$x"));
 
-  auto *typeof4 = c.make_node<Typeof>(l, CreateUInt32());
+  auto *typeof4 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32"));
   Expression expr4 = c.make_node<Integer>(l, 42UL);
 
   return { c.make_node<Cast>(l, typeof1, std::move(expr1)),
@@ -398,9 +437,12 @@ std::vector<BlockExpr *> variants<BlockExpr>(ASTContext &c, SourceLocation l)
 template <>
 std::vector<Typeinfo *> variants<Typeinfo>(ASTContext &c, SourceLocation l)
 {
-  auto *typeof1 = c.make_node<Typeof>(l, CreateInt32());
-  auto *typeof2 = c.make_node<Typeof>(l, CreateInt64());
-  auto *typeof3 = c.make_node<Typeof>(l, CreateUInt32());
+  auto *typeof1 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32"));
+  auto *typeof2 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int64"));
+  auto *typeof3 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32"));
   Expression expr = c.make_node<Variable>(l, std::string("$x"));
   auto *typeof4 = c.make_node<Typeof>(l, std::move(expr));
 
@@ -444,16 +486,20 @@ std::vector<VarDeclStatement *> variants<VarDeclStatement>(ASTContext &c,
                                                            SourceLocation l)
 {
   auto *var1 = c.make_node<Variable>(l, std::string("$var"));
-  auto *typeof1 = c.make_node<Typeof>(l, CreateInt32());
+  auto *typeof1 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32"));
 
   auto *var2 = c.make_node<Variable>(l, std::string("$other"));
-  auto *typeof2 = c.make_node<Typeof>(l, CreateInt64());
+  auto *typeof2 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int64"));
 
   auto *var3 = c.make_node<Variable>(l, std::string("$x"));
-  auto *typeof3 = c.make_node<Typeof>(l, CreateUInt32());
+  auto *typeof3 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32"));
 
   auto *var4 = c.make_node<Variable>(l, std::string("$test"));
-  auto *typeof4 = c.make_node<Typeof>(l, CreateInt32());
+  auto *typeof4 = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32"));
 
   return { c.make_node<VarDeclStatement>(l, var1, typeof1),
            c.make_node<VarDeclStatement>(l, var2, typeof2),
@@ -714,7 +760,8 @@ std::vector<Statement> variants<Statement>(ASTContext &c, SourceLocation l)
   Expression expr1 = c.make_node<Integer>(l, 42UL);
   Expression expr2 = c.make_node<Integer>(l, 24UL);
   auto *var = c.make_node<Variable>(l, std::string("$var"));
-  auto *typeof_node = c.make_node<Typeof>(l, CreateInt32());
+  auto *typeof_node = c.make_node<Typeof>(
+      l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32"));
   auto *map = c.make_node<Map>(l, std::string("@map"));
   Expression expr3 = c.make_node<String>(l, std::string("value"));
 
@@ -768,6 +815,7 @@ using TestTypes = ::testing::Types<Integer,
                                    PositionalParameter,
                                    PositionalParameterCount,
                                    Call,
+                                   ParsedType,
                                    Sizeof,
                                    Offsetof,
                                    VariableAddr,

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -472,6 +472,110 @@ inline SizedTypeMatcher SizedType(Type ty)
   return SizedTypeMatcher().WithType(ty);
 }
 
+class ParsedTypeMatcher
+    : public PredicateMatcher<
+          ParsedTypeMatcher,
+          ast::ParsedType,
+          std::function<bool(const ast::ParsedType&, MatchResultListener*)>> {
+public:
+  ParsedTypeMatcher& WithKind(ast::ParsedType::Kind kind)
+  {
+    return Where(
+        [kind](const ast::ParsedType& type, MatchResultListener* listener) {
+          return type.kind == kind ||
+                 (*listener << "has kind " << static_cast<int>(type.kind)
+                            << " instead of " << static_cast<int>(kind),
+                  false);
+        });
+  }
+
+  ParsedTypeMatcher& WithName(const std::string& name)
+  {
+    return Where(
+        [name](const ast::ParsedType& type, MatchResultListener* listener) {
+          return type.name == name ||
+                 (*listener << "has name \"" << type.name << "\" instead of \""
+                            << name << "\"",
+                  false);
+        });
+  }
+
+  ParsedTypeMatcher& WithArraySize(uint64_t size)
+  {
+    return Where(
+        [size](const ast::ParsedType& type, MatchResultListener* listener) {
+          return type.array_size == size ||
+                 (*listener << "has array size " << type.array_size
+                            << " instead of " << size,
+                  false);
+        });
+  }
+
+  ParsedTypeMatcher& WithInner(
+      const Matcher<const ast::ParsedType&>& inner_matcher)
+  {
+    return Where([inner_matcher](const ast::ParsedType& type,
+                                 MatchResultListener* listener) {
+      if (!type.inner) {
+        *listener << "has no inner type";
+        return false;
+      }
+      return inner_matcher.MatchAndExplain(*type.inner, listener);
+    });
+  }
+
+  bool MatchAndExplain(const ast::ParsedType& type,
+                       MatchResultListener* listener) const
+  {
+    return std::ranges::all_of(predicates_, [&](const auto& pred) {
+      return pred(type, listener);
+    });
+  }
+
+  operator Matcher<const ast::ParsedType&>() const
+  {
+    return ::testing::MakeMatcher(new Impl(predicates_));
+  }
+
+private:
+  class Impl : public MatcherInterface<const ast::ParsedType&> {
+  public:
+    explicit Impl(
+        const std::vector<
+            std::function<bool(const ast::ParsedType&, MatchResultListener*)>>&
+            predicates)
+        : predicates_(predicates) {};
+
+    bool MatchAndExplain(const ast::ParsedType& type,
+                         MatchResultListener* listener) const override
+    {
+      return std::ranges::all_of(predicates_, [&](const auto& pred) {
+        return pred(type, listener);
+      });
+    }
+
+    void DescribeTo(std::ostream* os) const override
+    {
+      *os << "is a ParsedType";
+    }
+
+    std::vector<
+        std::function<bool(const ast::ParsedType&, MatchResultListener*)>>
+        predicates_;
+  };
+};
+
+inline ParsedTypeMatcher ParsedType(ast::ParsedType::Kind kind)
+{
+  return ParsedTypeMatcher().WithKind(kind);
+}
+
+inline ParsedTypeMatcher ParsedType(ast::ParsedType::Kind kind,
+                                    const std::string& name)
+{
+  return ParsedTypeMatcher().WithKind(kind).WithName(name);
+}
+
 class ProgramMatcher : public NodeMatcher<ProgramMatcher, ast::Program> {
 public:
   ProgramMatcher& WithProbe(const Matcher<const ast::Probe&>& probe_matcher)
@@ -801,12 +905,25 @@ public:
   TypeofMatcher& WithType(const Matcher<const class SizedType&>& type_matcher)
   {
     return Where([type_matcher](const ast::Typeof& node) {
-      if (!std::holds_alternative<class SizedType>(node.record)) {
-        node.addError() << "record is not a SizedType";
+      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+        node.addError() << "record is not a ParsedType";
         return false;
       }
-      const auto& type = std::get<class SizedType>(node.record);
+      const auto type = parsed_type_to_sized_type(
+          *std::get<ast::ParsedType*>(node.record));
       return MatchWith(node, type_matcher, type);
+    });
+  }
+
+  TypeofMatcher& WithType(const Matcher<const ast::ParsedType&>& type_matcher)
+  {
+    return Where([type_matcher](const ast::Typeof& node) {
+      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+        node.addError() << "record is not a ParsedType";
+        return false;
+      }
+      const auto* type = std::get<ast::ParsedType*>(node.record);
+      return type && MatchWith(node, type_matcher, *type);
     });
   }
 };
@@ -817,6 +934,11 @@ inline TypeofMatcher Typeof(const Matcher<const ast::Expression&>& expr_matcher)
 }
 
 inline TypeofMatcher Typeof(const Matcher<const class SizedType&>& type_matcher)
+{
+  return TypeofMatcher().WithType(type_matcher);
+}
+
+inline TypeofMatcher Typeof(const Matcher<const ast::ParsedType&>& type_matcher)
 {
   return TypeofMatcher().WithType(type_matcher);
 }
@@ -1457,12 +1579,25 @@ public:
   SizeofMatcher& WithType(const Matcher<const class SizedType&>& type_matcher)
   {
     return Where([type_matcher](const ast::Sizeof& node) {
-      if (!std::holds_alternative<class SizedType>(node.record)) {
-        node.addError() << "record is not a SizedType";
+      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+        node.addError() << "record is not a ParsedType";
         return false;
       }
-      const auto& type = std::get<class SizedType>(node.record);
+      const auto type = parsed_type_to_sized_type(
+          *std::get<ast::ParsedType*>(node.record));
       return MatchWith(node, type_matcher, type);
+    });
+  }
+
+  SizeofMatcher& WithType(const Matcher<const ast::ParsedType&>& type_matcher)
+  {
+    return Where([type_matcher](const ast::Sizeof& node) {
+      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+        node.addError() << "record is not a ParsedType";
+        return false;
+      }
+      const auto* type = std::get<ast::ParsedType*>(node.record);
+      return type && MatchWith(node, type_matcher, *type);
     });
   }
 };
@@ -1473,6 +1608,11 @@ inline SizeofMatcher Sizeof(const Matcher<const ast::Expression&>& expr)
 }
 
 inline SizeofMatcher Sizeof(const Matcher<const class SizedType&>& type)
+{
+  return SizeofMatcher().WithType(type);
+}
+
+inline SizeofMatcher Sizeof(const Matcher<const ast::ParsedType&>& type)
 {
   return SizeofMatcher().WithType(type);
 }
@@ -1495,12 +1635,25 @@ public:
   OffsetofMatcher& WithType(const Matcher<const class SizedType&>& type_matcher)
   {
     return Where([type_matcher](const ast::Offsetof& node) {
-      if (!std::holds_alternative<class SizedType>(node.record)) {
-        node.addError() << "record is not a SizedType";
+      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+        node.addError() << "record is not a ParsedType";
         return false;
       }
-      const auto& type = std::get<class SizedType>(node.record);
+      const auto type = parsed_type_to_sized_type(
+          *std::get<ast::ParsedType*>(node.record));
       return MatchWith(node, type_matcher, type);
+    });
+  }
+
+  OffsetofMatcher& WithType(const Matcher<const ast::ParsedType&>& type_matcher)
+  {
+    return Where([type_matcher](const ast::Offsetof& node) {
+      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+        node.addError() << "record is not a ParsedType";
+        return false;
+      }
+      const auto* type = std::get<ast::ParsedType*>(node.record);
+      return type && MatchWith(node, type_matcher, *type);
     });
   }
 
@@ -1517,6 +1670,12 @@ inline OffsetofMatcher Offsetof(const Matcher<const ast::Expression&>& expr,
 }
 
 inline OffsetofMatcher Offsetof(const Matcher<const class SizedType&>& type,
+                                const std::vector<std::string>& field)
+{
+  return OffsetofMatcher().WithType(type).WithField(field);
+}
+
+inline OffsetofMatcher Offsetof(const Matcher<const ast::ParsedType&>& type,
                                 const std::vector<std::string>& field)
 {
   return OffsetofMatcher().WithType(type).WithField(field);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -30,11 +30,12 @@ using bpftrace::test::Map;
 using bpftrace::test::MapAddr;
 using bpftrace::test::None;
 using bpftrace::test::Offsetof;
+using bpftrace::test::ParsedType;
 using bpftrace::test::PositionalParameter;
 using bpftrace::test::PositionalParameterCount;
 using bpftrace::test::Probe;
 using bpftrace::test::Program;
-using bpftrace::test::SizedType;
+
 using bpftrace::test::String;
 using bpftrace::test::Tuple;
 using bpftrace::test::Typeof;
@@ -1639,37 +1640,45 @@ TEST(Parser, brackets)
 TEST(Parser, cast_simple_type)
 {
   test("kprobe:sys_read { (int32)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::integer)),
-                                      Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "int32")),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_simple_type_pointer)
 {
   test("kprobe:sys_read { (int32 *)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::pointer)),
-                                      Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(ParsedType(
+                              ast::ParsedType::Kind::Identifier, "int32"))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_sized_type)
 {
   test("kprobe:sys_read { (string)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::string)),
-                                      Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "string")),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_sized_type_pointer)
 {
   test("kprobe:sys_read { (string *)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::pointer)),
-                                      Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(ParsedType(
+                              ast::ParsedType::Kind::Identifier, "string"))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_sized_type_pointer_with_size)
@@ -1677,9 +1686,14 @@ TEST(Parser, cast_sized_type_pointer_with_size)
   test("kprobe:sys_read { (inet[1] *)arg0; }",
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
-           { ExprStatement(Cast(Typeof(SizedType(Type::pointer)
-                                           .WithElement(SizedType(Type::inet))),
-                                Builtin("arg0"))) })));
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(ParsedType(ast::ParsedType::Kind::Array)
+                                         .WithArraySize(1)
+                                         .WithInner(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "inet")))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_struct)
@@ -1688,13 +1702,13 @@ TEST(Parser, cast_struct)
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
            { ExprStatement(
-               Cast(Typeof(SizedType(Type::c_struct).WithName("struct mytype")),
+               Cast(Typeof(ParsedType(ast::ParsedType::Kind::Struct, "mytype")),
                     Builtin("arg0"))) })));
   test("kprobe:sys_read { (union mytype)arg0; }",
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
                  { ExprStatement(Cast(
-                     Typeof(SizedType(Type::c_struct).WithName("union mytype")),
+                     Typeof(ParsedType(ast::ParsedType::Kind::Union, "mytype")),
                      Builtin("arg0"))) })));
 }
 
@@ -1703,49 +1717,63 @@ TEST(Parser, cast_struct_ptr)
   test("kprobe:sys_read { (struct mytype*)arg0; }",
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::pointer)),
-                                      Builtin("arg0"))) })));
+                 { ExprStatement(Cast(
+                     Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                                .WithInner(ParsedType(
+                                    ast::ParsedType::Kind::Struct, "mytype"))),
+                     Builtin("arg0"))) })));
   test("kprobe:sys_read { (union mytype*)arg0; }",
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::pointer)),
-                                      Builtin("arg0"))) })));
+                 { ExprStatement(Cast(
+                     Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                                .WithInner(ParsedType(
+                                    ast::ParsedType::Kind::Union, "mytype"))),
+                     Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_typedef)
 {
   test("kprobe:sys_read { (mytype)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(
-                     Cast(Typeof(Identifier("mytype")), Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "mytype")),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_ptr_typedef)
 {
   test("kprobe:sys_read { (mytype*)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::pointer)),
-                                      Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(ParsedType(
+                              ast::ParsedType::Kind::Identifier, "mytype"))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_deep_pointer)
 {
-  test("kprobe:sys_read { (uint64 ****)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(
-                     Typeof(SizedType(Type::pointer)
-                                .WithElement(
-                                    SizedType(Type::pointer)
-                                        .WithElement(
-                                            SizedType(Type::pointer)
-                                                .WithElement(
-                                                    SizedType(Type::pointer)
-                                                        .WithElement(SizedType(
-                                                            Type::integer)))))),
-                     Builtin("arg0"))) })));
+  test(
+      "kprobe:sys_read { (uint64 ****)arg0; }",
+      Program().WithProbe(Probe(
+          { "kprobe:sys_read" },
+          { ExprStatement(Cast(
+              Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                         .WithInner(
+                             ParsedType(ast::ParsedType::Kind::Pointer)
+                                 .WithInner(
+                                     ParsedType(ast::ParsedType::Kind::Pointer)
+                                         .WithInner(
+                                             ParsedType(
+                                                 ast::ParsedType::Kind::Pointer)
+                                                 .WithInner(ParsedType(
+                                                     ast::ParsedType::Kind::
+                                                         Identifier,
+                                                     "uint64")))))),
+              Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_or_expr1)
@@ -1754,7 +1782,7 @@ TEST(Parser, cast_or_expr1)
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
            { ExprStatement(
-               Cast(Typeof(SizedType(Type::c_struct).WithName("struct mytype")),
+               Cast(Typeof(ParsedType(ast::ParsedType::Kind::Struct, "mytype")),
                     Unop(Operator::MUL, Builtin("arg0")))) })));
 
   test("kprobe:sys_read { (arg1)*arg0; }",
@@ -1766,8 +1794,9 @@ TEST(Parser, cast_or_expr1)
   test("kprobe:sys_read { (mytype)*arg0; }",
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
-           { ExprStatement(Cast(Typeof(Identifier("mytype")),
-                                Unop(Operator::MUL, Builtin("arg0")))) })));
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "mytype")),
+               Unop(Operator::MUL, Builtin("arg0")))) })));
 }
 
 TEST(Parser, cast_precedence)
@@ -1776,21 +1805,24 @@ TEST(Parser, cast_precedence)
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
            { ExprStatement(
-               Cast(Typeof(SizedType(Type::c_struct).WithName("struct mytype")),
+               Cast(Typeof(ParsedType(ast::ParsedType::Kind::Struct, "mytype")),
                     FieldAccess("field", Builtin("arg0")))) })));
 
   test("kprobe:sys_read { (struct mytype*)arg0->field; }",
-       Program().WithProbe(Probe(
-           { "kprobe:sys_read" },
-           { ExprStatement(Cast(Typeof(SizedType(Type::pointer)),
-                                FieldAccess("field", Builtin("arg0")))) })));
+       Program().WithProbe(
+           Probe({ "kprobe:sys_read" },
+                 { ExprStatement(Cast(
+                     Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                                .WithInner(ParsedType(
+                                    ast::ParsedType::Kind::Struct, "mytype"))),
+                     FieldAccess("field", Builtin("arg0")))) })));
 
   test("kprobe:sys_read { (struct mytype)arg0+123; }",
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
            { ExprStatement(Binop(
                Operator::PLUS,
-               Cast(Typeof(SizedType(Type::c_struct).WithName("struct mytype")),
+               Cast(Typeof(ParsedType(ast::ParsedType::Kind::Struct, "mytype")),
                     Builtin("arg0")),
                Integer(123))) })));
 }
@@ -1802,37 +1834,41 @@ TEST(Parser, cast_enum)
            .WithCStatements({ CStatement("enum Foo { ONE = 1 };") })
            .WithProbe(
                Probe({ "kprobe:sys_read" },
-                     { ExprStatement(
-                         Cast(Typeof(SizedType(Type::integer).WithName("Foo")),
-                              Integer(1))) })));
+                     { ExprStatement(Cast(
+                         Typeof(ParsedType(ast::ParsedType::Kind::Enum, "Foo")),
+                         Integer(1))) })));
 }
 
 TEST(Parser, cast_pointer_then_array)
 {
   // int32*[4] → array of pointers to int32
   test("kprobe:sys_read { (int32*[4])arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(
-                     Cast(Typeof(SizedType(Type::array)
-                                     .WithElement(SizedType(Type::pointer)
-                                                      .WithElement(SizedType(
-                                                          Type::integer)))),
-                          Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Array)
+                          .WithArraySize(4)
+                          .WithInner(ParsedType(ast::ParsedType::Kind::Pointer)
+                                         .WithInner(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "int32")))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_array_then_pointer)
 {
   // int32[4]* → pointer to array of int32
   test("kprobe:sys_read { (int32[4]*)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(
-                     Cast(Typeof(SizedType(Type::pointer)
-                                     .WithElement(SizedType(Type::array)
-                                                      .WithElement(SizedType(
-                                                          Type::integer)))),
-                          Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(ParsedType(ast::ParsedType::Kind::Array)
+                                         .WithArraySize(4)
+                                         .WithInner(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "int32")))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_struct_array_then_pointer)
@@ -1842,66 +1878,78 @@ TEST(Parser, cast_struct_array_then_pointer)
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
            { ExprStatement(Cast(
-               Typeof(SizedType(Type::pointer)
-                          .WithElement(
-                              SizedType(Type::array)
-                                  .WithElement(SizedType(Type::c_struct)
-                                                   .WithName("struct foo")))),
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(
+                              ParsedType(ast::ParsedType::Kind::Array)
+                                  .WithArraySize(4)
+                                  .WithInner(ParsedType(
+                                      ast::ParsedType::Kind::Struct, "foo")))),
                Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_struct_pointer_then_array)
 {
   // struct mytype*[4] → array of pointers to struct mytype
-  test(
-      "kprobe:sys_read { (struct mytype*[4])arg0; }",
-      Program().WithProbe(Probe(
-          { "kprobe:sys_read" },
-          { ExprStatement(Cast(
-              Typeof(SizedType(Type::array)
-                         .WithElement(
-                             SizedType(Type::pointer)
-                                 .WithElement(SizedType(Type::c_struct)
-                                                  .WithName("struct mytype")))),
-              Builtin("arg0"))) })));
+  test("kprobe:sys_read { (struct mytype*[4])arg0; }",
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Array)
+                          .WithArraySize(4)
+                          .WithInner(ParsedType(ast::ParsedType::Kind::Pointer)
+                                         .WithInner(ParsedType(
+                                             ast::ParsedType::Kind::Struct,
+                                             "mytype")))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_sized_type_normalization)
 {
   // string[64] normalizes from Array(64, String(0)) to String(64)
   test("kprobe:sys_read { (string[64])arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(Typeof(SizedType(Type::string)),
-                                      Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Array)
+                          .WithArraySize(64)
+                          .WithInner(ParsedType(
+                              ast::ParsedType::Kind::Identifier, "string"))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_sized_type_pointer_normalization)
 {
   // string[64]* normalizes to pointer to String(64)
   test("kprobe:sys_read { (string[64]*)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(
-                     Cast(Typeof(SizedType(Type::pointer)
-                                     .WithElement(SizedType(Type::string))),
-                          Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(ParsedType(ast::ParsedType::Kind::Array)
+                                         .WithArraySize(64)
+                                         .WithInner(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "string")))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, cast_mixed_suffix_levels)
 {
   // int32*[4]* → pointer to array of pointers to int32
   test("kprobe:sys_read { (int32*[4]*)arg0; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Cast(
-                     Typeof(SizedType(Type::pointer)
-                                .WithElement(
-                                    SizedType(Type::array)
-                                        .WithElement(SizedType(Type::pointer)
-                                                         .WithElement(SizedType(
-                                                             Type::integer))))),
-                     Builtin("arg0"))) })));
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Cast(
+               Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(
+                              ParsedType(ast::ParsedType::Kind::Array)
+                                  .WithArraySize(4)
+                                  .WithInner(
+                                      ParsedType(ast::ParsedType::Kind::Pointer)
+                                          .WithInner(ParsedType(
+                                              ast::ParsedType::Kind::Identifier,
+                                              "int32"))))),
+               Builtin("arg0"))) })));
 }
 
 TEST(Parser, sizeof_expression)
@@ -1916,7 +1964,8 @@ TEST(Parser, sizeof_type)
   test("kprobe:sys_read { sizeof(int32); }",
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
-                 { ExprStatement(Sizeof(SizedType(Type::integer))) })));
+                 { ExprStatement(Sizeof(ParsedType(
+                     ast::ParsedType::Kind::Identifier, "int32"))) })));
 }
 
 TEST(Parser, offsetof_type)
@@ -1927,7 +1976,7 @@ TEST(Parser, offsetof_type)
            .WithProbe(
                Probe({ "begin" },
                      { ExprStatement(Offsetof(
-                         SizedType(Type::c_struct).WithName("struct Foo"),
+                         ParsedType(ast::ParsedType::Kind::Struct, "Foo"),
                          { "x" })) })));
   test("struct Foo { struct Bar { int x; } bar; } "
        "begin { offsetof(struct Foo, bar.x); }",
@@ -1937,7 +1986,7 @@ TEST(Parser, offsetof_type)
            .WithProbe(
                Probe({ "begin" },
                      { ExprStatement(Offsetof(
-                         SizedType(Type::c_struct).WithName("struct Foo"),
+                         ParsedType(ast::ParsedType::Kind::Struct, "Foo"),
                          { "bar", "x" })) })));
   test_parse_failure("struct Foo { struct Bar { int x; } *bar; } "
                      "begin { offsetof(struct Foo, bar->x); }",
@@ -1953,17 +2002,21 @@ struct Foo { struct Bar { int x; } *bar; } begin { offsetof(struct Foo, bar->x);
 
 TEST(Parser, offsetof_expression)
 {
-  test("struct Foo { int x; }; "
-       "begin { $foo = (struct Foo *)0; offsetof(*$foo, x); }",
-       Program()
-           .WithCStatements({ CStatement("struct Foo { int x; };") })
-           .WithProbe(Probe(
-               { "begin" },
-               { AssignVarStatement(Variable("$foo"),
-                                    Cast(Typeof(SizedType(Type::pointer)),
-                                         Integer(0))),
-                 ExprStatement(Offsetof(Unop(Operator::MUL, Variable("$foo")),
-                                        { "x" })) })));
+  test(
+      "struct Foo { int x; }; "
+      "begin { $foo = (struct Foo *)0; offsetof(*$foo, x); }",
+      Program()
+          .WithCStatements({ CStatement("struct Foo { int x; };") })
+          .WithProbe(Probe(
+              { "begin" },
+              { AssignVarStatement(
+                    Variable("$foo"),
+                    Cast(Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                                    .WithInner(ParsedType(
+                                        ast::ParsedType::Kind::Struct, "Foo"))),
+                         Integer(0))),
+                ExprStatement(Offsetof(Unop(Operator::MUL, Variable("$foo")),
+                                       { "x" })) })));
 }
 
 TEST(Parser, offsetof_builtin_type)
@@ -1975,7 +2028,7 @@ TEST(Parser, offsetof_builtin_type)
            .WithProbe(
                Probe({ "begin" },
                      { ExprStatement(Offsetof(
-                         SizedType(Type::c_struct).WithName("struct Foo"),
+                         ParsedType(ast::ParsedType::Kind::Struct, "Foo"),
                          { "timestamp" })) })));
 }
 
@@ -2800,20 +2853,24 @@ TEST(Parser, keywords_as_identifiers)
                                         "unroll",   "while" };
   for (const auto &keyword : keywords) {
     test("begin { $x = (struct Foo*)0; $x->" + keyword + "; }",
-         Program().WithProbe(
-             Probe({ "begin" },
-                   { AssignVarStatement(Variable("$x"),
-                                        Cast(Typeof(SizedType(Type::pointer)),
-                                             Integer(0))),
-                     ExprStatement(FieldAccess(keyword, Variable("$x"))) })));
-    test("begin { $x = (struct Foo)0; $x." + keyword + "; }",
          Program().WithProbe(Probe(
              { "begin" },
-             { AssignVarStatement(Variable("$x"),
-                                  Cast(Typeof(SizedType(Type::c_struct)
-                                                  .WithName("struct Foo")),
-                                       Integer(0))),
+             { AssignVarStatement(
+                   Variable("$x"),
+                   Cast(Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                                   .WithInner(ParsedType(
+                                       ast::ParsedType::Kind::Struct, "Foo"))),
+                        Integer(0))),
                ExprStatement(FieldAccess(keyword, Variable("$x"))) })));
+    test("begin { $x = (struct Foo)0; $x." + keyword + "; }",
+         Program().WithProbe(
+             Probe({ "begin" },
+                   { AssignVarStatement(
+                         Variable("$x"),
+                         Cast(Typeof(ParsedType(ast::ParsedType::Kind::Struct,
+                                                "Foo")),
+                              Integer(0))),
+                     ExprStatement(FieldAccess(keyword, Variable("$x"))) })));
     test("begin { $x = offsetof(*__builtin_cpu, " + keyword + "); }",
          Program().WithProbe(
              Probe({ "begin" },
@@ -2833,8 +2890,16 @@ TEST(Parser, prog_body_items)
        Program()
            .WithMapDecls({ MapDeclStatement("@a", "hash", 5) })
            .WithFunctions(
-               { Subprog("f1", Typeof(SizedType(Type::voidtype)), {}, {}),
-                 Subprog("f2", Typeof(SizedType(Type::voidtype)), {}, {}) })
+               { Subprog("f1",
+                         Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                           "void")),
+                         {},
+                         {}),
+                 Subprog("f2",
+                         Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                           "void")),
+                         {},
+                         {}) })
            .WithProbes({ Probe({ "interval:s:1" }, {}),
                          Probe({ "interval:s:1" }, {}) }));
 }
@@ -2842,15 +2907,21 @@ TEST(Parser, prog_body_items)
 TEST(Parser, subprog_void_no_args)
 {
   test("fn f(): void {}",
-       Program().WithFunction(
-           Subprog("f", Typeof(SizedType(Type::voidtype)), {}, {})));
+       Program().WithFunction(Subprog(
+           "f",
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
+           {},
+           {})));
 }
 
 TEST(Parser, subprog_ident_return_type)
 {
   test("fn f(): nonexistent {}",
-       Program().WithFunction(
-           Subprog("f", Typeof(Identifier("nonexistent")), {}, {})));
+       Program().WithFunction(Subprog(
+           "f",
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "nonexistent")),
+           {},
+           {})));
 }
 
 TEST(Parser, subprog_one_arg)
@@ -2858,8 +2929,10 @@ TEST(Parser, subprog_one_arg)
   test("fn f($a : uint8): void {}",
        Program().WithFunction(Subprog(
            "f",
-           Typeof(SizedType(Type::voidtype)),
-           { SubprogArg(Variable("$a"), Typeof(SizedType(Type::integer))) },
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
+           { SubprogArg(Variable("$a"),
+                        Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                          "uint8"))) },
            {})));
 }
 
@@ -2868,9 +2941,13 @@ TEST(Parser, subprog_two_args)
   test("fn f($a : uint8, $b : uint8): void {}",
        Program().WithFunction(Subprog(
            "f",
-           Typeof(SizedType(Type::voidtype)),
-           { SubprogArg(Variable("$a"), Typeof(SizedType(Type::integer))),
-             SubprogArg(Variable("$b"), Typeof(SizedType(Type::integer))) },
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
+           { SubprogArg(Variable("$a"),
+                        Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                          "uint8"))),
+             SubprogArg(Variable("$b"),
+                        Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                          "uint8"))) },
            {})));
 }
 
@@ -2879,8 +2956,10 @@ TEST(Parser, subprog_string_arg)
   test("fn f($a : string): void {}",
        Program().WithFunction(Subprog(
            "f",
-           Typeof(SizedType(Type::voidtype)),
-           { SubprogArg(Variable("$a"), Typeof(SizedType(Type::string))) },
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
+           { SubprogArg(Variable("$a"),
+                        Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                          "string"))) },
            {})));
 }
 
@@ -2889,10 +2968,10 @@ TEST(Parser, subprog_struct_arg)
   test("fn f($a: struct x): void {}",
        Program().WithFunction(Subprog(
            "f",
-           Typeof(SizedType(Type::voidtype)),
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
            { SubprogArg(Variable("$a"),
                         Typeof(
-                            SizedType(Type::c_struct).WithName("struct x"))) },
+                            ParsedType(ast::ParsedType::Kind::Struct, "x"))) },
            {})));
 }
 
@@ -2902,9 +2981,9 @@ TEST(Parser, subprog_union_arg)
       "fn f($a : union x): void {}",
       Program().WithFunction(Subprog(
           "f",
-          Typeof(SizedType(Type::voidtype)),
+          Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
           { SubprogArg(Variable("$a"),
-                       Typeof(SizedType(Type::c_struct).WithName("union x"))) },
+                       Typeof(ParsedType(ast::ParsedType::Kind::Union, "x"))) },
           {})));
 }
 
@@ -2913,9 +2992,9 @@ TEST(Parser, subprog_enum_arg)
   test("fn f($a : enum x): void {}",
        Program().WithFunction(Subprog(
            "f",
-           Typeof(SizedType(Type::voidtype)),
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
            { SubprogArg(Variable("$a"),
-                        Typeof(SizedType(Type::integer).WithName("x"))) },
+                        Typeof(ParsedType(ast::ParsedType::Kind::Enum, "x"))) },
            {})));
 }
 
@@ -2924,19 +3003,21 @@ TEST(Parser, subprog_ident_arg_type)
   test("fn f($x : nonexistent): void {}",
        Program().WithFunction(Subprog(
            "f",
-           Typeof(SizedType(Type::voidtype)),
-           { SubprogArg(Variable("$x"), Typeof(Identifier("nonexistent"))) },
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
+           { SubprogArg(Variable("$x"),
+                        Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                          "nonexistent"))) },
            {})));
 }
 
 TEST(Parser, subprog_return)
 {
   test("fn f(): void { return 1 + 1; }",
-       Program().WithFunction(
-           Subprog("f",
-                   Typeof(SizedType(Type::voidtype)),
-                   {},
-                   { Return(Binop(Operator::PLUS, Integer(1), Integer(1))) })));
+       Program().WithFunction(Subprog(
+           "f",
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "void")),
+           {},
+           { Return(Binop(Operator::PLUS, Integer(1), Integer(1))) })));
 }
 
 TEST(Parser, jump_statements_require_separator)
@@ -2996,8 +3077,11 @@ begin { $x++ print(2); }
 TEST(Parser, subprog_string)
 {
   test("fn f(): string {}",
-       Program().WithFunction(
-           Subprog("f", Typeof(SizedType(Type::string)), {}, {})));
+       Program().WithFunction(Subprog(
+           "f",
+           Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "string")),
+           {},
+           {})));
 }
 
 TEST(Parser, subprog_struct)
@@ -3005,7 +3089,7 @@ TEST(Parser, subprog_struct)
   test("fn f(): struct x {}",
        Program().WithFunction(
            Subprog("f",
-                   Typeof(SizedType(Type::c_struct).WithName("struct x")),
+                   Typeof(ParsedType(ast::ParsedType::Kind::Struct, "x")),
                    {},
                    {})));
 }
@@ -3015,14 +3099,14 @@ TEST(Parser, subprog_union)
   test(
       "fn f(): union x {}",
       Program().WithFunction(Subprog(
-          "f", Typeof(SizedType(Type::c_struct).WithName("union x")), {}, {})));
+          "f", Typeof(ParsedType(ast::ParsedType::Kind::Union, "x")), {}, {})));
 }
 
 TEST(Parser, subprog_enum)
 {
   test("fn f(): enum x {}",
        Program().WithFunction(Subprog(
-           "f", Typeof(SizedType(Type::integer).WithName("x")), {}, {})));
+           "f", Typeof(ParsedType(ast::ParsedType::Kind::Enum, "x")), {}, {})));
 }
 
 TEST(Parser, for_loop)
@@ -3110,33 +3194,37 @@ TEST(Parser, variable_declarations)
   test("begin { let $x: int8; }",
        Program().WithProbe(
            Probe({ "begin" },
-                 { VarDeclStatement(Variable("$x"),
-                                    Typeof(SizedType(Type::integer))) })));
+                 { VarDeclStatement(
+                     Variable("$x"),
+                     Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                       "int8"))) })));
 
   test("begin { let $x: nonexistent; }",
        Program().WithProbe(
            Probe({ "begin" },
-                 { VarDeclStatement(Variable("$x"),
-                                    Typeof(Identifier("nonexistent"))) })));
+                 { VarDeclStatement(
+                     Variable("$x"),
+                     Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                       "nonexistent"))) })));
 
   test("begin { let $x: nonexistent *; }",
        Program().WithProbe(Probe(
            { "begin" },
-           { VarDeclStatement(
-               Variable("$x"),
-               Typeof(SizedType(Type::pointer)
-                          .WithElement(SizedType(Type::c_struct)
-                                           .WithName("nonexistent")))) })));
+           { VarDeclStatement(Variable("$x"),
+                              Typeof(ParsedType(ast::ParsedType::Kind::Pointer)
+                                         .WithInner(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "nonexistent")))) })));
 
   test("begin { let $x: nonexistent[5]; }",
        Program().WithProbe(Probe(
            { "begin" },
-           { VarDeclStatement(
-               Variable("$x"),
-               Typeof(SizedType(Type::array)
-                          .WithNumElements(5)
-                          .WithElement(SizedType(Type::c_struct)
-                                           .WithName("nonexistent")))) })));
+           { VarDeclStatement(Variable("$x"),
+                              Typeof(ParsedType(ast::ParsedType::Kind::Array)
+                                         .WithArraySize(5)
+                                         .WithInner(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "nonexistent")))) })));
 
   test("begin { let $x = 1; }",
        Program().WithProbe(Probe(
@@ -3203,12 +3291,12 @@ TEST(Parser, struct_save_nested)
     } baz;
   } bar;
 };)") })
-           .WithProbe(Probe(
-               { "interval:ms:100" },
-               { AssignVarStatement(Variable("$s"),
-                                    Cast(Typeof(SizedType(Type::c_struct)
-                                                    .WithName("struct Foo")),
-                                         Integer(1))) })));
+           .WithProbe(Probe({ "interval:ms:100" },
+                            { AssignVarStatement(
+                                Variable("$s"),
+                                Cast(Typeof(ParsedType(
+                                         ast::ParsedType::Kind::Struct, "Foo")),
+                                     Integer(1))) })));
 }
 
 TEST(Parser, bare_blocks)

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -73,16 +73,23 @@ REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
+NAME complex type declaration
+PROG uprobe:./testprogs/uprobe_test:uprobeFunctionBar { let $x: struct Foo *[2] = args.bar->foos; printf("bar.foos[0].a = %d\n", $x[0]->a); exit(); }
+EXPECT bar.foos[0].a = 123
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
 # Attaching probes using source code location
 NAME uprobe source location - attach probe to source line
-PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:16 { printf("0x%lx\n", reg("ip")); exit(); }
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:22 { printf("0x%lx\n", reg("ip")); exit(); }
 EXPECT_REGEX ^0x[0-9A-Fa-f]+$
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe source location - source line to address validation
-PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:16 { @a = reg("ip"); }
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:22 { @a = reg("ip"); }
      uprobe:./testprogs/uprobe_test:uprobeFunction1 { @b = reg("ip"); if (@b == @a) { printf("0x%lx == 0x%lx\n", @a, @b); exit(); } }
 EXPECT_REGEX ^0x[0-9A-Fa-f]+ == 0x[0-9A-Fa-f]+$
 REQUIRES_FEATURE dwarf
@@ -90,9 +97,9 @@ TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe source location - attach multiple probes
-PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:28 { @a=1; }
-     uprobe:./testprogs/uprobe_test@uprobe_test.c:30 { @b=1; }
-     uprobe:./testprogs/uprobe_test@uprobe_test.c:33 { if (@a == 1 && @b == 1) { print("success"); exit(); } }
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:34 { @a=1; }
+     uprobe:./testprogs/uprobe_test@uprobe_test.c:36 { @b=1; }
+     uprobe:./testprogs/uprobe_test@uprobe_test.c:39 { if (@a == 1 && @b == 1) { print("success"); exit(); } }
 EXPECT success
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
@@ -112,7 +119,7 @@ TIMEOUT 5
 BEFORE ./testprogs/uprobe_test-stripped
 
 NAME parse stripped debuginfo - attach by source line
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped@uprobe_test.c:16 { print("ok"); exit(); }' --debuginfo=./debug
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped@uprobe_test.c:22 { print("ok"); exit(); }' --debuginfo=./debug
 EXPECT ok
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
@@ -132,7 +139,7 @@ TIMEOUT 5
 BEFORE ./testprogs/debug/dwo/uprobe_test-split
 
 NAME parse DWO debuginfo - attach by source line
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwo/uprobe_test-split@uprobe_test.c:16 { printf("ok"); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwo/uprobe_test-split@uprobe_test.c:22 { printf("ok"); exit(); }'
 EXPECT ok
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
@@ -152,7 +159,7 @@ TIMEOUT 5
 BEFORE ./testprogs/debug/dwp/uprobe_test-split
 
 NAME parse DWP debuginfo - attach by source line
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwp/uprobe_test-split@uprobe_test.c:16 { printf("ok"); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwp/uprobe_test-split@uprobe_test.c:22 { printf("ok"); exit(); }'
 EXPECT ok
 REQUIRES_FEATURE dwarf
 TIMEOUT 5

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -12,6 +12,12 @@ struct Foo {
   __int128_t d;
 };
 
+struct Bar {
+  int x;
+  struct Foo *foos[2];
+  struct Foo nested;
+};
+
 int uprobeFunction1(int *n, char c __attribute__((unused)))
 {
   return *n;
@@ -63,6 +69,11 @@ int uprobeFunctionBranching(int n)
  */
 // clang-format on
 
+struct Bar *uprobeFunctionBar(struct Bar *bar)
+{
+  return bar;
+}
+
 __uint128_t uprobeFunctionUint128(__uint128_t x,
                                   __uint128_t y __attribute__((unused)),
                                   __uint128_t z __attribute__((unused)),
@@ -87,6 +98,11 @@ int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
     uprobeFunction2(&foo1, &foo2);
 
     uprobeFunctionBranching(n);
+
+    struct Bar bar = {
+      .x = 42, .foos = { &foo1, &foo2 }, .nested = foo1
+    };
+    uprobeFunctionBar(&bar);
 
     __uint128_t x = 0x123456789ABCDEF0;
     __uint128_t y = 0xEFEFEFEFEFEFEFEF;

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2334,12 +2334,9 @@ begin { (struct faketype *)cpu }
          ~~~~~~~~~~~~~~~~~
 )" });
   test("begin { (faketype)cpu }", Error{ R"(
-stdin:1:10-18: ERROR: Unknown identifier: 'faketype'
+stdin:1:10-18: ERROR: Cannot resolve unknown type "faketype"
 begin { (faketype)cpu }
          ~~~~~~~~
-stdin:1:9-19: ERROR: Incomplete cast, unknown type
-begin { (faketype)cpu }
-        ~~~~~~~~~~
 )" });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #5122
 * __->__#5121


--- --- ---

### Remove SizedType from AST


Replace with a ParsedType AST node, which doesn't know about any of the
internal type names, e.g. "uint64", "sum_t", "string", etc.

This further simplifies the type system so that we're only dealing with
SizedType, which has additional internal complexities, past the type
resolution pass. All preceding passes just need to know we're dealing with
some kind of generic type but that's all.

This has the added benefit of being able to handle more complex written
types, e.g. `let $x: struct Foo *[2]`. Note: the type checker still has
restrictions on what types can be in the cast statement but that will be
fixed in a follow-up commit.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>